### PR TITLE
feat(runtime): add authoritative scheduler writer lookup

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -540,7 +540,7 @@ the per-epic implementation notes).
   delete the negotiation and the expanded-form encoder and always send the
   compact form.
 
-> Two neighbours in the same handshake are related but are not runtime-toggleable
+> Three neighbours in the same handshake are related but are not runtime-toggleable
 > experimental flags:
 >
 > - **`syncSchemaTable`** is the older, index-keyed predecessor of
@@ -554,6 +554,12 @@ the per-epic implementation notes).
 >   keeps its write gate failing closed. It was added by Bernhard Seefeld in
 >   "server-side commit-time row-label re-derivation (Epic E4, Phase 3.c)"
 >   (#4552). It is permanent.
+> - **`schedulerWriterLookup`** is a build-inherent capability, hardwired to
+>   `true`, advertising authenticated target/path-overlap lookup over durable
+>   scheduler write indexes. It is not configuration: an older server that
+>   lacks the capability advertises it absent (parsed as `false`), and a newer
+>   runner fails open to piece-root discovery without sending the unsupported
+>   request. It was added by Bernhard Seefeld for server-side execution W0.3.
 
 ---
 

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -50,7 +50,8 @@ The client MUST declare its protocol version in the first WebSocket message:
   "protocol": "memory/v2",
   "flags": {
     "modernCellRep": true,
-    "persistentSchedulerState": true
+    "persistentSchedulerState": true,
+    "schedulerWriterLookup": true
   }
 }
 ```
@@ -63,7 +64,8 @@ If the server accepts the protocol, it returns:
   "protocol": "memory/v2",
   "flags": {
     "modernCellRep": true,
-    "persistentSchedulerState": true
+    "persistentSchedulerState": true,
+    "schedulerWriterLookup": true
   },
   "sessionOpen": {
     "audience": "did:key:z6Mk...",
@@ -127,6 +129,13 @@ rows exist in the database. This flag is negotiated as an optional capability:
 a client and server may connect when their scheduler-state flags differ, and
 the server's flag controls the scheduler-observation data plane for that
 connection.
+
+`schedulerWriterLookup` is a build-inherent, optional capability. When it is
+absent it parses as `false`, and a newer runner does not send a request that an
+older memory server cannot parse. It instead fails open to piece-root
+discovery. When advertised, an authenticated space session may use
+`scheduler.writer.list`; the server, not the caller, supplies the owner space,
+principal/session execution contexts, and effective target scope keys.
 
 ### 4.1.2 Logical Sessions and Resume
 
@@ -233,6 +242,7 @@ interface HelloMessage {
   flags: {
     modernCellRep: boolean;
     persistentSchedulerState?: boolean;
+    schedulerWriterLookup?: boolean;
   };
 }
 
@@ -241,6 +251,8 @@ interface RequestMessage {
     | "session.open"
     | "transact"
     | "graph.query"
+    | "scheduler.snapshot.list"
+    | "scheduler.writer.list"
     | "session.watch.set"
     | "session.watch.add"
     | "session.ack";
@@ -493,6 +505,74 @@ Semantics:
 Branch create / delete / merge lifecycle commands are not currently exposed on
 the v2 wire. The engine already carries branch state internally, but public wire
 commands for that surface remain deferred in this pass.
+
+### 4.3.7 `scheduler.writer.list` — Authenticated Producer Lookup
+
+The durable scheduler lookup returns every action whose current-known,
+declared, or materializer write overlaps one of the requested target paths. It
+does not select a winner and does not use document creation provenance.
+
+```typescript
+// Shown at module scope.
+interface SchedulerWriterTarget {
+  id: EntityId;
+  scope?: "space" | "user" | "session";
+  path: Array<string>;
+}
+
+interface SchedulerWriterListRequest {
+  type: "scheduler.writer.list";
+  requestId: string;
+  space: SpaceId;
+  sessionId: SessionId;
+  query: {
+    branch?: BranchId;
+    targets: SchedulerWriterTarget[];
+  };
+}
+
+interface SchedulerWritersForTargetsResult {
+  serverSeq: number;
+  writers: Array<{
+    branch: BranchId;
+    ownerSpace?: SpaceId;
+    pieceId: string;
+    processGeneration: number;
+    actionId: string;
+    executionContextKey: string;
+    observationId: number;
+    commitSeq: number | null;
+    observedAtSeq: number;
+    actionKind: "computation" | "effect" | "event-handler";
+    implementationFingerprint: string;
+    runtimeFingerprint: string;
+    status: "success" | "failed";
+    errorFingerprint?: string;
+    directDirtySeq?: number;
+    staleSeq?: number;
+    unknownReason?: string;
+    matchedWrites: Array<{
+      kind: "current-known" | "declared" | "materializer";
+      write: {
+        space: SpaceId;
+        id: EntityId;
+        scope: "space" | "user" | "session";
+        scopeKey: string;
+        path: Array<string>;
+      };
+    }>;
+  }>;
+}
+```
+
+The request has READ authority. The server requires the exact attached session,
+stamps the request's space onto every target, derives effective scope keys from
+that session's authenticated principal and session id, and returns only the
+shared plus applicable user/session action contexts. Callers cannot submit
+`scopeKey`, an execution-context key, or a different target space. Matching is
+bidirectional path-prefix overlap and results are deterministic. Missing,
+disabled, or corrupt scheduler state returns no candidates so the runner can
+fall back to ordinary piece-root discovery.
 
 ## 4.4 Selectors
 

--- a/docs/specs/server-side-execution/README.md
+++ b/docs/specs/server-side-execution/README.md
@@ -208,8 +208,8 @@ application in `packages/runner/src/scheduler/facade.ts` is fingerprint-gated
 and fail-open. Restart-skip is proven by `reload-rehydration.test.ts` and
 `v2-scheduler-state-test.ts`.
 
-Still missing (G4): durable dirty markers
-consumed as a **wake query** — the tree marks readers dirty *inline* during
+Still missing from G4: durable dirty markers consumed as a **wake query** — the
+tree marks readers dirty *inline* during
 commit (`findSchedulerReadersForWrite` `engine.ts:1849`,
 `markSchedulerReadersDirtyForWrites` `:1912`) but exposes no named
 `staleReadersFor(space, changedIds, seq)` batched query for a *parked*
@@ -283,15 +283,16 @@ stamping nor promises a per-document causal-audit mechanism. A future audit
 lineage design is separate; creation source must not select an executor action.
 
 The authoritative producer projection is `scheduler_write_index`, joined to
-`scheduler_action_state` and the durable action snapshot. Lookup is by
+`scheduler_action_state` and the durable action snapshot. The implemented
+`writersForTargets` lookup is by
 effective `(space, scope_key, doc id, path)` with path-overlap semantics and
 returns every candidate writer; it must never choose an arbitrary winner.
 The action snapshot supplies `(pieceId, actionId,
 implementationFingerprint)`, and the piece's `patternIdentity` is the sole
 durable pointer used to load executable code. Implementation-plan W0.3 adds
-target/path lookup over the durable declared, current-known, and materializer
-rows written with scheduler observations. A live worker can also consult its
-registration-time static surface before the first run.
+the named target/path lookup over the durable declared, current-known, and
+materializer rows written with scheduler observations. A live worker can also
+consult its registration-time static surface before the first run.
 
 If a demanded piece has no usable writer row yet, the client interest already
 identifies the piece. The executor instantiates that piece, validates its
@@ -1235,7 +1236,7 @@ means a design doc/decision is required before implementation.
 | G1 | `SchedulerExecutionContextKey` and effective scope-qualified snapshots/state/indexes (§3.2.1) | server reliance on durable state | prerequisite; needs-impl |
 | G2 | Branch-qualified authenticated `ExecutionDemand`, sticky sponsor selection, and fenced `ExecutionLease` | shadow | needs-impl |
 | G3 | Branch-qualified ephemeral per-action `ExecutionClaim` with worker lease generation + independent claim generation, revocation, and required client handshake | B | needs-impl |
-| G4 | Named parked-reader wake query plus target/path-overlap `scheduler_write_index` producer lookup | shadow/B | indexes exist; query/consumer needs-impl |
+| G4 | Named parked-reader wake query plus target/path-overlap `scheduler_write_index` producer lookup | shadow/B | producer lookup implemented; parked-reader query/consumer needs-impl |
 | G5 | Exact-claim client routing, speculative overlay, read layering, revoke-and-rerun | B | needs-impl |
 | G6 | Transformer/runner enforcement of one direct root result binding; update hand-built tests | producer eligibility | implemented; no migration |
 | G7 | Authenticated branch-qualified demand + reconnect claim snapshots + ordered doc-set delta feed carrying commit/settlement sequence barriers; closure export | B/feed | needs protocol implementation |

--- a/docs/specs/server-side-execution/implementation-plan.md
+++ b/docs/specs/server-side-execution/implementation-plan.md
@@ -292,9 +292,12 @@ guessing for computation nodes.
 
 **Depends on:** W0.1, W0.2.
 **Unblocks:** demand discovery and cold wake.
+**Status:** implemented.
 
 **Decision:** creation provenance is not current producer identity. Do not add
-universal source stamping or walk from a target through its creator.
+universal source stamping or walk from a target through its creator. Likewise,
+`actualChangedWrites` is downstream invalidation evidence, not a producer
+surface; producer lookup uses declared, current-known, and materializer rows.
 
 **Read first:**
 
@@ -325,15 +328,15 @@ universal source stamping or walk from a target through its creator.
 
 **Success criteria:**
 
-- [ ] A direct result target returns its producing action from the durable row
+- [x] A direct result target returns its producing action from the durable row
       after observation and from the live static surface before first run.
-- [ ] A side-write target and materializer target return the correct action.
-- [ ] A pre-existing target redirected from a computation returns the current
+- [x] A side-write target and materializer target return the correct action.
+- [x] A pre-existing target redirected from a computation returns the current
       writer even though its creator is unrelated.
-- [ ] Multiple candidate writers are all returned deterministically.
-- [ ] PerUser/PerSession target lookups never return another context's writer.
-- [ ] Re-observation with a smaller write set removes obsolete lookup results.
-- [ ] A 10k-row query uses the intended index and meets the existing scheduler
+- [x] Multiple candidate writers are all returned deterministically.
+- [x] PerUser/PerSession target lookups never return another context's writer.
+- [x] Re-observation with a smaller write set removes obsolete lookup results.
+- [x] A 10k-row query uses the intended index and meets the existing scheduler
       index performance budget.
 
 ---

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -2963,6 +2963,107 @@ Deno.test("memory v2 writer lookup fails open when the server omits its capabili
   }
 });
 
+Deno.test("memory v2 writer lookup rechecks capability after reconnect", async () => {
+  setPersistentSchedulerStateConfig(true);
+  const currentFlags = getMemoryProtocolFlags();
+  const legacyFlags = { ...currentFlags } as Record<string, boolean>;
+  delete legacyFlags.schedulerWriterLookup;
+  const secondHelloSent = defer<void>();
+  const releaseLegacyHello = defer<void>();
+  let helloCount = 0;
+  let writerLookupCount = 0;
+  let receiver = (_payload: string) => {};
+  let closeReceiver = (_error?: Error) => {};
+  const respond = (message: FabricValue) =>
+    receiver(encodeMemoryBoundary(message));
+  const transport: Transport & { disconnect(): void } = {
+    send(payload): Promise<void> {
+      const message = decodeMemoryBoundary(payload) as {
+        type?: string;
+        requestId?: string;
+      };
+      switch (message.type) {
+        case "hello": {
+          helloCount += 1;
+          if (helloCount === 1) {
+            respond(HELLO_OK);
+          } else {
+            secondHelloSent.resolve();
+            void releaseLegacyHello.promise.then(() =>
+              respond({
+                ...HELLO_OK,
+                flags: legacyFlags,
+              })
+            );
+          }
+          return Promise.resolve();
+        }
+        case "session.open":
+          respond({
+            type: "response",
+            requestId: message.requestId!,
+            ok: {
+              sessionId: "session:writer-reconnect-capability",
+              sessionToken: "token:writer-reconnect-capability",
+              serverSeq: helloCount === 1 ? 17 : 23,
+              resumed: helloCount > 1,
+              sessionOpen: sessionOpenFor(message.requestId!),
+            },
+          });
+          return Promise.resolve();
+        case "scheduler.writer.list":
+          writerLookupCount += 1;
+          respond({
+            type: "response",
+            requestId: message.requestId!,
+            error: {
+              name: "ProtocolError",
+              message: "legacy server does not support scheduler.writer.list",
+            },
+          });
+          return Promise.resolve();
+        default:
+          throw new Error(`unexpected memory request: ${message.type}`);
+      }
+    },
+    async close() {},
+    setReceiver(next) {
+      receiver = next;
+    },
+    setCloseReceiver(next) {
+      closeReceiver = next;
+    },
+    disconnect() {
+      closeReceiver(new Error("switch to legacy server"));
+    },
+  };
+
+  const client = await connect({ transport });
+  try {
+    const session = await client.mount(
+      "did:key:z6Mk-writer-reconnect-capability-space",
+    );
+    transport.disconnect();
+    await secondHelloSent.promise;
+    const lookup = session.writersForTargets({
+      branch: "",
+      targets: [{
+        id: "of:output",
+        path: toDocumentPath(["value"]),
+      }],
+    });
+    releaseLegacyHello.resolve();
+
+    assertEquals(await lookup, { serverSeq: 23, writers: [] });
+    assertEquals(writerLookupCount, 0);
+    assertEquals(client.serverFlags?.schedulerWriterLookup, false);
+  } finally {
+    releaseLegacyHello.resolve();
+    await client.close();
+    resetPersistentSchedulerStateConfig();
+  }
+});
+
 Deno.test("memory v2 client wraps close errors with connection error names", async () => {
   const client = await connect({
     transport: new CloseOnSessionOpenTransport(),

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -9,7 +9,9 @@ import {
   type EntitySnapshot,
   getMemoryProtocolFlags,
   MEMORY_PROTOCOL,
+  resetPersistentSchedulerStateConfig,
   type SessionSync,
+  setPersistentSchedulerStateConfig,
   toDocumentPath,
 } from "../v2.ts";
 import {
@@ -2885,6 +2887,79 @@ Deno.test("memory v2 client stores the server's advertised flags (capability han
     assertEquals(legacy.serverFlags?.sqliteCommitRowLabelEval, false);
   } finally {
     await legacy.close();
+  }
+});
+
+Deno.test("memory v2 writer lookup fails open when the server omits its capability", async () => {
+  setPersistentSchedulerStateConfig(true);
+  const requestTypes: string[] = [];
+  const legacyFlags = {
+    ...getMemoryProtocolFlags(),
+  } as unknown as Record<string, boolean>;
+  delete legacyFlags.schedulerWriterLookup;
+  let receiver = (_payload: string) => {};
+  const transport: Transport = {
+    send(payload): Promise<void> {
+      const message = decodeMemoryBoundary(payload) as {
+        type?: string;
+        requestId?: string;
+      };
+      requestTypes.push(message.type ?? "<missing>");
+      switch (message.type) {
+        case "hello":
+          receiver(encodeMemoryBoundary({
+            type: "hello.ok",
+            protocol: MEMORY_PROTOCOL,
+            flags: legacyFlags,
+            sessionOpen: {
+              audience: TEST_SESSION_OPEN_AUDIENCE,
+              challenge: sessionOpenChallenge,
+            },
+          }));
+          return Promise.resolve();
+        case "session.open":
+          receiver(encodeMemoryBoundary({
+            type: "response",
+            requestId: message.requestId!,
+            ok: {
+              sessionId: "session:writer-capability",
+              sessionToken: "token:writer-capability",
+              serverSeq: 17,
+              sessionOpen: sessionOpenFor(message.requestId!),
+            },
+          }));
+          return Promise.resolve();
+        default:
+          throw new Error(`unexpected memory request: ${message.type}`);
+      }
+    },
+    async close() {},
+    setReceiver(next) {
+      receiver = next;
+    },
+    setCloseReceiver() {},
+  };
+
+  const client = await connect({ transport });
+  try {
+    assertEquals(client.serverFlags?.schedulerWriterLookup, false);
+    const session = await client.mount(
+      "did:key:z6Mk-writer-capability-space",
+      {},
+      testSessionOpenAuthFactory,
+    );
+    const result = await session.writersForTargets({
+      branch: "",
+      targets: [{
+        id: "of:output",
+        path: toDocumentPath(["value"]),
+      }],
+    });
+    assertEquals(result, { serverSeq: 17, writers: [] });
+    assertEquals(requestTypes, ["hello", "session.open"]);
+  } finally {
+    await client.close();
+    resetPersistentSchedulerStateConfig();
   }
 });
 

--- a/packages/memory/test/v2-scheduler-context-test.ts
+++ b/packages/memory/test/v2-scheduler-context-test.ts
@@ -1720,6 +1720,106 @@ Deno.test("scheduler writer lookup isolates user and session contexts", async ()
   });
 });
 
+Deno.test("scheduler writer lookup filters shared targets by action context", async () => {
+  await withEngine((engine) => {
+    const sharedTarget = schedulerAddress("shared-output", "space");
+    const userActionId = "context:writer:shared-user";
+    const userBase = observationFor({
+      actionId: userActionId,
+      summaryScope: "user",
+    });
+    const userObservation: SchedulerActionObservation = {
+      ...userBase,
+      completeActionScopeSummary: {
+        ...userBase.completeActionScopeSummary!,
+        writes: [sharedTarget],
+        directOutputs: [sharedTarget],
+      },
+      currentKnownWrites: [sharedTarget],
+    };
+    storeObservation(engine, userObservation, ALICE_A);
+    storeObservation(engine, userObservation, BOB);
+
+    const target = { ...sharedTarget, scopeKey: SPACE_KEY };
+    assertEquals(
+      writersForTargets(engine, {
+        branch: "",
+        targets: [target],
+        applicableExecutionContextKeys: [
+          SPACE_KEY,
+          ALICE_USER_KEY,
+          ALICE_A_SESSION_KEY,
+        ],
+      }).map((candidate) => candidate.executionContextKey),
+      [ALICE_USER_KEY],
+    );
+    assertEquals(
+      writersForTargets(engine, {
+        branch: "",
+        targets: [target],
+        applicableExecutionContextKeys: [
+          SPACE_KEY,
+          BOB_USER_KEY,
+          BOB_SESSION_KEY,
+        ],
+      }).map((candidate) => candidate.executionContextKey),
+      [BOB_USER_KEY],
+    );
+    assertEquals(
+      writersForTargets(engine, {
+        branch: "",
+        targets: [target],
+        applicableExecutionContextKeys: [SPACE_KEY],
+      }),
+      [],
+    );
+
+    const sessionActionId = "context:writer:shared-session";
+    const sessionBase = observationFor({
+      actionId: sessionActionId,
+      summaryScope: "session",
+    });
+    const sessionObservation: SchedulerActionObservation = {
+      ...sessionBase,
+      completeActionScopeSummary: {
+        ...sessionBase.completeActionScopeSummary!,
+        writes: [sharedTarget],
+        directOutputs: [sharedTarget],
+      },
+      currentKnownWrites: [sharedTarget],
+    };
+    storeObservation(engine, sessionObservation, ALICE_A);
+    storeObservation(engine, sessionObservation, ALICE_B);
+
+    assertEquals(
+      writersForTargets(engine, {
+        branch: "",
+        targets: [target],
+        applicableExecutionContextKeys: [
+          SPACE_KEY,
+          ALICE_USER_KEY,
+          ALICE_A_SESSION_KEY,
+        ],
+      }).filter((candidate) => candidate.actionId === sessionActionId)
+        .map((candidate) => candidate.executionContextKey),
+      [ALICE_A_SESSION_KEY],
+    );
+    assertEquals(
+      writersForTargets(engine, {
+        branch: "",
+        targets: [target],
+        applicableExecutionContextKeys: [
+          SPACE_KEY,
+          ALICE_USER_KEY,
+          ALICE_B_SESSION_KEY,
+        ],
+      }).filter((candidate) => candidate.actionId === sessionActionId)
+        .map((candidate) => candidate.executionContextKey),
+      [ALICE_B_SESSION_KEY],
+    );
+  });
+});
+
 Deno.test("scheduler writer lookup keeps its target index at 10k rows", async () => {
   await withEngine((engine) => {
     const actionId = "context:writer-index-plan";

--- a/packages/memory/test/v2-scheduler-context-test.ts
+++ b/packages/memory/test/v2-scheduler-context-test.ts
@@ -1823,76 +1823,44 @@ Deno.test("scheduler writer lookup filters shared targets by action context", as
 Deno.test("scheduler writer lookup keeps its target index at 10k rows", async () => {
   await withEngine((engine) => {
     const actionId = "context:writer-index-plan";
-    const stored = storeObservation(
-      engine,
-      observationFor({ actionId, summaryScope: "user" }),
-      ALICE_A,
+    const writes = Array.from(
+      { length: 10_000 },
+      (_, index) =>
+        schedulerAddress(
+          `output-${index.toString().padStart(5, "0")}`,
+          "user",
+        ),
     );
-    engine.database.prepare(`
-      DELETE FROM scheduler_write_index
-      WHERE action_id = :action_id
-    `).run({ action_id: actionId });
-
-    const insert = engine.database.prepare(`
-      INSERT INTO scheduler_write_index (
-        branch,
-        owner_space,
-        write_space,
-        write_id,
-        write_scope,
-        write_scope_key,
-        write_path,
-        write_kind,
-        piece_id,
-        process_generation,
-        action_id,
-        execution_context_key,
-        observation_id
-      ) VALUES (
-        '',
-        :owner_space,
-        :write_space,
-        :write_id,
-        'user',
-        :write_scope_key,
-        :write_path,
-        'current-known',
-        :piece_id,
-        1,
-        :action_id,
-        :execution_context_key,
-        :observation_id
-      )
-    `);
-    engine.database.transaction(() => {
-      for (let index = 0; index < 10_000; index++) {
-        insert.run({
-          owner_space: OWNER_SPACE,
-          write_space: OWNER_SPACE,
-          write_id: `output-${index.toString().padStart(5, "0")}`,
-          write_scope_key: ALICE_USER_KEY,
-          write_path: encodeMemoryBoundary(["value"]),
-          piece_id: PIECE_ID,
-          action_id: actionId,
-          execution_context_key: stored.executionContextKey,
-          observation_id: stored.observationId,
-        });
-      }
-    }).immediate();
+    const base = observationFor({ actionId, summaryScope: "user" });
+    storeObservation(engine, {
+      ...base,
+      completeActionScopeSummary: {
+        ...base.completeActionScopeSummary!,
+        writes,
+        directOutputs: writes,
+      },
+      currentKnownWrites: writes,
+    }, ALICE_A);
+    const target = writes.at(-1)!;
 
     assertEquals(
       writersForTargets(engine, {
         branch: "",
         targets: [{
-          space: OWNER_SPACE,
-          id: "output-09999",
-          scope: "user",
+          ...target,
           scopeKey: ALICE_USER_KEY,
-          path: ["value"],
         }],
         applicableExecutionContextKeys: [ALICE_USER_KEY],
       })[0]?.actionId,
       actionId,
+    );
+    assertEquals(
+      (engine.database.prepare(`
+        SELECT COUNT(*) AS count
+        FROM scheduler_write_index
+        WHERE action_id = :action_id
+      `).get({ action_id: actionId }) as { count: number }).count,
+      10_000,
     );
 
     const plan = engine.database.prepare(`
@@ -1905,7 +1873,7 @@ Deno.test("scheduler writer lookup keeps its target index at 10k rows", async ()
         AND write_scope_key = :write_scope_key
     `).all({
       write_space: OWNER_SPACE,
-      write_id: "output-09999",
+      write_id: target.id,
       write_scope_key: ALICE_USER_KEY,
     }) as Array<{ detail: string }>;
     assert(

--- a/packages/memory/test/v2-scheduler-context-test.ts
+++ b/packages/memory/test/v2-scheduler-context-test.ts
@@ -1837,7 +1837,7 @@ Deno.test("scheduler writer lookup keeps its target index at 10k rows", async ()
       completeActionScopeSummary: {
         ...base.completeActionScopeSummary!,
         writes,
-        directOutputs: writes,
+        directOutputs: [writes[0]!],
       },
       currentKnownWrites: writes,
     }, ALICE_A);

--- a/packages/memory/test/v2-scheduler-context-test.ts
+++ b/packages/memory/test/v2-scheduler-context-test.ts
@@ -18,6 +18,7 @@ import {
   schedulerObservationFromValue,
   type SchedulerScopeContext,
   upsertSchedulerObservation,
+  writersForTargets,
 } from "../v2/engine.ts";
 
 const OWNER_SPACE = "did:key:scheduler-context-owner";
@@ -1631,6 +1632,195 @@ Deno.test("scheduler context read lookup keeps its target index at 10k rows", as
         .sort((left, right) => left.seqno - right.seqno)
         .map((row) => row.name),
       ["branch", "read_space", "read_id", "read_scope_key"],
+    );
+  });
+});
+
+Deno.test("scheduler writer lookup isolates user and session contexts", async () => {
+  await withEngine((engine) => {
+    const userActionId = "context:writer:user";
+    const userObservation = observationFor({
+      actionId: userActionId,
+      summaryScope: "user",
+    });
+    storeObservation(engine, userObservation, ALICE_A);
+    storeObservation(engine, userObservation, BOB);
+
+    const userTarget = {
+      ...schedulerAddress("output", "user"),
+      scopeKey: ALICE_USER_KEY,
+    };
+    const aliceUserWriters = writersForTargets(engine, {
+      branch: "",
+      targets: [userTarget],
+      applicableExecutionContextKeys: [
+        SPACE_KEY,
+        ALICE_USER_KEY,
+        ALICE_A_SESSION_KEY,
+      ],
+    });
+    assertEquals(aliceUserWriters.length, 1);
+    assertEquals(aliceUserWriters[0]?.actionId, userActionId);
+    assertEquals(
+      aliceUserWriters[0]?.executionContextKey,
+      ALICE_USER_KEY,
+    );
+    assertEquals(
+      writersForTargets(engine, {
+        branch: "",
+        targets: [userTarget],
+        applicableExecutionContextKeys: [
+          SPACE_KEY,
+          BOB_USER_KEY,
+          BOB_SESSION_KEY,
+        ],
+      }),
+      [],
+    );
+
+    const sessionActionId = "context:writer:session";
+    const sessionObservation = observationFor({
+      actionId: sessionActionId,
+      summaryScope: "session",
+    });
+    storeObservation(engine, sessionObservation, ALICE_A);
+    storeObservation(engine, sessionObservation, ALICE_B);
+
+    const sessionTarget = {
+      ...schedulerAddress("output", "session"),
+      scopeKey: ALICE_A_SESSION_KEY,
+    };
+    const aliceSessionWriters = writersForTargets(engine, {
+      branch: "",
+      targets: [sessionTarget],
+      applicableExecutionContextKeys: [
+        SPACE_KEY,
+        ALICE_USER_KEY,
+        ALICE_A_SESSION_KEY,
+      ],
+    });
+    assertEquals(aliceSessionWriters.length, 1);
+    assertEquals(aliceSessionWriters[0]?.actionId, sessionActionId);
+    assertEquals(
+      aliceSessionWriters[0]?.executionContextKey,
+      ALICE_A_SESSION_KEY,
+    );
+    assertEquals(
+      writersForTargets(engine, {
+        branch: "",
+        targets: [sessionTarget],
+        applicableExecutionContextKeys: [
+          SPACE_KEY,
+          ALICE_USER_KEY,
+          ALICE_B_SESSION_KEY,
+        ],
+      }),
+      [],
+    );
+  });
+});
+
+Deno.test("scheduler writer lookup keeps its target index at 10k rows", async () => {
+  await withEngine((engine) => {
+    const actionId = "context:writer-index-plan";
+    const stored = storeObservation(
+      engine,
+      observationFor({ actionId, summaryScope: "user" }),
+      ALICE_A,
+    );
+    engine.database.prepare(`
+      DELETE FROM scheduler_write_index
+      WHERE action_id = :action_id
+    `).run({ action_id: actionId });
+
+    const insert = engine.database.prepare(`
+      INSERT INTO scheduler_write_index (
+        branch,
+        owner_space,
+        write_space,
+        write_id,
+        write_scope,
+        write_scope_key,
+        write_path,
+        write_kind,
+        piece_id,
+        process_generation,
+        action_id,
+        execution_context_key,
+        observation_id
+      ) VALUES (
+        '',
+        :owner_space,
+        :write_space,
+        :write_id,
+        'user',
+        :write_scope_key,
+        :write_path,
+        'current-known',
+        :piece_id,
+        1,
+        :action_id,
+        :execution_context_key,
+        :observation_id
+      )
+    `);
+    engine.database.transaction(() => {
+      for (let index = 0; index < 10_000; index++) {
+        insert.run({
+          owner_space: OWNER_SPACE,
+          write_space: OWNER_SPACE,
+          write_id: `output-${index.toString().padStart(5, "0")}`,
+          write_scope_key: ALICE_USER_KEY,
+          write_path: encodeMemoryBoundary(["value"]),
+          piece_id: PIECE_ID,
+          action_id: actionId,
+          execution_context_key: stored.executionContextKey,
+          observation_id: stored.observationId,
+        });
+      }
+    }).immediate();
+
+    assertEquals(
+      writersForTargets(engine, {
+        branch: "",
+        targets: [{
+          space: OWNER_SPACE,
+          id: "output-09999",
+          scope: "user",
+          scopeKey: ALICE_USER_KEY,
+          path: ["value"],
+        }],
+        applicableExecutionContextKeys: [ALICE_USER_KEY],
+      })[0]?.actionId,
+      actionId,
+    );
+
+    const plan = engine.database.prepare(`
+      EXPLAIN QUERY PLAN
+      SELECT observation_id
+      FROM scheduler_write_index
+      WHERE branch = ''
+        AND write_space = :write_space
+        AND write_id = :write_id
+        AND write_scope_key = :write_scope_key
+    `).all({
+      write_space: OWNER_SPACE,
+      write_id: "output-09999",
+      write_scope_key: ALICE_USER_KEY,
+    }) as Array<{ detail: string }>;
+    assert(
+      plan.some((row) =>
+        row.detail.includes("idx_scheduler_write_index_lookup")
+      ),
+      `expected indexed writer target lookup, got ${JSON.stringify(plan)}`,
+    );
+    assertEquals(
+      (engine.database.prepare(`
+        PRAGMA index_info('idx_scheduler_write_index_lookup')
+      `).all() as Array<{ seqno: number; name: string }>)
+        .sort((left, right) => left.seqno - right.seqno)
+        .map((row) => row.name),
+      ["branch", "write_space", "write_id", "write_scope_key"],
     );
   });
 });

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -2172,7 +2172,7 @@ Deno.test("memory v2 writer lookup derives authenticated action contexts", async
   }
 });
 
-Deno.test("memory v2 server lists only scheduler contexts applicable to the authenticated session", async () => {
+Deno.test("memory v2 server lists and looks up only scheduler contexts applicable to the authenticated session", async () => {
   setPersistentSchedulerStateConfig(true);
   const storePath = await Deno.makeTempDir();
   const store = toFileUrl(`${storePath}/`);
@@ -2304,6 +2304,46 @@ Deno.test("memory v2 server lists only scheduler contexts applicable to the auth
     assertEquals(
       await listedContexts(bob),
       expectedContexts(bobPrincipal, bob.sessionId),
+    );
+
+    const listedWriters = async (
+      session: typeof aliceA,
+      scope: "user" | "session",
+    ) =>
+      (await session.writersForTargets({
+        branch: "",
+        targets: [{
+          id: `of:${scope}-value`,
+          scope,
+          path: toDocumentPath(["value"]),
+        }],
+      })).writers.map((writer) =>
+        `${writer.actionId}@${writer.executionContextKey}`
+      );
+
+    assertEquals(
+      await listedWriters(aliceA, "user"),
+      [`${userAction}@${userKey(alicePrincipal)}`],
+    );
+    assertEquals(
+      await listedWriters(aliceB, "user"),
+      [`${userAction}@${userKey(alicePrincipal)}`],
+    );
+    assertEquals(
+      await listedWriters(bob, "user"),
+      [`${userAction}@${userKey(bobPrincipal)}`],
+    );
+    assertEquals(
+      await listedWriters(aliceA, "session"),
+      [`${sessionAction}@${sessionKey(alicePrincipal, aliceA.sessionId)}`],
+    );
+    assertEquals(
+      await listedWriters(aliceB, "session"),
+      [`${sessionAction}@${sessionKey(alicePrincipal, aliceB.sessionId)}`],
+    );
+    assertEquals(
+      await listedWriters(bob, "session"),
+      [`${sessionAction}@${sessionKey(bobPrincipal, bob.sessionId)}`],
     );
   } finally {
     await aliceAClient.close().catch(() => {});

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -20,6 +20,7 @@ import {
   serverSeq,
   upsertSchedulerObservation as upsertSchedulerObservationEngine,
   type UpsertSchedulerObservationOptions,
+  writersForTargets,
 } from "../v2/engine.ts";
 import {
   connect,
@@ -1391,6 +1392,242 @@ Deno.test("memory v2 updates scheduler index rows by diff instead of rewriting u
       }).length,
       1,
     );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 writer lookup matches direct, side, and materializer surfaces", async () => {
+  const { engine, path } = await createEngine();
+  const ownerSpace = "did:key:scheduler-writer-lookup";
+  const directWrite = {
+    space: ownerSpace,
+    scope: "space" as const,
+    id: "of:direct-output",
+    path: ["value"],
+  };
+  const sideWrite = {
+    space: ownerSpace,
+    scope: "space" as const,
+    id: "of:side-output",
+    path: ["value", "summary"],
+  };
+  const materializerWrite = {
+    space: ownerSpace,
+    scope: "space" as const,
+    id: "of:materialized-output",
+    path: ["value", "items"],
+  };
+
+  try {
+    const stored = upsertSchedulerObservation(engine, {
+      branch: "",
+      ownerSpace,
+      observedAtSeq: 7,
+      observation: observationForAction("writer-lookup:surfaces", {
+        ownerSpace,
+        pieceId: "space:of:writer-piece",
+        currentKnownWrites: [directWrite, sideWrite],
+        materializerWriteEnvelopes: [materializerWrite],
+      }),
+    });
+
+    const direct = writersForTargets(engine, {
+      branch: "",
+      targets: [{
+        ...directWrite,
+        scopeKey: "space",
+        path: ["value", "nested", "result"],
+      }],
+    });
+    assertEquals(direct.length, 1);
+    assertEquals(direct[0]?.actionId, "writer-lookup:surfaces");
+    assertEquals(direct[0]?.pieceId, "space:of:writer-piece");
+    assertEquals(direct[0]?.actionKind, "computation");
+    assertEquals(direct[0]?.implementationFingerprint, "impl:v1");
+    assertEquals(direct[0]?.runtimeFingerprint, "runtime:test");
+    assertEquals(direct[0]?.status, "success");
+    assertEquals(direct[0]?.executionContextKey, stored.executionContextKey);
+    assertEquals(direct[0]?.matchedWrites, [{
+      kind: "current-known",
+      write: { ...directWrite, scopeKey: "space" },
+    }]);
+
+    const side = writersForTargets(engine, {
+      branch: "",
+      targets: [{ ...sideWrite, scopeKey: "space" }],
+    });
+    assertEquals(side.length, 1);
+    assertEquals(side[0]?.actionId, "writer-lookup:surfaces");
+    assertEquals(side[0]?.matchedWrites, [{
+      kind: "current-known",
+      write: { ...sideWrite, scopeKey: "space" },
+    }]);
+
+    const materializer = writersForTargets(engine, {
+      branch: "",
+      targets: [{
+        ...materializerWrite,
+        scopeKey: "space",
+        path: ["value", "items", "0"],
+      }],
+    });
+    assertEquals(materializer.length, 1);
+    assertEquals(materializer[0]?.actionId, "writer-lookup:surfaces");
+    assertEquals(materializer[0]?.matchedWrites, [{
+      kind: "materializer",
+      write: { ...materializerWrite, scopeKey: "space" },
+    }]);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 writer lookup returns every candidate deterministically", async () => {
+  const { engine, path } = await createEngine();
+  const ownerSpace = "did:key:scheduler-writer-candidates";
+  const sharedTarget = {
+    space: ownerSpace,
+    scope: "space" as const,
+    id: "of:shared-output",
+    path: ["value"],
+  };
+
+  try {
+    for (const actionId of ["writer:z-last", "writer:a-first"]) {
+      upsertSchedulerObservation(engine, {
+        branch: "",
+        ownerSpace,
+        observedAtSeq: 1,
+        observation: observationForAction(actionId, {
+          ownerSpace,
+          pieceId: `space:of:${actionId}`,
+          currentKnownWrites: [sharedTarget],
+        }),
+      });
+    }
+
+    const candidates = writersForTargets(engine, {
+      branch: "",
+      targets: [{ ...sharedTarget, scopeKey: "space" }],
+    });
+    assertEquals(candidates.length, 2);
+    assertEquals(candidates[0]?.actionId, "writer:a-first");
+    assertEquals(candidates[1]?.actionId, "writer:z-last");
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 writer lookup replaces stale targets on re-observation", async () => {
+  const { engine, path } = await createEngine();
+  const ownerSpace = "did:key:scheduler-writer-reobservation";
+  const retained = {
+    space: ownerSpace,
+    scope: "space" as const,
+    id: "of:retained-output",
+    path: ["value"],
+  };
+  const removed = {
+    space: ownerSpace,
+    scope: "space" as const,
+    id: "of:removed-output",
+    path: ["value"],
+  };
+  const actionId = "writer-lookup:reobserved";
+
+  try {
+    upsertSchedulerObservation(engine, {
+      branch: "",
+      ownerSpace,
+      observedAtSeq: 1,
+      observation: observationForAction(actionId, {
+        ownerSpace,
+        currentKnownWrites: [retained, removed],
+      }),
+    });
+    assertEquals(
+      writersForTargets(engine, {
+        branch: "",
+        targets: [{ ...removed, scopeKey: "space" }],
+      }).length,
+      1,
+    );
+
+    upsertSchedulerObservation(engine, {
+      branch: "",
+      ownerSpace,
+      observedAtSeq: 2,
+      observation: observationForAction(actionId, {
+        ownerSpace,
+        observedAtSeq: 2,
+        currentKnownWrites: [retained],
+      }),
+    });
+
+    assertEquals(
+      writersForTargets(engine, {
+        branch: "",
+        targets: [{ ...removed, scopeKey: "space" }],
+      }),
+      [],
+    );
+    assertEquals(
+      writersForTargets(engine, {
+        branch: "",
+        targets: [{ ...retained, scopeKey: "space" }],
+      })[0]?.actionId,
+      actionId,
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 writer lookup ignores target creation provenance", async () => {
+  const { engine, path } = await createEngine();
+  const ownerSpace = "did:key:scheduler-writer-preexisting";
+  const target = {
+    space: ownerSpace,
+    scope: "space" as const,
+    id: "of:preexisting-output",
+    path: ["value"],
+  };
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:unrelated-creator",
+      space: ownerSpace,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: target.id,
+          value: { value: { creator: "unrelated" } },
+        }],
+      },
+    });
+    upsertSchedulerObservation(engine, {
+      branch: "",
+      ownerSpace,
+      observedAtSeq: headSeq(engine),
+      observation: observationForAction("writer-lookup:current-producer", {
+        ownerSpace,
+        currentKnownWrites: [target],
+      }),
+    });
+
+    const candidates = writersForTargets(engine, {
+      branch: "",
+      targets: [{ ...target, scopeKey: "space" }],
+    });
+    assertEquals(candidates.length, 1);
+    assertEquals(candidates[0]?.actionId, "writer-lookup:current-producer");
   } finally {
     close(engine);
     await Deno.remove(path);

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -1774,6 +1774,28 @@ Deno.test("memory v2 writer lookup fails open on corrupt projections", async () 
     });
     assertEquals(lookup(mismatchedPayload.target), []);
 
+    const mismatchedAddress = storeWriter(
+      "writer-corrupt:mismatched-address",
+    );
+    const forgedTarget = {
+      ...mismatchedAddress.target,
+      id: "of:forged-writer-target",
+    };
+    engine.database.prepare(`
+      UPDATE scheduler_write_index
+      SET write_id = :write_id
+      WHERE action_id = 'writer-corrupt:mismatched-address'
+    `).run({ write_id: forgedTarget.id });
+    assertEquals(lookup(forgedTarget), []);
+
+    const mismatchedKind = storeWriter("writer-corrupt:mismatched-kind");
+    engine.database.prepare(`
+      UPDATE scheduler_write_index
+      SET write_kind = 'materializer'
+      WHERE action_id = 'writer-corrupt:mismatched-kind'
+    `).run();
+    assertEquals(lookup(mismatchedKind.target), []);
+
     const invalidPath = storeWriter("writer-corrupt:invalid-path");
     engine.database.prepare(`
       UPDATE scheduler_write_index

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -1635,6 +1635,41 @@ Deno.test("memory v2 writer lookup ignores target creation provenance", async ()
   }
 });
 
+Deno.test("memory v2 writer lookup reports the last failure fingerprint", async () => {
+  const { engine, path } = await createEngine();
+  const ownerSpace = "did:key:scheduler-writer-failure";
+  const target = {
+    space: ownerSpace,
+    scope: "space" as const,
+    id: "of:failed-output",
+    path: ["value"],
+  };
+
+  try {
+    upsertSchedulerObservation(engine, {
+      branch: "",
+      ownerSpace,
+      observedAtSeq: 1,
+      observation: observationForAction("writer-lookup:failed", {
+        ownerSpace,
+        currentKnownWrites: [target],
+        status: "failed",
+        errorFingerprint: "error:stable-fingerprint",
+      }),
+    });
+
+    const candidate = writersForTargets(engine, {
+      branch: "",
+      targets: [{ ...target, scopeKey: "space" }],
+    })[0];
+    assertEquals(candidate?.status, "failed");
+    assertEquals(candidate?.errorFingerprint, "error:stable-fingerprint");
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
 Deno.test("memory v2 writer lookup fails open on corrupt projections", async () => {
   const { engine, path } = await createEngine();
   const ownerSpace = "did:key:scheduler-writer-corruption";
@@ -1699,7 +1734,10 @@ Deno.test("memory v2 writer lookup fails open on corrupt projections", async () 
       SET write_path = :write_path
       WHERE action_id = 'writer-corrupt:invalid-path'
     `).run({ write_path: encodeMemoryBoundary([42]) });
-    assertEquals(lookup(invalidPath.target), []);
+    assertEquals(
+      lookup({ ...invalidPath.target, path: ["42"] }),
+      [],
+    );
 
     const invalidKind = storeWriter("writer-corrupt:invalid-kind");
     engine.database.prepare(`

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -16,6 +16,7 @@ import {
   open as openEngine,
   principalOfSessionKey,
   resolveCommitSessionKey,
+  resolveScopeKey,
   type SchedulerActionObservation,
   serverSeq,
   upsertSchedulerObservation as upsertSchedulerObservationEngine,
@@ -1784,6 +1785,22 @@ Deno.test("memory v2 writer lookup fails open on corrupt projections", async () 
     });
     assertEquals(lookup(mismatchedPayload.target), []);
 
+    const divergentSnapshot = storeWriter(
+      "writer-corrupt:divergent-snapshot",
+    );
+    engine.database.prepare(`
+      UPDATE scheduler_action_snapshot
+      SET payload = :payload
+      WHERE action_id = 'writer-corrupt:divergent-snapshot'
+    `).run({
+      payload: encodeMemoryBoundary({
+        ...divergentSnapshot.storedObservation,
+        status: "failed",
+        errorFingerprint: "forged-error",
+      }),
+    });
+    assertEquals(lookup(divergentSnapshot.target), []);
+
     const mismatchedAddress = storeWriter(
       "writer-corrupt:mismatched-address",
     );
@@ -1805,6 +1822,50 @@ Deno.test("memory v2 writer lookup fails open on corrupt projections", async () 
       WHERE action_id = 'writer-corrupt:mismatched-kind'
     `).run();
     assertEquals(lookup(mismatchedKind.target), []);
+
+    const scopedContext = {
+      principal: "did:key:scheduler-writer-corruption-owner",
+      sessionId: "session:scheduler-writer-corruption-owner",
+    };
+    for (const scope of ["user", "session"] as const) {
+      const actionId = `writer-corrupt:mismatched-${scope}-scope-key`;
+      const target = {
+        space: ownerSpace,
+        scope,
+        id: `of:${actionId}`,
+        path: ["value"],
+      };
+      const stored = upsertSchedulerObservation(engine, {
+        branch: "",
+        ownerSpace,
+        observedAtSeq: 1,
+        observation: observationForAction(actionId, {
+          ownerSpace,
+          currentKnownWrites: [target],
+        }),
+        scopeContext: scopedContext,
+      });
+      const forgedScopeKey = resolveScopeKey(scope, {
+        principal: "did:key:scheduler-writer-corruption-forged",
+        sessionId: "session:scheduler-writer-corruption-forged",
+      });
+      engine.database.prepare(`
+        UPDATE scheduler_write_index
+        SET write_scope_key = :write_scope_key
+        WHERE action_id = :action_id
+      `).run({
+        action_id: actionId,
+        write_scope_key: forgedScopeKey,
+      });
+      assertEquals(
+        writersForTargets(engine, {
+          branch: "",
+          targets: [{ ...target, scopeKey: forgedScopeKey }],
+          applicableExecutionContextKeys: [stored.executionContextKey],
+        }),
+        [],
+      );
+    }
 
     const invalidPath = storeWriter("writer-corrupt:invalid-path");
     engine.database.prepare(`

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -1994,6 +1994,138 @@ Deno.test("memory v2 keeps scheduler state for two user contexts", async () => {
   }
 });
 
+Deno.test("memory v2 writer lookup derives authenticated action contexts", async () => {
+  setPersistentSchedulerStateConfig(true);
+  const storePath = await Deno.makeTempDir();
+  const store = toFileUrl(`${storePath}/`);
+  const server = new Server({
+    store,
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: testSessionOpenAuth,
+  });
+  const aliceClient = await connect({ transport: loopback(server) });
+  const bobClient = await connect({ transport: loopback(server) });
+  const ownerSpace = "did:key:scheduler-writer-protocol-owner";
+  const alicePrincipal = "did:key:scheduler-writer-protocol-alice";
+  const bobPrincipal = "did:key:scheduler-writer-protocol-bob";
+  const alice = await aliceClient.mount(
+    ownerSpace,
+    {},
+    schedulerAuthFactoryFor(alicePrincipal),
+  );
+  const bob = await bobClient.mount(
+    ownerSpace,
+    {},
+    schedulerAuthFactoryFor(bobPrincipal),
+  );
+  const piece = {
+    space: ownerSpace,
+    scope: "space" as const,
+    id: "of:piece",
+    path: [],
+  };
+  const sharedTarget = {
+    space: ownerSpace,
+    scope: "space" as const,
+    id: "of:shared-output",
+    path: ["value"],
+  };
+  const userRead = {
+    space: ownerSpace,
+    scope: "user" as const,
+    id: "of:user-input",
+    path: ["value"],
+  };
+  const contextObservation = (
+    actionId: string,
+  ): SchedulerActionObservation => {
+    const implementationFingerprint = `impl:${actionId}`;
+    return observationForAction(actionId, {
+      version: 2,
+      ownerSpace,
+      pieceId: "space:of:piece",
+      implementationFingerprint,
+      reads: [userRead],
+      currentKnownWrites: [sharedTarget],
+      completeActionScopeSummary: {
+        version: 1,
+        complete: true,
+        implementationFingerprint,
+        runtimeFingerprint: observation.runtimeFingerprint,
+        piece,
+        reads: [userRead],
+        writes: [sharedTarget],
+        materializerWriteEnvelopes: [],
+        directOutputs: [sharedTarget],
+      },
+    });
+  };
+  const aliceAction = "pattern.tsx:computed:writer-alice";
+  const bobAction = "pattern.tsx:computed:writer-bob";
+
+  try {
+    await alice.transact({
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [],
+      schedulerObservation: contextObservation(aliceAction),
+    });
+    await bob.transact({
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [],
+      schedulerObservation: contextObservation(bobAction),
+    });
+
+    const query = {
+      branch: "",
+      targets: [{
+        id: sharedTarget.id,
+        scope: sharedTarget.scope,
+        path: toDocumentPath(sharedTarget.path),
+      }],
+    };
+    const aliceWriters = await alice.writersForTargets(query);
+    const bobWriters = await bob.writersForTargets(query);
+    assertEquals(
+      aliceWriters.writers.map((writer: {
+        actionId: string;
+        executionContextKey: string;
+      }) => ({
+        actionId: writer.actionId,
+        executionContextKey: writer.executionContextKey,
+      })),
+      [{
+        actionId: aliceAction,
+        executionContextKey: `user:${encodeURIComponent(alicePrincipal)}`,
+      }],
+    );
+    assertEquals(
+      bobWriters.writers.map((writer: {
+        actionId: string;
+        executionContextKey: string;
+      }) => ({
+        actionId: writer.actionId,
+        executionContextKey: writer.executionContextKey,
+      })),
+      [{
+        actionId: bobAction,
+        executionContextKey: `user:${encodeURIComponent(bobPrincipal)}`,
+      }],
+    );
+  } finally {
+    await aliceClient.close().catch(() => {});
+    await bobClient.close().catch(() => {});
+    await server.close().catch(() => {});
+    await Deno.remove(storePath, { recursive: true });
+    resetPersistentSchedulerStateConfig();
+  }
+});
+
 Deno.test("memory v2 server lists only scheduler contexts applicable to the authenticated session", async () => {
   setPersistentSchedulerStateConfig(true);
   const storePath = await Deno.makeTempDir();
@@ -2231,6 +2363,17 @@ Deno.test("memory v2 server does not serve scheduler snapshots while persistent 
   const storePath = await Deno.makeTempDir();
   const store = toFileUrl(`${storePath}/`);
   const ownerSpace = "did:key:scheduler-flag-off-owner-space";
+  const ownerTarget = {
+    space: ownerSpace,
+    scope: "space" as const,
+    id: "of:flag-off-output",
+    path: ["value"],
+  };
+  const storedObservation = {
+    ...observation,
+    ownerSpace,
+    currentKnownWrites: [ownerTarget],
+  } satisfies SchedulerActionObservation;
 
   setPersistentSchedulerStateConfig(true);
   const setupServer = new Server({
@@ -2249,7 +2392,7 @@ Deno.test("memory v2 server does not serve scheduler snapshots while persistent 
       localSeq: 1,
       reads: { confirmed: [], pending: [] },
       operations: [],
-      schedulerObservation: { ...observation, ownerSpace },
+      schedulerObservation: storedObservation,
     });
   } finally {
     await setupClient.close().catch(() => {});
@@ -2273,6 +2416,15 @@ Deno.test("memory v2 server does not serve scheduler snapshots while persistent 
       actionId: observation.actionId,
     });
     assertEquals(listed.snapshots, []);
+    const writers = await owner.writersForTargets({
+      branch: "",
+      targets: [{
+        id: ownerTarget.id,
+        scope: ownerTarget.scope,
+        path: toDocumentPath(ownerTarget.path),
+      }],
+    });
+    assertEquals(writers.writers, []);
   } finally {
     await client.close().catch(() => {});
     await server.close().catch(() => {});

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -1497,7 +1497,14 @@ Deno.test("memory v2 writer lookup returns every candidate deterministically", a
   };
 
   try {
-    for (const actionId of ["writer:z-last", "writer:a-first"]) {
+    for (
+      const actionId of [
+        "writer:z-last",
+        "writer:\u{10000}",
+        "writer:a-first",
+        "writer:\uffff",
+      ]
+    ) {
       upsertSchedulerObservation(engine, {
         branch: "",
         ownerSpace,
@@ -1514,9 +1521,12 @@ Deno.test("memory v2 writer lookup returns every candidate deterministically", a
       branch: "",
       targets: [{ ...sharedTarget, scopeKey: "space" }],
     });
-    assertEquals(candidates.length, 2);
-    assertEquals(candidates[0]?.actionId, "writer:a-first");
-    assertEquals(candidates[1]?.actionId, "writer:z-last");
+    assertEquals(candidates.map((candidate) => candidate.actionId), [
+      "writer:a-first",
+      "writer:z-last",
+      "writer:\uffff",
+      "writer:\u{10000}",
+    ]);
   } finally {
     close(engine);
     await Deno.remove(path);

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -1101,6 +1101,13 @@ Deno.test("memory v2 coalesces identical scheduler observations without leaving 
     assertEquals(countRows(engine, "scheduler_observation"), 1);
     assertEquals(countRows(engine, "scheduler_observation_replay"), 2);
     assertEquals(
+      writersForTargets(engine, {
+        branch: "",
+        targets: [{ ...targetWrite, scopeKey: "space" }],
+      }).map((writer) => writer.actionId),
+      [observation.actionId],
+    );
+    assertEquals(
       getSchedulerActionState(engine, {
         branch: "",
         pieceId: observation.pieceId,
@@ -1721,6 +1728,55 @@ Deno.test("memory v2 writer lookup recovers commit sequence from its observation
       targets: [{ ...target, scopeKey: "space" }],
     })[0];
     assertEquals(candidate?.commitSeq, applied.seq);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 writer lookup uses a distinct snapshot delivery slot", async () => {
+  const { engine, path } = await createEngine();
+  const ownerSpace = "did:key:scheduler-writer-delivery-slot";
+  const target = {
+    space: ownerSpace,
+    scope: "space" as const,
+    id: "of:delivery-slot-output",
+    path: ["value"],
+  };
+  const actionId = "writer-lookup:delivery-slot";
+
+  try {
+    const semantic = applyCommit(engine, {
+      sessionId: "session:scheduler-writer-delivery-slot",
+      space: ownerSpace,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "of:semantic-input",
+          value: { value: 1 },
+        }],
+      },
+    });
+    upsertSchedulerObservation(engine, {
+      branch: "",
+      ownerSpace,
+      commitSeq: semantic.seq,
+      deliveryCommitSeq: semantic.seq + 1,
+      observedAtSeq: semantic.seq,
+      observation: observationForAction(actionId, {
+        ownerSpace,
+        currentKnownWrites: [target],
+      }),
+    });
+
+    const candidate = writersForTargets(engine, {
+      branch: "",
+      targets: [{ ...target, scopeKey: "space" }],
+    })[0];
+    assertEquals(candidate?.actionId, actionId);
+    assertEquals(candidate?.commitSeq, semantic.seq + 1);
   } finally {
     close(engine);
     await Deno.remove(path);

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -30,6 +30,7 @@ import {
 import { Server } from "../v2/server.ts";
 import { resolveSpaceStoreUrl } from "../v2/storage-path.ts";
 import {
+  encodeMemoryBoundary,
   resetPersistentSchedulerStateConfig,
   setPersistentSchedulerStateConfig,
   toDocumentPath,
@@ -1628,6 +1629,85 @@ Deno.test("memory v2 writer lookup ignores target creation provenance", async ()
     });
     assertEquals(candidates.length, 1);
     assertEquals(candidates[0]?.actionId, "writer-lookup:current-producer");
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 writer lookup fails open on corrupt projections", async () => {
+  const { engine, path } = await createEngine();
+  const ownerSpace = "did:key:scheduler-writer-corruption";
+  const storeWriter = (actionId: string) => {
+    const target = {
+      space: ownerSpace,
+      scope: "space" as const,
+      id: `of:${actionId}`,
+      path: ["value"],
+    };
+    const storedObservation = observationForAction(actionId, {
+      ownerSpace,
+      currentKnownWrites: [target],
+    });
+    upsertSchedulerObservation(engine, {
+      branch: "",
+      ownerSpace,
+      observedAtSeq: 1,
+      observation: storedObservation,
+    });
+    return { target, storedObservation };
+  };
+  const lookup = (
+    target: SchedulerActionObservation["currentKnownWrites"][number],
+  ) =>
+    writersForTargets(engine, {
+      branch: "",
+      targets: [{ ...target, scopeKey: "space" }],
+    });
+
+  try {
+    const missingState = storeWriter("writer-corrupt:missing-state");
+    engine.database.prepare(`
+      DELETE FROM scheduler_action_state
+      WHERE action_id = 'writer-corrupt:missing-state'
+    `).run();
+    assertEquals(lookup(missingState.target), []);
+
+    const missingSnapshot = storeWriter("writer-corrupt:missing-snapshot");
+    engine.database.prepare(`
+      DELETE FROM scheduler_action_snapshot
+      WHERE action_id = 'writer-corrupt:missing-snapshot'
+    `).run();
+    assertEquals(lookup(missingSnapshot.target), []);
+
+    const mismatchedPayload = storeWriter("writer-corrupt:mismatched-payload");
+    engine.database.prepare(`
+      UPDATE scheduler_action_snapshot
+      SET payload = :payload
+      WHERE action_id = 'writer-corrupt:mismatched-payload'
+    `).run({
+      payload: encodeMemoryBoundary({
+        ...mismatchedPayload.storedObservation,
+        actionId: "writer-corrupt:forged-action",
+      }),
+    });
+    assertEquals(lookup(mismatchedPayload.target), []);
+
+    const invalidPath = storeWriter("writer-corrupt:invalid-path");
+    engine.database.prepare(`
+      UPDATE scheduler_write_index
+      SET write_path = :write_path
+      WHERE action_id = 'writer-corrupt:invalid-path'
+    `).run({ write_path: encodeMemoryBoundary([42]) });
+    assertEquals(lookup(invalidPath.target), []);
+
+    const invalidKind = storeWriter("writer-corrupt:invalid-kind");
+    engine.database.prepare(`
+      UPDATE scheduler_write_index
+      SET write_kind = 'forged-kind'
+      WHERE action_id = 'writer-corrupt:invalid-kind'
+    `).run();
+    assertEquals(lookup(invalidKind.target), []);
   } finally {
     close(engine);
     await Deno.remove(path);

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -1670,6 +1670,52 @@ Deno.test("memory v2 writer lookup reports the last failure fingerprint", async 
   }
 });
 
+Deno.test("memory v2 writer lookup recovers commit sequence from its observation", async () => {
+  const { engine, path } = await createEngine();
+  const ownerSpace = "did:key:scheduler-writer-commit-seq";
+  const target = {
+    space: ownerSpace,
+    scope: "space" as const,
+    id: "of:commit-seq-output",
+    path: ["value"],
+  };
+  const actionId = "writer-lookup:commit-seq";
+
+  try {
+    const applied = applyCommit(engine, {
+      sessionId: "session:scheduler-writer-commit-seq",
+      space: ownerSpace,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: target.id,
+          value: { value: 1 },
+        }],
+        schedulerObservation: observationForAction(actionId, {
+          ownerSpace,
+          currentKnownWrites: [target],
+        }),
+      },
+    });
+    engine.database.prepare(`
+      UPDATE scheduler_action_snapshot
+      SET commit_seq = NULL
+      WHERE action_id = :action_id
+    `).run({ action_id: actionId });
+
+    const candidate = writersForTargets(engine, {
+      branch: "",
+      targets: [{ ...target, scopeKey: "space" }],
+    })[0];
+    assertEquals(candidate?.commitSeq, applied.seq);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
 Deno.test("memory v2 writer lookup fails open on corrupt projections", async () => {
   const { engine, path } = await createEngine();
   const ownerSpace = "did:key:scheduler-writer-corruption";

--- a/packages/memory/test/v2-server-acl-test.ts
+++ b/packages/memory/test/v2-server-acl-test.ts
@@ -1421,9 +1421,9 @@ Deno.test("acl enforce: auxiliary read and operator surfaces honor capabilities"
     assertEquals(writers.requestId, bobWriterRequestId);
     assertEquals(writers.ok?.writers, []);
 
-    const carolWriterRequestId = nextRequestId(
-      "acl-scheduler-writers-denied",
-    );
+    // Capabilities are hierarchical: WRITE implies READ, so Carol may use
+    // this READ-class lookup just like Bob.
+    const carolWriterRequestId = nextRequestId("acl-scheduler-writers-write");
     await carol.connection.receive(encodeMemoryBoundary({
       type: "scheduler.writer.list",
       requestId: carolWriterRequestId,
@@ -1434,9 +1434,12 @@ Deno.test("acl enforce: auxiliary read and operator surfaces honor capabilities"
         targets: [{ id: "of:output", path: ["value"] }],
       },
     }));
-    const deniedWriters = assertResponse<unknown>(shiftMessage(carol.messages));
-    assertEquals(deniedWriters.requestId, carolWriterRequestId);
-    assertEquals(deniedWriters.error?.name, "AuthorizationError");
+    const carolWriters = assertResponse<{
+      serverSeq: number;
+      writers: unknown[];
+    }>(shiftMessage(carol.messages));
+    assertEquals(carolWriters.requestId, carolWriterRequestId);
+    assertEquals(carolWriters.ok?.writers, []);
 
     const watch = await server.watchAdd({
       type: "session.watch.add",

--- a/packages/memory/test/v2-server-acl-test.ts
+++ b/packages/memory/test/v2-server-acl-test.ts
@@ -1404,6 +1404,40 @@ Deno.test("acl enforce: auxiliary read and operator surfaces honor capabilities"
     });
     assertEquals(snapshots.ok?.snapshots, []);
 
+    const bobWriterRequestId = nextRequestId("acl-scheduler-writers");
+    await bob.connection.receive(encodeMemoryBoundary({
+      type: "scheduler.writer.list",
+      requestId: bobWriterRequestId,
+      space,
+      sessionId: bobSession.ok.sessionId,
+      query: {
+        branch: "",
+        targets: [{ id: "of:output", path: ["value"] }],
+      },
+    }));
+    const writers = assertResponse<{ serverSeq: number; writers: unknown[] }>(
+      shiftMessage(bob.messages),
+    );
+    assertEquals(writers.requestId, bobWriterRequestId);
+    assertEquals(writers.ok?.writers, []);
+
+    const carolWriterRequestId = nextRequestId(
+      "acl-scheduler-writers-denied",
+    );
+    await carol.connection.receive(encodeMemoryBoundary({
+      type: "scheduler.writer.list",
+      requestId: carolWriterRequestId,
+      space,
+      sessionId: carolSession.ok.sessionId,
+      query: {
+        branch: "",
+        targets: [{ id: "of:output", path: ["value"] }],
+      },
+    }));
+    const deniedWriters = assertResponse<unknown>(shiftMessage(carol.messages));
+    assertEquals(deniedWriters.requestId, carolWriterRequestId);
+    assertEquals(deniedWriters.error?.name, "AuthorizationError");
+
     const watch = await server.watchAdd({
       type: "session.watch.add",
       requestId: nextRequestId("acl-watch-add"),

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -212,6 +212,74 @@ Deno.test("memory v2 scheduler listing rejects arbitrary context selectors", () 
   );
 });
 
+Deno.test("memory v2 scheduler writer lookup accepts only server-scoped targets", () => {
+  const request = {
+    type: "scheduler.writer.list",
+    requestId: "scheduler-writer-list",
+    space: "did:key:z6Mk-space",
+    sessionId: "session:alice",
+    query: {
+      branch: "feature",
+      targets: [{
+        id: "of:output",
+        scope: "user",
+        path: ["value", "result"],
+      }],
+    },
+  };
+  assertEquals(
+    parseClientMessage(encodeMemoryBoundary(request)),
+    request as unknown as ReturnType<typeof parseClientMessage>,
+  );
+
+  const invalidQueries = [
+    {
+      executionContextKey: "user:did%3Akey%3Abob",
+      targets: [{ id: "of:output", path: ["value"] }],
+    },
+    {
+      targets: [{
+        id: "of:output",
+        path: ["value"],
+        scopeKey: "user:did%3Akey%3Abob",
+      }],
+    },
+    {
+      targets: [{
+        id: "of:output",
+        path: ["value"],
+        execution_context_key: "session:other:session",
+      }],
+    },
+    {
+      targets: [{
+        space: "did:key:z6Mk-other-space",
+        id: "of:output",
+        path: ["value"],
+      }],
+    },
+    {
+      targets: [{ id: "of:output", scope: "global", path: ["value"] }],
+    },
+    {
+      targets: [{ id: "of:output", path: ["value", 0] }],
+    },
+  ];
+
+  for (const [index, query] of invalidQueries.entries()) {
+    assertEquals(
+      parseClientMessage(encodeMemoryBoundary({
+        type: "scheduler.writer.list",
+        requestId: `scheduler-writer-invalid-${index}`,
+        space: "did:key:z6Mk-space",
+        sessionId: "session:alice",
+        query,
+      })),
+      null,
+    );
+  }
+});
+
 Deno.test("memory v2 session registry scopes session ids by space", () => {
   const sessions = new SessionRegistry();
   const first = sessions.open(

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -138,6 +138,7 @@ describe("memory v2 flags", () => {
     assertEquals(getMemoryProtocolFlags(), {
       modernCellRep: false,
       persistentSchedulerState: false,
+      schedulerWriterLookup: true,
       commitPreconditions: false,
       syncSchemaTable: false,
       // Build-inherent capability, not configuration: always advertised.
@@ -153,6 +154,7 @@ describe("memory v2 flags", () => {
     assertEquals(getMemoryProtocolFlags(), {
       modernCellRep: true,
       persistentSchedulerState: true,
+      schedulerWriterLookup: true,
       commitPreconditions: true,
       syncSchemaTable: false,
       sqliteCommitRowLabelEval: true,
@@ -170,6 +172,7 @@ describe("memory v2 flags", () => {
       {
         modernCellRep: true,
         persistentSchedulerState: true,
+        schedulerWriterLookup: true,
         commitPreconditions: true,
         syncSchemaTable: true,
         syncSchemaTableV2: true,
@@ -178,6 +181,7 @@ describe("memory v2 flags", () => {
       {
         modernCellRep: true,
         persistentSchedulerState: false,
+        schedulerWriterLookup: false,
         commitPreconditions: false,
         syncSchemaTable: false,
         syncSchemaTableV2: false,
@@ -195,6 +199,7 @@ describe("parseMemoryProtocolFlags", () => {
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: true }), {
       modernCellRep: true,
       persistentSchedulerState: false,
+      schedulerWriterLookup: false,
       commitPreconditions: false,
       syncSchemaTable: false,
       syncSchemaTableV2: false,
@@ -203,6 +208,7 @@ describe("parseMemoryProtocolFlags", () => {
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: false }), {
       modernCellRep: false,
       persistentSchedulerState: false,
+      schedulerWriterLookup: false,
       commitPreconditions: false,
       syncSchemaTable: false,
       syncSchemaTableV2: false,
@@ -218,6 +224,22 @@ describe("parseMemoryProtocolFlags", () => {
       {
         modernCellRep: false,
         persistentSchedulerState: true,
+        schedulerWriterLookup: false,
+        commitPreconditions: false,
+        syncSchemaTable: false,
+        syncSchemaTableV2: false,
+        sqliteCommitRowLabelEval: false,
+      },
+    );
+  });
+
+  it("accepts the schedulerWriterLookup capability key", () => {
+    assertEquals(
+      parseMemoryProtocolFlags({ schedulerWriterLookup: true }),
+      {
+        modernCellRep: false,
+        persistentSchedulerState: false,
+        schedulerWriterLookup: true,
         commitPreconditions: false,
         syncSchemaTable: false,
         syncSchemaTableV2: false,
@@ -234,6 +256,7 @@ describe("parseMemoryProtocolFlags", () => {
       {
         modernCellRep: false,
         persistentSchedulerState: false,
+        schedulerWriterLookup: false,
         commitPreconditions: true,
         syncSchemaTable: false,
         syncSchemaTableV2: false,
@@ -250,6 +273,7 @@ describe("parseMemoryProtocolFlags", () => {
       {
         modernCellRep: false,
         persistentSchedulerState: false,
+        schedulerWriterLookup: false,
         commitPreconditions: false,
         syncSchemaTable: true,
         syncSchemaTableV2: false,
@@ -266,6 +290,7 @@ describe("parseMemoryProtocolFlags", () => {
       {
         modernCellRep: false,
         persistentSchedulerState: false,
+        schedulerWriterLookup: false,
         commitPreconditions: false,
         syncSchemaTable: false,
         syncSchemaTableV2: true,
@@ -282,6 +307,7 @@ describe("parseMemoryProtocolFlags", () => {
       {
         modernCellRep: false,
         persistentSchedulerState: false,
+        schedulerWriterLookup: false,
         commitPreconditions: false,
         syncSchemaTable: false,
         syncSchemaTableV2: false,
@@ -298,6 +324,10 @@ describe("parseMemoryProtocolFlags", () => {
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: "true" }), null);
     assertEquals(parseMemoryProtocolFlags({ syncSchemaTable: "true" }), null);
     assertEquals(parseMemoryProtocolFlags({ syncSchemaTableV2: "true" }), null);
+    assertEquals(
+      parseMemoryProtocolFlags({ schedulerWriterLookup: "true" }),
+      null,
+    );
     assertEquals(
       parseMemoryProtocolFlags({ sqliteCommitRowLabelEval: "true" }),
       null,

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -237,6 +237,8 @@ export interface SessionOpenResult {
 export interface MemoryProtocolFlags {
   modernCellRep: boolean;
   persistentSchedulerState: boolean;
+  /** Build-inherent support for authenticated scheduler writer lookup. */
+  schedulerWriterLookup: boolean;
   commitPreconditions: boolean;
   /** Legacy CT-1775 draft capability: index-keyed per-frame schema table. */
   syncSchemaTable: boolean;
@@ -261,6 +263,7 @@ export interface MemoryProtocolFlags {
 export type WireMemoryProtocolFlags = {
   modernCellRep?: boolean;
   persistentSchedulerState?: boolean;
+  schedulerWriterLookup?: boolean;
   commitPreconditions?: boolean;
   syncSchemaTable?: boolean;
   syncSchemaTableV2?: boolean;
@@ -603,6 +606,69 @@ export interface SchedulerSnapshotListRequest {
   query: SchedulerActionSnapshotQuery;
 }
 
+export interface SchedulerWriterTarget {
+  id: EntityId;
+  scope?: CellScope;
+  path: DocumentPath;
+}
+
+export interface SchedulerWritersForTargetsQuery {
+  branch?: BranchName;
+  targets: SchedulerWriterTarget[];
+}
+
+export type SchedulerWriterMatchKind =
+  | "current-known"
+  | "declared"
+  | "materializer";
+
+export interface SchedulerResolvedWriterAddress {
+  space: string;
+  id: EntityId;
+  scope: CellScope;
+  scopeKey: string;
+  path: DocumentPath;
+}
+
+export interface SchedulerWriterMatch {
+  kind: SchedulerWriterMatchKind;
+  write: SchedulerResolvedWriterAddress;
+}
+
+export interface SchedulerWriterCandidate {
+  branch: BranchName;
+  ownerSpace?: string;
+  pieceId: string;
+  processGeneration: number;
+  actionId: string;
+  executionContextKey: SchedulerExecutionContextKey;
+  observationId: number;
+  commitSeq: number | null;
+  observedAtSeq: number;
+  actionKind: "computation" | "effect" | "event-handler";
+  implementationFingerprint: string;
+  runtimeFingerprint: string;
+  status: "success" | "failed";
+  errorFingerprint?: string;
+  directDirtySeq?: number;
+  staleSeq?: number;
+  unknownReason?: string;
+  matchedWrites: SchedulerWriterMatch[];
+}
+
+export interface SchedulerWritersForTargetsResult {
+  serverSeq: number;
+  writers: SchedulerWriterCandidate[];
+}
+
+export interface SchedulerWriterListRequest {
+  type: "scheduler.writer.list";
+  requestId: string;
+  space: string;
+  sessionId: SessionId;
+  query: SchedulerWritersForTargetsQuery;
+}
+
 export interface ResponseMessage<Result> {
   type: "response";
   requestId: string;
@@ -652,6 +718,7 @@ export type ClientMessage =
   | WatchSetRequest
   | WatchAddRequest
   | SchedulerSnapshotListRequest
+  | SchedulerWriterListRequest
   | SessionAckRequest;
 export type ServerMessage =
   | HelloOkMessage
@@ -725,6 +792,9 @@ export function resetSyncSchemaTableConfig(): void {
 export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
   modernCellRep: getModernCellRepConfig(),
   persistentSchedulerState: getPersistentSchedulerStateConfig(),
+  // Build-inherent capability: older servers omit it and clients fail open to
+  // piece-root discovery rather than sending an RPC the peer cannot parse.
+  schedulerWriterLookup: true,
   commitPreconditions: getCommitPreconditionsConfig(),
   syncSchemaTable: false,
   // A build-inherent capability, not configuration: this build's engine always
@@ -761,6 +831,14 @@ export const parseMemoryProtocolFlags = (
   if (
     persistentSchedulerState !== undefined &&
     typeof persistentSchedulerState !== "boolean"
+  ) {
+    return null;
+  }
+
+  const schedulerWriterLookup = value.schedulerWriterLookup;
+  if (
+    schedulerWriterLookup !== undefined &&
+    typeof schedulerWriterLookup !== "boolean"
   ) {
     return null;
   }
@@ -808,6 +886,7 @@ export const parseMemoryProtocolFlags = (
   return {
     modernCellRep: modernCellRep === true,
     persistentSchedulerState: persistentSchedulerState === true,
+    schedulerWriterLookup: schedulerWriterLookup === true,
     commitPreconditions: commitPreconditions === true,
     syncSchemaTable: syncSchemaTable === true,
     syncSchemaTableV2: syncSchemaTableV2 === true,
@@ -825,6 +904,7 @@ export const wireMemoryProtocolFlags = (
 ): WireMemoryProtocolFlags => ({
   modernCellRep: flags.modernCellRep,
   persistentSchedulerState: flags.persistentSchedulerState,
+  schedulerWriterLookup: flags.schedulerWriterLookup,
   commitPreconditions: flags.commitPreconditions,
   syncSchemaTable: flags.syncSchemaTable,
   syncSchemaTableV2: flags.syncSchemaTableV2,

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -14,6 +14,8 @@ import {
   type ResponseMessage,
   type SchedulerActionSnapshotQuery,
   type SchedulerSnapshotListResult,
+  type SchedulerWritersForTargetsQuery,
+  type SchedulerWritersForTargetsResult,
   type SessionEffectMessage,
   type SessionOpenAuthMetadata,
   type SessionOpenChallenge,
@@ -598,6 +600,28 @@ export class SpaceSession {
     }
     const result = await this.client.request<SchedulerSnapshotListResult>({
       type: "scheduler.snapshot.list",
+      requestId: crypto.randomUUID(),
+      space: this.space,
+      sessionId: this.#sessionId,
+      query,
+    });
+
+    this.noteResult(result.serverSeq);
+    return result;
+  }
+
+  async writersForTargets(
+    query: SchedulerWritersForTargetsQuery,
+  ): Promise<SchedulerWritersForTargetsResult> {
+    this.#assertOpen();
+    if (
+      !getPersistentSchedulerStateConfig() ||
+      this.client.serverFlags?.schedulerWriterLookup !== true
+    ) {
+      return { serverSeq: this.#serverSeq, writers: [] };
+    }
+    const result = await this.client.request<SchedulerWritersForTargetsResult>({
+      type: "scheduler.writer.list",
       requestId: crypto.randomUUID(),
       space: this.space,
       sessionId: this.#sessionId,

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -174,6 +174,26 @@ export class Client {
 
   async request<Result>(message: Record<string, unknown>): Promise<Result> {
     await this.ensureConnected();
+    return await this.requestConnected(message);
+  }
+
+  /**
+   * Dispatch only when the active connection advertises the capability.
+   * Checking after ensureConnected keeps a reconnect from carrying a cached
+   * capable-server decision onto an older peer.
+   */
+  async requestIfServerSupports<Result>(
+    capability: keyof MemoryProtocolFlags,
+    message: Record<string, unknown>,
+  ): Promise<Result | undefined> {
+    await this.ensureConnected();
+    if (this.#serverFlags?.[capability] !== true) return undefined;
+    return await this.requestConnected(message);
+  }
+
+  private async requestConnected<Result>(
+    message: Record<string, unknown>,
+  ): Promise<Result> {
     const requestId = message.requestId as string;
     const pending = Promise.withResolvers<unknown>();
     this.#pending.set(requestId, pending);
@@ -614,19 +634,23 @@ export class SpaceSession {
     query: SchedulerWritersForTargetsQuery,
   ): Promise<SchedulerWritersForTargetsResult> {
     this.#assertOpen();
-    if (
-      !getPersistentSchedulerStateConfig() ||
-      this.client.serverFlags?.schedulerWriterLookup !== true
-    ) {
+    if (!getPersistentSchedulerStateConfig()) {
       return { serverSeq: this.#serverSeq, writers: [] };
     }
-    const result = await this.client.request<SchedulerWritersForTargetsResult>({
-      type: "scheduler.writer.list",
-      requestId: crypto.randomUUID(),
-      space: this.space,
-      sessionId: this.#sessionId,
-      query,
-    });
+    const result = await this.client
+      .requestIfServerSupports<SchedulerWritersForTargetsResult>(
+        "schedulerWriterLookup",
+        {
+          type: "scheduler.writer.list",
+          requestId: crypto.randomUUID(),
+          space: this.space,
+          sessionId: this.#sessionId,
+          query,
+        },
+      );
+    if (result === undefined) {
+      return { serverSeq: this.#serverSeq, writers: [] };
+    }
 
     this.noteResult(result.serverSeq);
     return result;

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -3041,13 +3041,7 @@ export const writersForTargets = (
         AND o.piece_id = s.piece_id
         AND o.process_generation = s.process_generation
         AND o.action_id = s.action_id
-        AND o.observed_at_seq = s.observed_at_seq
         AND o.payload = s.payload
-        AND (
-          o.commit_seq = s.commit_seq
-          OR o.commit_seq IS NULL
-          OR s.commit_seq IS NULL
-        )
       JOIN scheduler_action_state a
         ON a.branch = w.branch
         AND a.owner_space = w.owner_space

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -3088,9 +3088,17 @@ export const writersForTargets = (
       }
       if (
         observation === undefined ||
+        observation.branch !== row.branch ||
+        normalizeSchedulerOwnerSpace(observation.ownerSpace) !==
+          row.owner_space ||
         observation.pieceId !== row.piece_id ||
         observation.processGeneration !== row.process_generation ||
-        observation.actionId !== row.action_id
+        observation.actionId !== row.action_id ||
+        !schedulerObservationContainsIndexedWrite(
+          observation,
+          row,
+          writePath,
+        )
       ) {
         continue;
       }
@@ -4160,6 +4168,74 @@ function isSchedulerWriteIndexKind(
 ): value is SchedulerWriteIndexKind {
   return value === "current-known" || value === "declared" ||
     value === "materializer";
+}
+
+function schedulerObservationContainsIndexedWrite(
+  observation: SchedulerActionObservation,
+  row: SchedulerWriterLookupRow,
+  writePath: readonly string[],
+): boolean {
+  const writes = row.write_kind === "current-known"
+    ? observation.currentKnownWrites
+    : row.write_kind === "declared"
+    ? observation.declaredWrites ?? []
+    : row.write_kind === "materializer"
+    ? observation.materializerWriteEnvelopes
+    : [];
+
+  return writes.some((write) => {
+    const scope = normalizeSchedulerScope(write.scope);
+    return write.space === row.write_space &&
+      write.id === row.write_id &&
+      scope === row.write_scope &&
+      schedulerScopeKeyForExecutionContext(
+          scope,
+          row.execution_context_key,
+        ) === row.write_scope_key &&
+      write.path.length === writePath.length &&
+      write.path.every((part, index) => part === writePath[index]);
+  });
+}
+
+function schedulerScopeKeyForExecutionContext(
+  scope: CellScope,
+  executionContextKey: SchedulerExecutionContextKey,
+): string | undefined {
+  const parts = executionContextKey.split(":");
+  let encodedPrincipal: string | undefined;
+  let contextScope: "space" | "user" | "session";
+  if (executionContextKey === "space") {
+    contextScope = "space";
+  } else if (parts.length === 2 && parts[0] === "user" && parts[1] !== "") {
+    contextScope = "user";
+    encodedPrincipal = parts[1];
+  } else if (
+    parts.length === 3 && parts[0] === "session" && parts[1] !== "" &&
+    parts[2] !== ""
+  ) {
+    contextScope = "session";
+    encodedPrincipal = parts[1];
+  } else {
+    return undefined;
+  }
+
+  try {
+    if (encodedPrincipal !== undefined) {
+      decodeURIComponent(encodedPrincipal);
+    }
+    if (contextScope === "session") decodeURIComponent(parts[2]);
+  } catch {
+    return undefined;
+  }
+
+  if (scope === "space") return DEFAULT_SCOPE_KEY;
+  if (scope === "user" && encodedPrincipal !== undefined) {
+    return `user:${encodedPrincipal}`;
+  }
+  if (scope === "session" && contextScope === "session") {
+    return executionContextKey;
+  }
+  return undefined;
 }
 
 function selectSchedulerSnapshotRow(

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -3018,7 +3018,7 @@ export const writersForTargets = (
         w.action_id,
         w.execution_context_key,
         w.observation_id,
-        s.commit_seq,
+        COALESCE(s.commit_seq, o.commit_seq) AS commit_seq,
         s.observed_at_seq,
         s.payload,
         a.direct_dirty_seq,
@@ -3033,6 +3033,9 @@ export const writersForTargets = (
         AND s.action_id = w.action_id
         AND s.execution_context_key = w.execution_context_key
         AND s.observation_id = w.observation_id
+      JOIN scheduler_observation o
+        ON o.observation_id = s.observation_id
+        AND o.execution_context_key = s.execution_context_key
       JOIN scheduler_action_state a
         ON a.branch = w.branch
         AND a.owner_space = w.owner_space

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -1080,6 +1080,7 @@ export interface SchedulerWriterCandidate {
   implementationFingerprint: string;
   runtimeFingerprint: string;
   status: SchedulerActionObservation["status"];
+  errorFingerprint?: string;
   directDirtySeq?: number;
   staleSeq?: number;
   unknownReason?: string;
@@ -3061,7 +3062,12 @@ export const writersForTargets = (
 
     for (const row of rows) {
       if (!isSchedulerWriteIndexKind(row.write_kind)) continue;
-      const writePath = decodeSchedulerPath(row.write_path);
+      let writePath: string[];
+      try {
+        writePath = decodeSchedulerPath(row.write_path);
+      } catch {
+        continue;
+      }
       if (!schedulerPathsOverlap(writePath, target.path, false)) continue;
 
       let observation: SchedulerActionObservation | undefined;
@@ -3112,6 +3118,9 @@ export const writersForTargets = (
             implementationFingerprint: observation.implementationFingerprint,
             runtimeFingerprint: observation.runtimeFingerprint,
             status: observation.status,
+            ...(observation.errorFingerprint !== undefined
+              ? { errorFingerprint: observation.errorFingerprint }
+              : {}),
             ...(row.direct_dirty_seq !== null
               ? { directDirtySeq: row.direct_dirty_seq }
               : {}),
@@ -4984,10 +4993,13 @@ function encodeSchedulerPath(path: readonly string[]): string {
 
 function decodeSchedulerPath(payload: string): string[] {
   const path = decodeMemoryBoundary(payload);
-  if (!Array.isArray(path)) {
-    throw new Error("scheduler paths must be arrays");
+  if (
+    !Array.isArray(path) ||
+    !path.every((part): part is string => typeof part === "string")
+  ) {
+    throw new Error("scheduler paths must be arrays of strings");
   }
-  return path.map((part) => String(part));
+  return path;
 }
 
 function schedulerPathsOverlap(

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -1,5 +1,6 @@
 import { Database } from "@db/sqlite";
 import type { FabricValue } from "@commonfabric/api";
+import { utf8Compare } from "@commonfabric/utils/utf8";
 import { applySqliteCommitWrite } from "./sqlite/commit-eval.ts";
 import {
   applyPatch,
@@ -5145,7 +5146,7 @@ function schedulerMatchedWriteKey(match: SchedulerMatchedWrite): string {
 }
 
 function compareSchedulerKeys(left: string, right: string): number {
-  return left < right ? -1 : left > right ? 1 : 0;
+  return utf8Compare(left, right);
 }
 
 const applyCommitTransaction = (

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -244,6 +244,8 @@ CREATE TABLE IF NOT EXISTS scheduler_write_index (
   FOREIGN KEY (observation_id, execution_context_key)
     REFERENCES scheduler_observation(observation_id, execution_context_key)
 );
+CREATE INDEX IF NOT EXISTS idx_scheduler_write_index_lookup
+  ON scheduler_write_index (branch, write_space, write_id, write_scope_key);
 CREATE INDEX IF NOT EXISTS idx_scheduler_write_index_action
   ON scheduler_write_index (
     branch,
@@ -1050,6 +1052,40 @@ export interface SchedulerReaderIndexEntry {
   read: ResolvedSchedulerObservationAddress;
 }
 
+export type SchedulerWriteIndexKind =
+  | "current-known"
+  | "declared"
+  | "materializer";
+
+export type SchedulerWriterTarget = SchedulerObservationAddress & {
+  scopeKey?: string;
+};
+
+export interface SchedulerMatchedWrite {
+  kind: SchedulerWriteIndexKind;
+  write: ResolvedSchedulerObservationAddress;
+}
+
+export interface SchedulerWriterCandidate {
+  branch: BranchName;
+  ownerSpace?: string;
+  pieceId: string;
+  processGeneration: number;
+  actionId: string;
+  executionContextKey: SchedulerExecutionContextKey;
+  observationId: number;
+  commitSeq: number | null;
+  observedAtSeq: number;
+  actionKind: SchedulerActionKind;
+  implementationFingerprint: string;
+  runtimeFingerprint: string;
+  status: SchedulerActionObservation["status"];
+  directDirtySeq?: number;
+  staleSeq?: number;
+  unknownReason?: string;
+  matchedWrites: SchedulerMatchedWrite[];
+}
+
 export interface SchedulerActionState {
   branch: BranchName;
   ownerSpace?: string;
@@ -1603,6 +1639,30 @@ CREATE INDEX idx_scheduler_write_index_action
     action_id,
     execution_context_key
   );
+`);
+};
+
+const migrateSchedulerWriteLookupIndex = (database: Database): void => {
+  if (
+    hasExactIndex(
+      database,
+      "scheduler_write_index",
+      "idx_scheduler_write_index_lookup",
+      ["branch", "write_space", "write_id", "write_scope_key"],
+      false,
+    )
+  ) {
+    return;
+  }
+
+  // This index is an additive target projection, not part of the scheduler
+  // execution-context table contract. Repair it independently so adding or
+  // correcting the index never triggers the conservative context-table
+  // rebuild used for ownership/schema migrations.
+  database.exec(`
+DROP INDEX IF EXISTS idx_scheduler_write_index_lookup;
+CREATE INDEX idx_scheduler_write_index_lookup
+  ON scheduler_write_index (branch, write_space, write_id, write_scope_key);
 `);
 };
 
@@ -2201,6 +2261,7 @@ export const open = async (
     migrateSchedulerObservationReplayStatus(database);
   }
   migrateSchedulerExecutionContextSchema(database);
+  migrateSchedulerWriteLookupIndex(database);
   migrateSchedulerActionIndexes(database);
   return {
     url,
@@ -2886,6 +2947,216 @@ export const findSchedulerReadersForWrite = (
     });
 };
 
+/**
+ * Returns every current durable action whose indexed write surface overlaps
+ * one of `targets`.
+ *
+ * Target scope keys are resolved by the authenticated caller before reaching
+ * this engine seam. `applicableExecutionContextKeys` is likewise
+ * server-derived; omitting it is reserved for trusted internal scans.
+ */
+export const writersForTargets = (
+  engine: Engine,
+  options: {
+    branch?: BranchName;
+    ownerSpace?: string;
+    targets: readonly SchedulerWriterTarget[];
+    applicableExecutionContextKeys?: readonly SchedulerExecutionContextKey[];
+  },
+): SchedulerWriterCandidate[] => {
+  if (options.targets.length === 0) return [];
+
+  const branch = options.branch ?? DEFAULT_BRANCH;
+  const applicableContextKeys = options.applicableExecutionContextKeys ===
+      undefined
+    ? undefined
+    : [...new Set(options.applicableExecutionContextKeys)];
+  if (applicableContextKeys?.length === 0) return [];
+
+  const contextFilter = applicableContextKeys === undefined
+    ? ""
+    : `AND w.execution_context_key IN (${
+      applicableContextKeys.map((_, index) => `:context_${index}`).join(", ")
+    })`;
+  const contextParams = Object.fromEntries(
+    applicableContextKeys?.map((key, index) => [`context_${index}`, key]) ?? [],
+  );
+  const candidates = new Map<
+    string,
+    {
+      candidate: Omit<SchedulerWriterCandidate, "matchedWrites">;
+      matchedWrites: Map<string, SchedulerMatchedWrite>;
+    }
+  >();
+
+  for (const requestedTarget of options.targets) {
+    const declaredScope = normalizeSchedulerScope(requestedTarget.scope);
+    if (
+      requestedTarget.scopeKey === undefined && declaredScope !== "space"
+    ) {
+      throw new ProtocolError(
+        "scoped scheduler writer targets require a resolved scope key",
+      );
+    }
+    const target: ResolvedSchedulerObservationAddress = {
+      ...normalizeSchedulerAddress(requestedTarget),
+      scopeKey: requestedTarget.scopeKey ?? DEFAULT_SCOPE_KEY,
+    };
+    const rows = engine.database.prepare(`
+      SELECT
+        w.branch,
+        w.owner_space,
+        w.write_space,
+        w.write_id,
+        w.write_scope,
+        w.write_scope_key,
+        w.write_path,
+        w.write_kind,
+        w.piece_id,
+        w.process_generation,
+        w.action_id,
+        w.execution_context_key,
+        w.observation_id,
+        s.commit_seq,
+        s.observed_at_seq,
+        s.payload,
+        a.direct_dirty_seq,
+        a.stale_seq,
+        a.unknown_reason
+      FROM scheduler_write_index w
+      JOIN scheduler_action_snapshot s
+        ON s.branch = w.branch
+        AND s.owner_space = w.owner_space
+        AND s.piece_id = w.piece_id
+        AND s.process_generation = w.process_generation
+        AND s.action_id = w.action_id
+        AND s.execution_context_key = w.execution_context_key
+        AND s.observation_id = w.observation_id
+      JOIN scheduler_action_state a
+        ON a.branch = w.branch
+        AND a.owner_space = w.owner_space
+        AND a.piece_id = w.piece_id
+        AND a.process_generation = w.process_generation
+        AND a.action_id = w.action_id
+        AND a.execution_context_key = w.execution_context_key
+        AND a.latest_observation_id = w.observation_id
+      WHERE w.branch = :branch
+        AND w.write_space = :write_space
+        AND w.write_id = :write_id
+        AND w.write_scope_key = :write_scope_key
+        AND w.write_scope = :write_scope
+        AND (:owner_space IS NULL OR w.owner_space = :owner_space)
+        ${contextFilter}
+    `).all({
+      branch,
+      write_space: target.space,
+      write_id: target.id,
+      write_scope_key: target.scopeKey,
+      write_scope: declaredScope,
+      owner_space: options.ownerSpace === undefined
+        ? null
+        : normalizeSchedulerOwnerSpace(options.ownerSpace),
+      ...contextParams,
+    }) as SchedulerWriterLookupRow[];
+
+    for (const row of rows) {
+      if (!isSchedulerWriteIndexKind(row.write_kind)) continue;
+      const writePath = decodeSchedulerPath(row.write_path);
+      if (!schedulerPathsOverlap(writePath, target.path, false)) continue;
+
+      let observation: SchedulerActionObservation | undefined;
+      try {
+        observation = schedulerObservationFromValue(
+          decodeSchedulerSnapshotObservation(
+            row.payload,
+            row.observed_at_seq,
+          ),
+        );
+      } catch {
+        // Indexes are projections, never ground truth. A corrupt snapshot row
+        // is an index miss so callers can fail open to piece instantiation.
+        continue;
+      }
+      if (
+        observation === undefined ||
+        observation.pieceId !== row.piece_id ||
+        observation.processGeneration !== row.process_generation ||
+        observation.actionId !== row.action_id
+      ) {
+        continue;
+      }
+
+      const ownerSpace = denormalizeSchedulerOwnerSpace(row.owner_space);
+      const candidateKey = schedulerWriterCandidateKey({
+        branch: row.branch,
+        ownerSpace,
+        pieceId: row.piece_id,
+        processGeneration: row.process_generation,
+        actionId: row.action_id,
+        executionContextKey: row.execution_context_key,
+      });
+      let accumulated = candidates.get(candidateKey);
+      if (!accumulated) {
+        accumulated = {
+          candidate: {
+            branch: row.branch,
+            ...(ownerSpace !== undefined ? { ownerSpace } : {}),
+            pieceId: row.piece_id,
+            processGeneration: row.process_generation,
+            actionId: row.action_id,
+            executionContextKey: row.execution_context_key,
+            observationId: row.observation_id,
+            commitSeq: row.commit_seq,
+            observedAtSeq: row.observed_at_seq,
+            actionKind: observation.actionKind,
+            implementationFingerprint: observation.implementationFingerprint,
+            runtimeFingerprint: observation.runtimeFingerprint,
+            status: observation.status,
+            ...(row.direct_dirty_seq !== null
+              ? { directDirtySeq: row.direct_dirty_seq }
+              : {}),
+            ...(row.stale_seq !== null ? { staleSeq: row.stale_seq } : {}),
+            ...(row.unknown_reason !== null
+              ? { unknownReason: row.unknown_reason }
+              : {}),
+          },
+          matchedWrites: new Map(),
+        };
+        candidates.set(candidateKey, accumulated);
+      }
+
+      const match: SchedulerMatchedWrite = {
+        kind: row.write_kind,
+        write: {
+          space: row.write_space,
+          id: row.write_id,
+          scope: row.write_scope as CellScope,
+          scopeKey: row.write_scope_key,
+          path: writePath,
+        },
+      };
+      accumulated.matchedWrites.set(schedulerMatchedWriteKey(match), match);
+    }
+  }
+
+  return [...candidates.values()]
+    .map(({ candidate, matchedWrites }) => ({
+      ...candidate,
+      matchedWrites: [...matchedWrites.values()].sort((left, right) =>
+        compareSchedulerKeys(
+          schedulerMatchedWriteKey(left),
+          schedulerMatchedWriteKey(right),
+        )
+      ),
+    }))
+    .sort((left, right) =>
+      compareSchedulerKeys(
+        schedulerWriterCandidateKey(left),
+        schedulerWriterCandidateKey(right),
+      )
+    );
+};
+
 export const markSchedulerReadersDirtyForWrites = (
   engine: Engine,
   options: {
@@ -3238,6 +3509,15 @@ type SchedulerWriteIndexRow = {
   action_id: string;
   execution_context_key: SchedulerExecutionContextKey;
   observation_id: number;
+};
+
+type SchedulerWriterLookupRow = SchedulerWriteIndexRow & {
+  commit_seq: number | null;
+  observed_at_seq: number;
+  payload: string;
+  direct_dirty_seq: number | null;
+  stale_seq: number | null;
+  unknown_reason: string | null;
 };
 
 type SchedulerSnapshotRow = {
@@ -3861,6 +4141,13 @@ function invalidateSchedulerExecutionContexts(
 
 function normalizeSchedulerScope(scope: CellScope | undefined): CellScope {
   return scope ?? DEFAULT_SCOPE;
+}
+
+function isSchedulerWriteIndexKind(
+  value: string,
+): value is SchedulerWriteIndexKind {
+  return value === "current-known" || value === "declared" ||
+    value === "materializer";
 }
 
 function selectSchedulerSnapshotRow(
@@ -4736,6 +5023,38 @@ function schedulerActionKey(entry: {
   return `${entry.branch}\0${
     normalizeSchedulerOwnerSpace(entry.ownerSpace)
   }\0${entry.pieceId}\0${entry.processGeneration}\0${entry.actionId}\0${entry.executionContextKey}`;
+}
+
+function schedulerWriterCandidateKey(entry: {
+  branch: BranchName;
+  ownerSpace?: string | null;
+  pieceId: string;
+  processGeneration: number;
+  actionId: string;
+  executionContextKey: SchedulerExecutionContextKey;
+}): string {
+  return [
+    entry.branch,
+    normalizeSchedulerOwnerSpace(entry.ownerSpace),
+    entry.pieceId,
+    String(entry.processGeneration),
+    entry.actionId,
+    entry.executionContextKey,
+  ].join("\0");
+}
+
+function schedulerMatchedWriteKey(match: SchedulerMatchedWrite): string {
+  return [
+    match.kind,
+    match.write.space,
+    match.write.scopeKey,
+    match.write.id,
+    encodeSchedulerPath(match.write.path),
+  ].join("\0");
+}
+
+function compareSchedulerKeys(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 
 const applyCommitTransaction = (

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -3037,6 +3037,17 @@ export const writersForTargets = (
       JOIN scheduler_observation o
         ON o.observation_id = s.observation_id
         AND o.execution_context_key = s.execution_context_key
+        AND o.branch = s.branch
+        AND o.piece_id = s.piece_id
+        AND o.process_generation = s.process_generation
+        AND o.action_id = s.action_id
+        AND o.observed_at_seq = s.observed_at_seq
+        AND o.payload = s.payload
+        AND (
+          o.commit_seq = s.commit_seq
+          OR o.commit_seq IS NULL
+          OR s.commit_seq IS NULL
+        )
       JOIN scheduler_action_state a
         ON a.branch = w.branch
         AND a.owner_space = w.owner_space

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -21,6 +21,9 @@ import {
   type SchedulerExecutionContextKey,
   type SchedulerSnapshotListRequest,
   type SchedulerSnapshotListResult,
+  type SchedulerWriterListRequest,
+  type SchedulerWritersForTargetsQuery,
+  type SchedulerWritersForTargetsResult,
   type ServerMessage,
   type SessionAckRequest,
   type SessionAckResult,
@@ -38,6 +41,7 @@ import {
   type SqliteRegisterDiskSourceRequest,
   type SqliteRegisterDiskSourceResult,
   type SqliteResultColumn,
+  toDocumentPath,
   type TransactRequest,
   type V2Error,
   type WatchAddRequest,
@@ -741,6 +745,26 @@ class Connection {
           const response = await this.server.listSchedulerActionSnapshots(
             parsed,
           );
+          this.sendSessionResponse(
+            parsed.space,
+            parsed.sessionId,
+            parsed.requestId,
+            response,
+          );
+        }
+        return;
+      case "scheduler.writer.list":
+        if (
+          !this.requireSession(
+            parsed.requestId,
+            parsed.space,
+            parsed.sessionId,
+          )
+        ) {
+          return;
+        }
+        {
+          const response = await this.server.writersForTargets(parsed);
           this.sendSessionResponse(
             parsed.space,
             parsed.sessionId,
@@ -2320,6 +2344,97 @@ export class Server {
     }
   }
 
+  async writersForTargets(
+    message: SchedulerWriterListRequest,
+  ): Promise<ResponseMessage<SchedulerWritersForTargetsResult>> {
+    const session = this.#sessions.get(message.space, message.sessionId);
+    if (session === null) {
+      return respondTypedError<SchedulerWritersForTargetsResult>(
+        message.requestId,
+        toError("SessionError", "Unknown session for space"),
+      );
+    }
+
+    try {
+      const engine = await this.openEngine(message.space);
+      const deny = this.#authorizeCurrentSessionWithEngine(
+        engine,
+        message.space,
+        message.sessionId,
+        session,
+        "READ",
+      );
+      if (deny) {
+        return respondTypedError<SchedulerWritersForTargetsResult>(
+          message.requestId,
+          deny,
+        );
+      }
+
+      if (!getPersistentSchedulerStateConfig()) {
+        return {
+          type: "response",
+          requestId: message.requestId,
+          ok: {
+            serverSeq: Engine.serverSeq(engine),
+            writers: [],
+          },
+        };
+      }
+
+      const targets: Engine.SchedulerWriterTarget[] = message.query.targets.map(
+        (target) => ({
+          space: message.space,
+          id: target.id,
+          scope: target.scope,
+          scopeKey: Engine.resolveScopeKey(target.scope, {
+            principal: session.principal,
+            sessionId: message.sessionId,
+          }),
+          path: [...target.path],
+        }),
+      );
+      const writers: SchedulerWritersForTargetsResult["writers"] = Engine
+        .writersForTargets(engine, {
+          branch: message.query.branch,
+          ownerSpace: message.space,
+          targets,
+          applicableExecutionContextKeys: schedulerApplicableContextKeys(
+            session.principal,
+            message.sessionId,
+          ),
+        }).map((writer) => ({
+          ...writer,
+          matchedWrites: writer.matchedWrites.map((match) => ({
+            kind: match.kind,
+            write: {
+              space: match.write.space,
+              id: match.write.id,
+              scope: match.write.scope ?? "space",
+              scopeKey: match.write.scopeKey,
+              path: toDocumentPath(match.write.path),
+            },
+          })),
+        }));
+      return {
+        type: "response",
+        requestId: message.requestId,
+        ok: {
+          serverSeq: Engine.serverSeq(engine),
+          writers,
+        },
+      };
+    } catch (error) {
+      return respondTypedError<SchedulerWritersForTargetsResult>(
+        message.requestId,
+        toError(
+          "QueryError",
+          error instanceof Error ? error.message : String(error),
+        ),
+      );
+    }
+  }
+
   async watchSet(
     message: WatchSetRequest,
   ): Promise<ResponseMessage<WatchSetResult>> {
@@ -3457,6 +3572,48 @@ const parseSchedulerSnapshotQuery = (
   };
 };
 
+const parseSchedulerWritersForTargetsQuery = (
+  value: Record<string, unknown>,
+): SchedulerWritersForTargetsQuery | undefined => {
+  if (
+    Object.keys(value).some((key) => key !== "branch" && key !== "targets") ||
+    (value.branch !== undefined && typeof value.branch !== "string") ||
+    !Array.isArray(value.targets)
+  ) {
+    return undefined;
+  }
+
+  const targets: SchedulerWritersForTargetsQuery["targets"] = [];
+  for (const target of value.targets) {
+    if (
+      !isRecord(target) ||
+      Object.keys(target).some((key) =>
+        key !== "id" && key !== "scope" && key !== "path"
+      ) ||
+      typeof target.id !== "string" ||
+      target.id.length === 0 ||
+      (target.scope !== undefined && target.scope !== "space" &&
+        target.scope !== "user" && target.scope !== "session") ||
+      !Array.isArray(target.path) ||
+      !target.path.every((part) => typeof part === "string")
+    ) {
+      return undefined;
+    }
+    targets.push({
+      id: target.id,
+      ...(target.scope !== undefined
+        ? { scope: target.scope as CellScope }
+        : {}),
+      path: toDocumentPath(target.path),
+    });
+  }
+
+  return {
+    ...(value.branch !== undefined ? { branch: value.branch as string } : {}),
+    targets,
+  };
+};
+
 export const parseClientMessage = (
   payload: string,
 ): ClientMessage | null => {
@@ -3643,6 +3800,24 @@ export const parseClientMessage = (
     if (query === undefined) return null;
     return {
       type: "scheduler.snapshot.list",
+      requestId: parsed.requestId,
+      space: parsed.space,
+      sessionId: parsed.sessionId,
+      query,
+    };
+  }
+
+  if (
+    parsed.type === "scheduler.writer.list" &&
+    typeof parsed.requestId === "string" &&
+    typeof parsed.space === "string" &&
+    typeof parsed.sessionId === "string" &&
+    isRecord(parsed.query)
+  ) {
+    const query = parseSchedulerWritersForTargetsQuery(parsed.query);
+    if (query === undefined) return null;
+    return {
+      type: "scheduler.writer.list",
       requestId: parsed.requestId,
       space: parsed.space,
       sessionId: parsed.sessionId,

--- a/packages/runner/src/scheduler/facade.ts
+++ b/packages/runner/src/scheduler/facade.ts
@@ -12,6 +12,7 @@ import type {
   ChangeGroup,
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
+  IStorageProviderWithReplica,
   IStorageSubscription,
   MemorySpace,
   StorageNotification,
@@ -157,6 +158,11 @@ import type {
 } from "./types.ts";
 import { ensureNotRenderThread } from "@commonfabric/utils/env";
 import { entityKey } from "./keys.ts";
+import {
+  type SchedulerDurableWriterProvider,
+  type SchedulerWriterCandidate,
+  schedulerWritersForTargets,
+} from "./writer-lookup.ts";
 
 ensureNotRenderThread();
 
@@ -362,6 +368,11 @@ function observationAdoptionAddresses(
 
 // Re-export types that tests expect from scheduler
 export type { ErrorWithContext };
+export type {
+  LiveSchedulerMatchedWrite,
+  LiveSchedulerWriterEvidence,
+  SchedulerWriterCandidate,
+} from "./writer-lookup.ts";
 export type {
   Action,
   ActionRunTraceAddress,
@@ -615,6 +626,30 @@ export class Scheduler {
         this._running = undefined;
       });
     }
+  }
+
+  /**
+   * Find every live or durable scheduler action whose registered write surface
+   * overlaps one of the requested targets. Durable lookup is optional and
+   * fail-open; live actions remain discoverable before their first run.
+   */
+  async writersForTargets(
+    branch: string,
+    space: MemorySpace,
+    targets: readonly IMemorySpaceAddress[],
+  ): Promise<SchedulerWriterCandidate[]> {
+    const provider = this.runtime.storageManager.open(
+      space,
+    ) as IStorageProviderWithReplica & SchedulerDurableWriterProvider;
+    return await schedulerWritersForTargets(
+      {
+        nodes: this.nodes,
+        writeIndex: this.writeIndex,
+        materializers: this.materializers,
+        getActionId: (action) => this.getActionId(action),
+      },
+      { branch, space, targets, provider },
+    );
   }
 
   /**

--- a/packages/runner/src/scheduler/writer-lookup.ts
+++ b/packages/runner/src/scheduler/writer-lookup.ts
@@ -1,6 +1,7 @@
 import type {
   SchedulerWriterCandidate as DurableSchedulerWriterCandidate,
 } from "@commonfabric/memory/v2";
+import { utf8Compare } from "@commonfabric/utils/utf8";
 import { arraysOverlap } from "../reactive-dependencies.ts";
 import { normalizeCellScope } from "../scope.ts";
 import type {
@@ -322,5 +323,5 @@ function cloneAddress(address: IMemorySpaceAddress): IMemorySpaceAddress {
 }
 
 function compareKeys(left: string, right: string): number {
-  return left < right ? -1 : left > right ? 1 : 0;
+  return utf8Compare(left, right);
 }

--- a/packages/runner/src/scheduler/writer-lookup.ts
+++ b/packages/runner/src/scheduler/writer-lookup.ts
@@ -1,0 +1,326 @@
+import type {
+  SchedulerWriterCandidate as DurableSchedulerWriterCandidate,
+} from "@commonfabric/memory/v2";
+import { arraysOverlap } from "../reactive-dependencies.ts";
+import { normalizeCellScope } from "../scope.ts";
+import type {
+  IMemorySpaceAddress,
+  IStorageProviderWithReplica,
+  MemorySpace,
+} from "../storage/interface.ts";
+import { getSchedulerActionTelemetryInfo } from "./diagnostics.ts";
+import { entityKey } from "./keys.ts";
+import type { SchedulerMaterializers } from "./materializers.ts";
+import type { NodeRegistry, NodeStatus } from "./node-record.ts";
+import type { SchedulerActionKind } from "./persistent-observation.ts";
+import {
+  schedulerImplementationFingerprint,
+  schedulerRuntimeFingerprint,
+} from "./run.ts";
+import type { SchedulerWriteIndex } from "./scheduling-writes.ts";
+import type { Action, TelemetryAnnotations } from "./types.ts";
+
+export type LiveSchedulerMatchedWrite = {
+  kind: "current-known" | "materializer";
+  write: IMemorySpaceAddress;
+};
+
+export interface LiveSchedulerWriterEvidence {
+  action: Action;
+  status: NodeStatus;
+  registrationOrdinal: number;
+  matchedWrites: LiveSchedulerMatchedWrite[];
+}
+
+export interface SchedulerWriterCandidate {
+  branch: string;
+  ownerSpace?: string;
+  pieceId: string;
+  processGeneration: number;
+  actionId: string;
+  actionKind: SchedulerActionKind;
+  implementationFingerprint: string;
+  runtimeFingerprint: string;
+  source: "live" | "durable" | "live+durable";
+  live?: LiveSchedulerWriterEvidence;
+  durable?: DurableSchedulerWriterCandidate;
+}
+
+export type SchedulerDurableWriterProvider = Pick<
+  IStorageProviderWithReplica,
+  "writersForTargets"
+>;
+
+export interface SchedulerWriterLookupState {
+  nodes: NodeRegistry;
+  writeIndex: SchedulerWriteIndex;
+  materializers: SchedulerMaterializers;
+  getActionId(action: Action): string;
+}
+
+type LiveSchedulerWriterCandidate =
+  & Omit<
+    SchedulerWriterCandidate,
+    "source" | "durable"
+  >
+  & { live: LiveSchedulerWriterEvidence };
+
+type LiveCandidateAccumulator = {
+  action: Action;
+  matchedWrites: Map<string, LiveSchedulerMatchedWrite>;
+};
+
+export async function schedulerWritersForTargets(
+  state: SchedulerWriterLookupState,
+  options: {
+    branch: string;
+    space: MemorySpace;
+    targets: readonly IMemorySpaceAddress[];
+    provider?: SchedulerDurableWriterProvider;
+  },
+): Promise<SchedulerWriterCandidate[]> {
+  if (options.targets.some((target) => target.space !== options.space)) {
+    return [];
+  }
+  const targets = options.targets;
+  const live = collectLiveSchedulerWriters(state, {
+    branch: options.branch,
+    targets,
+  });
+  let durable: DurableSchedulerWriterCandidate[] = [];
+  const lookup = options.provider?.writersForTargets;
+  if (lookup && targets.length > 0) {
+    try {
+      const result = await lookup.call(options.provider, {
+        branch: options.branch,
+        targets,
+      });
+      durable = result.writers;
+    } catch {
+      // Durable lookup is an index optimization. Missing capability, stale
+      // server, or a transient query failure must preserve the live/fail-open
+      // discovery path.
+    }
+  }
+  return mergeSchedulerWriterCandidates(live, durable);
+}
+
+function collectLiveSchedulerWriters(
+  state: SchedulerWriterLookupState,
+  options: {
+    branch: string;
+    targets: readonly IMemorySpaceAddress[];
+  },
+): LiveSchedulerWriterCandidate[] {
+  const accumulators = new Map<Action, LiveCandidateAccumulator>();
+  const addMatches = (
+    target: IMemorySpaceAddress,
+    actions: ReadonlySet<Action> | undefined,
+    kind: LiveSchedulerMatchedWrite["kind"],
+    writesForAction: (
+      action: Action,
+    ) => readonly IMemorySpaceAddress[] | undefined,
+  ) => {
+    if (!actions) return;
+    const targetEntity = entityKey(target);
+    for (const action of actions) {
+      const record = state.nodes.get(action);
+      if (!record || record.kind === "effect") continue;
+      const identity = (action as Partial<TelemetryAnnotations>)
+        .schedulerObservationIdentity;
+      if (
+        identity?.ownerSpace !== target.space ||
+        (identity.branch ?? "") !== options.branch
+      ) {
+        continue;
+      }
+      for (const write of writesForAction(action) ?? []) {
+        if (
+          entityKey(write) !== targetEntity ||
+          !arraysOverlap(write.path, target.path)
+        ) {
+          continue;
+        }
+        let accumulator = accumulators.get(action);
+        if (!accumulator) {
+          accumulator = { action, matchedWrites: new Map() };
+          accumulators.set(action, accumulator);
+        }
+        const match: LiveSchedulerMatchedWrite = {
+          kind,
+          write: cloneAddress(write),
+        };
+        accumulator.matchedWrites.set(liveMatchedWriteKey(match), match);
+      }
+    }
+  };
+
+  for (const target of options.targets) {
+    const key = entityKey(target);
+    addMatches(
+      target,
+      state.writeIndex.writersByEntity.get(key),
+      "current-known",
+      (action) => state.writeIndex.getSchedulingWrites(action),
+    );
+    addMatches(
+      target,
+      state.materializers.materializersByEntity.get(key),
+      "materializer",
+      (action) => state.materializers.getMaterializerWriteEnvelopes(action),
+    );
+  }
+
+  const candidates: LiveSchedulerWriterCandidate[] = [];
+  for (const { action, matchedWrites } of accumulators.values()) {
+    const record = state.nodes.get(action);
+    const identity = (action as Partial<TelemetryAnnotations>)
+      .schedulerObservationIdentity;
+    if (!record || !identity?.ownerSpace) continue;
+    const actionId = state.getActionId(action);
+    candidates.push({
+      branch: identity.branch ?? "",
+      ownerSpace: identity.ownerSpace,
+      pieceId: identity.pieceId,
+      processGeneration: identity.processGeneration ?? 0,
+      actionId,
+      actionKind: record.kind,
+      implementationFingerprint: schedulerImplementationFingerprint(
+        action,
+        actionId,
+        getSchedulerActionTelemetryInfo(action),
+      ),
+      runtimeFingerprint: schedulerRuntimeFingerprint(),
+      live: {
+        action,
+        status: record.status,
+        registrationOrdinal: record.ordinal,
+        matchedWrites: [...matchedWrites.values()].sort(compareMatchedWrites),
+      },
+    });
+  }
+  return candidates;
+}
+
+function mergeSchedulerWriterCandidates(
+  live: readonly LiveSchedulerWriterCandidate[],
+  durable: readonly DurableSchedulerWriterCandidate[],
+): SchedulerWriterCandidate[] {
+  const liveByIdentity = new Map<string, LiveSchedulerWriterCandidate[]>();
+  for (const candidate of live) {
+    const key = schedulerWriterIdentityKey(candidate);
+    const candidates = liveByIdentity.get(key) ?? [];
+    candidates.push(candidate);
+    liveByIdentity.set(key, candidates);
+  }
+
+  const result: SchedulerWriterCandidate[] = [];
+  const mergedLive = new Set<LiveSchedulerWriterCandidate>();
+  for (const durableCandidate of durable) {
+    const exactLive = liveByIdentity.get(
+      schedulerWriterIdentityKey(durableCandidate),
+    ) ?? [];
+    if (exactLive.length === 0) {
+      result.push({
+        ...writerIdentityFromDurable(durableCandidate),
+        source: "durable",
+        durable: durableCandidate,
+      });
+      continue;
+    }
+    for (const liveCandidate of exactLive) {
+      mergedLive.add(liveCandidate);
+      result.push({
+        ...liveCandidate,
+        source: "live+durable",
+        durable: durableCandidate,
+      });
+    }
+  }
+  for (const liveCandidate of live) {
+    if (mergedLive.has(liveCandidate)) continue;
+    result.push({ ...liveCandidate, source: "live" });
+  }
+  return result.sort(compareWriterCandidates);
+}
+
+function writerIdentityFromDurable(
+  candidate: DurableSchedulerWriterCandidate,
+): Omit<SchedulerWriterCandidate, "source" | "live" | "durable"> {
+  return {
+    branch: candidate.branch,
+    ...(candidate.ownerSpace !== undefined
+      ? { ownerSpace: candidate.ownerSpace }
+      : {}),
+    pieceId: candidate.pieceId,
+    processGeneration: candidate.processGeneration,
+    actionId: candidate.actionId,
+    actionKind: candidate.actionKind,
+    implementationFingerprint: candidate.implementationFingerprint,
+    runtimeFingerprint: candidate.runtimeFingerprint,
+  };
+}
+
+function schedulerWriterIdentityKey(candidate: {
+  branch: string;
+  ownerSpace?: string;
+  pieceId: string;
+  processGeneration: number;
+  actionId: string;
+  actionKind: SchedulerActionKind;
+  implementationFingerprint: string;
+  runtimeFingerprint: string;
+}): string {
+  return [
+    candidate.branch,
+    candidate.ownerSpace ?? "",
+    candidate.pieceId,
+    String(candidate.processGeneration),
+    candidate.actionId,
+    candidate.actionKind,
+    candidate.implementationFingerprint,
+    candidate.runtimeFingerprint,
+  ].join("\0");
+}
+
+function compareWriterCandidates(
+  left: SchedulerWriterCandidate,
+  right: SchedulerWriterCandidate,
+): number {
+  const leftKey = [
+    schedulerWriterIdentityKey(left),
+    left.durable?.executionContextKey ?? "",
+    left.source,
+  ].join("\0");
+  const rightKey = [
+    schedulerWriterIdentityKey(right),
+    right.durable?.executionContextKey ?? "",
+    right.source,
+  ].join("\0");
+  return compareKeys(leftKey, rightKey);
+}
+
+function compareMatchedWrites(
+  left: LiveSchedulerMatchedWrite,
+  right: LiveSchedulerMatchedWrite,
+): number {
+  return compareKeys(liveMatchedWriteKey(left), liveMatchedWriteKey(right));
+}
+
+function liveMatchedWriteKey(match: LiveSchedulerMatchedWrite): string {
+  return [
+    match.kind,
+    match.write.space,
+    normalizeCellScope(match.write.scope),
+    match.write.id,
+    JSON.stringify(match.write.path),
+  ].join("\0");
+}
+
+function cloneAddress(address: IMemorySpaceAddress): IMemorySpaceAddress {
+  return { ...address, path: [...address.path] };
+}
+
+function compareKeys(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -5,12 +5,14 @@ import type {
   SchemaPathSelector,
 } from "@commonfabric/api";
 import type {
+  BranchName,
   CommitPrecondition,
   EntityDocument,
   PatchOp,
   SchedulerActionSnapshotQuery,
   SchedulerExecutionContextKey,
   SchedulerSnapshotListResult,
+  SchedulerWritersForTargetsResult,
   SqliteDbRef,
   SqliteOperation,
   SqliteParamsWire,
@@ -348,6 +350,11 @@ export interface IStorageProviderWithReplica extends IStorageProvider {
     query?: SchedulerActionSnapshotQuery,
   ): Promise<SchedulerSnapshotListResult>;
 
+  /** Authenticated durable writer-index lookup for this provider's space. */
+  writersForTargets?(
+    query: SchedulerWritersForTargetsProviderQuery,
+  ): Promise<SchedulerWritersForTargetsResult>;
+
   /**
    * Conservative scheduler-snapshot currency oracle. Returns true only when
    * every address belongs to this provider, has a confirmed local base, and
@@ -392,6 +399,11 @@ export interface IStorageProviderWithReplica extends IStorageProvider {
     id: string,
     path: string,
   ): Promise<SqliteRegisterDiskSourceResult>;
+}
+
+export interface SchedulerWritersForTargetsProviderQuery {
+  branch?: BranchName;
+  targets: readonly IMemorySpaceAddress[];
 }
 
 /**

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -29,6 +29,7 @@ import {
   type SchedulerActionSnapshotQuery,
   type SchedulerObservationCommit,
   type SchedulerSnapshotListResult,
+  type SchedulerWritersForTargetsResult,
   type SessionSync,
   type SqliteDbRef,
   type SqliteOperation,
@@ -79,6 +80,7 @@ import type {
   PullError,
   PushError,
   Result,
+  SchedulerWritersForTargetsProviderQuery,
   State,
   StorageNotification,
   StorageTransactionRejected,
@@ -1431,6 +1433,12 @@ class Provider implements IStorageProviderWithReplica {
     return this.replica.listSchedulerActionSnapshots(query);
   }
 
+  writersForTargets(
+    query: SchedulerWritersForTargetsProviderQuery,
+  ): Promise<SchedulerWritersForTargetsResult> {
+    return this.replica.writersForTargets(query);
+  }
+
   areSchedulerAddressesCurrentAtOrBelow(
     addresses: readonly IMemorySpaceAddress[],
     seq: number,
@@ -1700,6 +1708,29 @@ class SpaceReplica implements ISpaceReplica {
       return { serverSeq: 0, snapshots: [] };
     }
     return await session.listSchedulerActionSnapshots(query);
+  }
+
+  async writersForTargets(
+    query: SchedulerWritersForTargetsProviderQuery,
+  ): Promise<SchedulerWritersForTargetsResult> {
+    if (
+      !getPersistentSchedulerStateConfig() ||
+      query.targets.some((target) => target.space !== this.#space)
+    ) {
+      return { serverSeq: 0, writers: [] };
+    }
+    const { client, session } = await this.sessionHandle();
+    if (client.serverFlags?.schedulerWriterLookup !== true) {
+      return { serverSeq: 0, writers: [] };
+    }
+    return await session.writersForTargets({
+      ...(query.branch !== undefined ? { branch: query.branch } : {}),
+      targets: query.targets.map((target) => ({
+        id: target.id,
+        ...(target.scope !== undefined ? { scope: target.scope } : {}),
+        path: toDocumentPath([...target.path]),
+      })),
+    });
   }
 
   areSchedulerAddressesCurrentAtOrBelow(

--- a/packages/runner/test/scheduler-observation-capability-skew.test.ts
+++ b/packages/runner/test/scheduler-observation-capability-skew.test.ts
@@ -101,6 +101,7 @@ class FlagOffServerTransport implements MemoryV2Client.Transport {
           flags: {
             ...getMemoryProtocolFlags(),
             persistentSchedulerState: false,
+            schedulerWriterLookup: false,
           },
           sessionOpen: TEST_HELLO_SESSION_OPEN,
         });
@@ -215,6 +216,15 @@ type ReplicaSurface = {
     serverSeq: number;
     snapshots: unknown[];
   }>;
+  writersForTargets(query: {
+    branch?: string;
+    targets: Array<{
+      space: string;
+      id: URI;
+      scope?: "space" | "user" | "session";
+      path: string[];
+    }>;
+  }): Promise<{ serverSeq: number; writers: unknown[] }>;
 };
 
 const schedulerObservation = {
@@ -302,9 +312,19 @@ Deno.test("flag-ON client degrades observation traffic against a server that did
     // for a capability it never offered.
     const listed = await replica.listSchedulerActionSnapshots({});
     assertEquals(listed, { serverSeq: 0, snapshots: [] });
+    const writers = await replica.writersForTargets({
+      branch: "",
+      targets: [{
+        space,
+        id: DOC,
+        scope: "space",
+        path: ["value"],
+      }],
+    });
+    assertEquals(writers, { serverSeq: 0, writers: [] });
     assertEquals(
       transport.requestTypes.filter((type) =>
-        type === "scheduler.snapshot.list"
+        type === "scheduler.snapshot.list" || type === "scheduler.writer.list"
       ),
       [],
     );

--- a/packages/runner/test/scheduler-observations.test.ts
+++ b/packages/runner/test/scheduler-observations.test.ts
@@ -2319,6 +2319,22 @@ describe("persistent scheduler observations", () => {
       const sideWrite = materializer!.materializerWriteEnvelopes[0];
       expect(directOutput.id).not.toBe(sideWrite.id);
 
+      const provider = runtime.storageManager.open(space);
+      const durableWriters = await provider.writersForTargets?.({
+        branch: "",
+        targets: [
+          { ...directOutput, space },
+          { ...sideWrite, space },
+        ],
+      });
+      expect(durableWriters).toBeDefined();
+      expect(durableWriters?.writers).toHaveLength(1);
+      expect(durableWriters?.writers[0]?.actionId).toBe(materializer!.actionId);
+      expect(
+        durableWriters?.writers[0]?.matchedWrites.map((match) => match.kind),
+      )
+        .toEqual(["current-known", "materializer"]);
+
       type SchedulerIndexServer = {
         openEngine(space: string): Promise<{
           database: {

--- a/packages/runner/test/scheduler-writer-lookup.test.ts
+++ b/packages/runner/test/scheduler-writer-lookup.test.ts
@@ -1,7 +1,8 @@
-import type {
-  SchedulerMatchedWrite,
-  SchedulerWriterCandidate as DurableSchedulerWriterCandidate,
-} from "@commonfabric/memory/v2/engine";
+import {
+  type SchedulerWriterCandidate as DurableSchedulerWriterCandidate,
+  type SchedulerWriterMatch,
+  toDocumentPath,
+} from "@commonfabric/memory/v2";
 import type { NormalizedFullLink } from "../src/link-utils.ts";
 import type { NodeStatus } from "../src/scheduler/node-record.ts";
 import type { IMemorySpaceAddress } from "../src/storage/interface.ts";
@@ -120,13 +121,13 @@ function durableWriter(
   target: IMemorySpaceAddress,
   overrides: Partial<DurableSchedulerWriterCandidate> = {},
 ): DurableSchedulerWriterCandidate {
-  const matchedWrite: SchedulerMatchedWrite = {
+  const matchedWrite: SchedulerWriterMatch = {
     kind: "current-known",
     write: {
       ...target,
       scope: target.scope ?? "space",
       scopeKey: "space",
-      path: [...target.path],
+      path: toDocumentPath([...target.path]),
     },
   };
   return {
@@ -366,6 +367,38 @@ describe("scheduler writer lookup", () => {
         "writer-lookup:a-first",
         "writer-lookup:z-last",
       ]);
+    } finally {
+      await disposeSchedulerTestRuntime(env);
+    }
+  });
+
+  it("fails open for a mixed-space target set", async () => {
+    const env = createSchedulerTestRuntime(import.meta.url);
+    try {
+      stubDurableWriters(env.runtime, []);
+      const output = env.runtime.getCell<number>(
+        space,
+        "writer-lookup-mixed-space-output",
+        undefined,
+        env.tx,
+      );
+      const outputLink = output.getAsNormalizedFullLink();
+      registerIdentifiedWriter(
+        env.runtime,
+        createWriterAction("writer-lookup:mixed-space", {
+          writes: [outputLink],
+        }),
+      );
+
+      expect(
+        await writersForTargets(env.runtime, [
+          toMemorySpaceAddress(outputLink),
+          {
+            ...toMemorySpaceAddress(outputLink),
+            space: "did:key:other-space" as typeof space,
+          },
+        ]),
+      ).toEqual([]);
     } finally {
       await disposeSchedulerTestRuntime(env);
     }

--- a/packages/runner/test/scheduler-writer-lookup.test.ts
+++ b/packages/runner/test/scheduler-writer-lookup.test.ts
@@ -351,7 +351,12 @@ describe("scheduler writer lookup", () => {
       );
       const outputLink = output.getAsNormalizedFullLink();
       for (
-        const actionId of ["writer-lookup:z-last", "writer-lookup:a-first"]
+        const actionId of [
+          "writer-lookup:z-last",
+          "writer-lookup:\u{10000}",
+          "writer-lookup:a-first",
+          "writer-lookup:\uffff",
+        ]
       ) {
         registerIdentifiedWriter(
           env.runtime,
@@ -366,6 +371,8 @@ describe("scheduler writer lookup", () => {
       expect(candidates.map((candidate) => candidate.actionId)).toEqual([
         "writer-lookup:a-first",
         "writer-lookup:z-last",
+        "writer-lookup:\uffff",
+        "writer-lookup:\u{10000}",
       ]);
     } finally {
       await disposeSchedulerTestRuntime(env);

--- a/packages/runner/test/scheduler-writer-lookup.test.ts
+++ b/packages/runner/test/scheduler-writer-lookup.test.ts
@@ -1,0 +1,373 @@
+import type {
+  SchedulerMatchedWrite,
+  SchedulerWriterCandidate as DurableSchedulerWriterCandidate,
+} from "@commonfabric/memory/v2/engine";
+import type { NormalizedFullLink } from "../src/link-utils.ts";
+import type { NodeStatus } from "../src/scheduler/node-record.ts";
+import type { IMemorySpaceAddress } from "../src/storage/interface.ts";
+import {
+  type Action,
+  createSchedulerTestRuntime,
+  describe,
+  disposeSchedulerTestRuntime,
+  expect,
+  it,
+  type Runtime,
+  space,
+  toMemorySpaceAddress,
+} from "./scheduler-test-utils.ts";
+
+const BRANCH = "";
+const PIECE_ID = "space:of:scheduler-writer-lookup-piece";
+const PROCESS_GENERATION = 0;
+const RUNTIME_FINGERPRINT = "runner:scheduler:v3";
+
+type LiveSchedulerMatchedWrite = {
+  kind: "current-known" | "materializer";
+  write: IMemorySpaceAddress;
+};
+
+type IntendedSchedulerWriterCandidate = {
+  branch: string;
+  ownerSpace?: string;
+  pieceId: string;
+  processGeneration: number;
+  actionId: string;
+  actionKind: "computation" | "effect" | "event-handler";
+  implementationFingerprint: string;
+  runtimeFingerprint: string;
+  source: "live" | "durable" | "live+durable";
+  live?: {
+    action: Action;
+    status: NodeStatus;
+    registrationOrdinal: number;
+    matchedWrites: LiveSchedulerMatchedWrite[];
+  };
+  durable?: DurableSchedulerWriterCandidate;
+};
+
+type DurableWriterProvider = {
+  writersForTargets(query: {
+    branch?: string;
+    targets: readonly IMemorySpaceAddress[];
+  }): Promise<{
+    serverSeq: number;
+    writers: DurableSchedulerWriterCandidate[];
+  }>;
+};
+
+type WriterAction = Action & {
+  implementationHash: string;
+  writes?: NormalizedFullLink[];
+  materializerWriteEnvelopes?: NormalizedFullLink[];
+};
+
+function createWriterAction(
+  actionId: string,
+  options: {
+    writes?: NormalizedFullLink[];
+    materializerWriteEnvelopes?: NormalizedFullLink[];
+  } = {},
+): WriterAction {
+  const action = ((_tx) => undefined) as WriterAction;
+  // No schedulerInstanceKey: the implementation hash is also the exact stable
+  // action id in these focused fixtures.
+  action.implementationHash = actionId;
+  if (options.writes) action.writes = options.writes;
+  if (options.materializerWriteEnvelopes) {
+    action.materializerWriteEnvelopes = options.materializerWriteEnvelopes;
+  }
+  return action;
+}
+
+function registerIdentifiedWriter(
+  runtime: Runtime,
+  action: Action,
+  pieceId = PIECE_ID,
+): void {
+  runtime.scheduler.register(action, {
+    rehydrateFromStorage: {
+      space,
+      pieceId,
+      processGeneration: PROCESS_GENERATION,
+    },
+  });
+}
+
+function stubDurableWriters(
+  runtime: Runtime,
+  writers: DurableSchedulerWriterCandidate[],
+): void {
+  const provider = runtime.storageManager.open(
+    space,
+  ) as unknown as DurableWriterProvider;
+  provider.writersForTargets = () =>
+    Promise.resolve({
+      serverSeq: 0,
+      writers,
+    });
+}
+
+async function writersForTargets(
+  runtime: Runtime,
+  targets: readonly IMemorySpaceAddress[],
+): Promise<IntendedSchedulerWriterCandidate[]> {
+  return await runtime.scheduler.writersForTargets(BRANCH, space, targets);
+}
+
+function durableWriter(
+  actionId: string,
+  target: IMemorySpaceAddress,
+  overrides: Partial<DurableSchedulerWriterCandidate> = {},
+): DurableSchedulerWriterCandidate {
+  const matchedWrite: SchedulerMatchedWrite = {
+    kind: "current-known",
+    write: {
+      ...target,
+      scope: target.scope ?? "space",
+      scopeKey: "space",
+      path: [...target.path],
+    },
+  };
+  return {
+    branch: BRANCH,
+    ownerSpace: space,
+    pieceId: PIECE_ID,
+    processGeneration: PROCESS_GENERATION,
+    actionId,
+    executionContextKey: "space",
+    observationId: 1,
+    commitSeq: null,
+    observedAtSeq: 0,
+    actionKind: "computation",
+    implementationFingerprint: `impl:${actionId}`,
+    runtimeFingerprint: RUNTIME_FINGERPRINT,
+    status: "success",
+    matchedWrites: [matchedWrite],
+    ...overrides,
+  };
+}
+
+describe("scheduler writer lookup", () => {
+  it("returns a never-run writer from its live static surface", async () => {
+    const env = createSchedulerTestRuntime(import.meta.url);
+    try {
+      stubDurableWriters(env.runtime, []);
+      const output = env.runtime.getCell<number>(
+        space,
+        "writer-lookup-never-ran-output",
+        undefined,
+        env.tx,
+      );
+      const outputLink = output.getAsNormalizedFullLink();
+      const outputAddress = toMemorySpaceAddress(outputLink);
+      const actionId = "writer-lookup:never-ran";
+      const action = createWriterAction(actionId, { writes: [outputLink] });
+      registerIdentifiedWriter(env.runtime, action);
+
+      const candidates = await writersForTargets(env.runtime, [{
+        ...outputAddress,
+        path: [...outputAddress.path, "nested"],
+      }]);
+
+      expect(candidates).toHaveLength(1);
+      expect(candidates[0]).toMatchObject({
+        branch: BRANCH,
+        ownerSpace: space,
+        pieceId: PIECE_ID,
+        processGeneration: PROCESS_GENERATION,
+        actionId,
+        actionKind: "computation",
+        implementationFingerprint: `impl:${actionId}`,
+        runtimeFingerprint: RUNTIME_FINGERPRINT,
+        source: "live",
+        live: {
+          status: "never-ran",
+          matchedWrites: [{
+            kind: "current-known",
+            write: outputAddress,
+          }],
+        },
+      });
+      expect(candidates[0]?.live?.action).toBe(action);
+      expect(candidates[0]?.durable).toBeUndefined();
+    } finally {
+      await disposeSchedulerTestRuntime(env);
+    }
+  });
+
+  it("returns a live materializer for a target inside its envelope", async () => {
+    const env = createSchedulerTestRuntime(import.meta.url);
+    try {
+      stubDurableWriters(env.runtime, []);
+      const output = env.runtime.getCell<Record<string, unknown>>(
+        space,
+        "writer-lookup-materializer-output",
+        undefined,
+        env.tx,
+      );
+      const envelope = output.getAsNormalizedFullLink();
+      const envelopeAddress = toMemorySpaceAddress(envelope);
+      const action = createWriterAction("writer-lookup:materializer", {
+        materializerWriteEnvelopes: [envelope],
+      });
+      registerIdentifiedWriter(env.runtime, action);
+
+      const candidates = await writersForTargets(env.runtime, [{
+        ...envelopeAddress,
+        path: [...envelopeAddress.path, "items", "0"],
+      }]);
+
+      expect(candidates).toHaveLength(1);
+      expect(candidates[0]?.source).toBe("live");
+      expect(candidates[0]?.live?.action).toBe(action);
+      expect(candidates[0]?.live?.matchedWrites).toEqual([{
+        kind: "materializer",
+        write: envelopeAddress,
+      }]);
+    } finally {
+      await disposeSchedulerTestRuntime(env);
+    }
+  });
+
+  it("skips a live writer without durable piece identity", async () => {
+    const env = createSchedulerTestRuntime(import.meta.url);
+    try {
+      stubDurableWriters(env.runtime, []);
+      const output = env.runtime.getCell<number>(
+        space,
+        "writer-lookup-identityless-output",
+        undefined,
+        env.tx,
+      );
+      const outputLink = output.getAsNormalizedFullLink();
+      const action = createWriterAction("writer-lookup:identityless", {
+        writes: [outputLink],
+      });
+      env.runtime.scheduler.register(action);
+
+      expect(
+        await writersForTargets(env.runtime, [
+          toMemorySpaceAddress(outputLink),
+        ]),
+      ).toEqual([]);
+    } finally {
+      await disposeSchedulerTestRuntime(env);
+    }
+  });
+
+  it("merges an exact durable row with its live action without mixing statuses", async () => {
+    const env = createSchedulerTestRuntime(import.meta.url);
+    try {
+      const output = env.runtime.getCell<number>(
+        space,
+        "writer-lookup-merged-output",
+        undefined,
+        env.tx,
+      );
+      const outputLink = output.getAsNormalizedFullLink();
+      const outputAddress = toMemorySpaceAddress(outputLink);
+      const actionId = "writer-lookup:merged";
+      const durable = durableWriter(actionId, outputAddress, {
+        status: "failed",
+        errorFingerprint: "Error:previous failure",
+        directDirtySeq: 9,
+      });
+      stubDurableWriters(env.runtime, [durable]);
+      const action = createWriterAction(actionId, { writes: [outputLink] });
+      registerIdentifiedWriter(env.runtime, action);
+
+      const candidates = await writersForTargets(env.runtime, [outputAddress]);
+
+      expect(candidates).toHaveLength(1);
+      expect(candidates[0]).toMatchObject({
+        actionId,
+        source: "live+durable",
+        live: { status: "never-ran" },
+        durable: {
+          status: "failed",
+          errorFingerprint: "Error:previous failure",
+          directDirtySeq: 9,
+        },
+      });
+      expect(candidates[0]?.live?.action).toBe(action);
+    } finally {
+      await disposeSchedulerTestRuntime(env);
+    }
+  });
+
+  it("keeps a fingerprint-mismatched durable row separate from the live action", async () => {
+    const env = createSchedulerTestRuntime(import.meta.url);
+    try {
+      const output = env.runtime.getCell<number>(
+        space,
+        "writer-lookup-mismatch-output",
+        undefined,
+        env.tx,
+      );
+      const outputLink = output.getAsNormalizedFullLink();
+      const outputAddress = toMemorySpaceAddress(outputLink);
+      const actionId = "writer-lookup:mismatch";
+      stubDurableWriters(env.runtime, [durableWriter(
+        actionId,
+        outputAddress,
+        { implementationFingerprint: "impl:writer-lookup:previous" },
+      )]);
+      registerIdentifiedWriter(
+        env.runtime,
+        createWriterAction(actionId, { writes: [outputLink] }),
+      );
+
+      const candidates = await writersForTargets(env.runtime, [outputAddress]);
+
+      expect(candidates).toHaveLength(2);
+      expect(
+        candidates.map(({ source, implementationFingerprint }) => ({
+          source,
+          implementationFingerprint,
+        })).toSorted((left, right) => left.source.localeCompare(right.source)),
+      ).toEqual([{
+        source: "durable",
+        implementationFingerprint: "impl:writer-lookup:previous",
+      }, {
+        source: "live",
+        implementationFingerprint: `impl:${actionId}`,
+      }]);
+    } finally {
+      await disposeSchedulerTestRuntime(env);
+    }
+  });
+
+  it("orders multiple live candidates by stable identity", async () => {
+    const env = createSchedulerTestRuntime(import.meta.url);
+    try {
+      stubDurableWriters(env.runtime, []);
+      const output = env.runtime.getCell<number>(
+        space,
+        "writer-lookup-shared-output",
+        undefined,
+        env.tx,
+      );
+      const outputLink = output.getAsNormalizedFullLink();
+      for (
+        const actionId of ["writer-lookup:z-last", "writer-lookup:a-first"]
+      ) {
+        registerIdentifiedWriter(
+          env.runtime,
+          createWriterAction(actionId, { writes: [outputLink] }),
+        );
+      }
+
+      const candidates = await writersForTargets(env.runtime, [
+        toMemorySpaceAddress(outputLink),
+      ]);
+
+      expect(candidates.map((candidate) => candidate.actionId)).toEqual([
+        "writer-lookup:a-first",
+        "writer-lookup:z-last",
+      ]);
+    } finally {
+      await disposeSchedulerTestRuntime(env);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add the indexed scheduler-v2 `writersForTargets` lookup with exact-document and path-overlap matching
- expose an authenticated memory-v2 lookup capability scoped to the attached session, effective user/session context, and READ authority
- merge durable observation-backed writers with live scheduler registration surfaces while preserving fingerprint and status distinctions
- validate indexed projections against canonical scheduler snapshots and fail open on corrupt rows, protocol skew, or misses
- document the completed W0.3 contract and capability handshake

This is W0.3 of the server-side execution plan and is stacked on #4685 (W0.2).

## Validation

- `deno fmt --check`
- `deno lint`
- `deno task check`
- `deno task check-docs` (508/508)
- focused memory and runner scheduler suites
- `deno task test` (all workspace packages passed)
- `deno task integration` (7/7 groups; all 89 pattern tests passed)

## Success criteria

- direct, side-write, and materializer targets resolve to their producing actions
- redirected writes to pre-existing cells use current scheduler writer identity, not creation provenance
- multiple candidates are returned deterministically with UTF-8 ordering
- PerUser and PerSession contexts remain isolated
- re-observation replaces stale dynamic write surfaces
- the 10k-row lookup uses the intended index and stays within the scheduler index budget

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an authoritative scheduler writer lookup and exposes it over `memory/v2` as `scheduler.writer.list` to resolve producers for a target by exact path or path-overlap. The runner merges durable index results with live registration and returns deterministic, UTF‑8–ordered candidates.

- **New Features**
  - Protocol: build-inherent `schedulerWriterLookup` flag and `scheduler.writer.list` request; client gates calls on handshake.
  - Engine/Server: `writersForTargets` over durable `scheduler_write_index` with exact-document and path-overlap matching; validates rows against snapshots and fails open on skew; isolates PerUser/PerSession contexts; keeps the 10k-row index budget.
  - Runner: merges durable and live writers; preserves fingerprints and failure status; rejects mixed-space and arbitrary context selectors; deterministic UTF‑8 ordering.

- **Migration**
  - No config changes. Older servers are supported (client skips the request).
  - Storage: `IStorageProviderWithReplica.writersForTargets` is optional; handle undefined by falling back to live surfaces.

<sup>Written for commit ce28d39a1b44589dba81e405df21d27caa5a2660. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

