### PR TITLE
feat(runner): add authenticated host execution provider

### DIFF
--- a/docs/specs/server-side-execution/README.md
+++ b/docs/specs/server-side-execution/README.md
@@ -887,18 +887,21 @@ hooks. In-process means transport-efficient, not policy-bypassing.
 
 The provider does not install a `session.watch` graph query. Instead, the
 server's host-only accepted-commit callback reports successful canonical
-commits after their scheduler side effects. The provider tracks the Worker's
-known roots and performs authenticated point queries for affected state, then
-delivers ordinary replica syncs over the port. Rejected transactions and
-catch-up reads do not appear as accepted commits; callback failures are
-contained and disposal unregisters the callback. The callback's per-space
+first applications after their scheduler side effects. Its frozen payload is
+limited to scalar revision metadata and changed scheduler-row ids; document
+values never enter the callback surface. Replays, rejected transactions, and
+catch-up reads do not appear as accepted commits. The provider tracks the
+Worker's known roots and performs authenticated point queries for affected
+state, then delivers ordinary replica syncs over the port. Scheduler-adoption
+failure is fail-open for those required data invalidations. Callback failures
+are contained and disposal unregisters the callback. The callback's per-space
 `order` is process-local wake ordering, not the reconnectable execution-control
 feed defined in §6.4/W0.6.
 
 W1.1 adds the `ExecutionLease` record and generation, host-derived
 `onBehalfOf`, and atomic fence validation to this same canonical transaction
-path. The provider buffers a claimed transaction until whole-action scope
-validation succeeds (§5.B.2).
+path. W1.3 will make the provider buffer a claimed transaction until
+whole-action scope validation succeeds (§5.B.2).
 
 ### 6.3 What runs: demand, not pieces
 

--- a/docs/specs/server-side-execution/README.md
+++ b/docs/specs/server-side-execution/README.md
@@ -877,24 +877,28 @@ engine assumption and keeps WAL discipline in one place.
 
 ### 6.2 Storage transport: in-process, no subscriptions
 
-An initial prototype may connect through the `loopback` transport
-(`packages/memory/v2/client.ts:1299`) to the same `Server`, but authority
-cannot transfer through a raw `Engine` shortcut.
+The implemented **executor-grade provider** gives the Worker an opaque
+`MessagePort`, principal DID, and exact space/branch lane. The host owns the
+real authenticated `Server.connect` session and its grant; neither a private
+key nor raw `Engine` access crosses into the Worker. Reads and commits therefore
+traverse the canonical protocol path, preserving session authentication, ACL
+and CFC validation, conflict handling, scheduler-state updates, and post-commit
+hooks. In-process means transport-efficient, not policy-bypassing.
 
-The production design is an **executor-grade provider** implementing
-`IStorageProviderWithReplica` (`packages/runner/src/storage/interface.ts:264`)
-that (a) reads through the engine's read pool directly
-(`packages/memory/v2/server.ts:711`) with MessageChannel batching, (b)
-commits through the server's canonical validated apply path, and (c) receives
-invalidations from the engine commit stream as a per-space callback — not via
-`session.watch` graph queries. It preserves authenticated `onBehalfOf`, ACL
-checks, CFC preparation/validation, conflict checks, `ExecutionLease`
-fencing, scheduler-state updates, and feed hooks. In-process means
-transport-efficient, not policy-bypassing.
+The provider does not install a `session.watch` graph query. Instead, the
+server's host-only accepted-commit callback reports successful canonical
+commits after their scheduler side effects. The provider tracks the Worker's
+known roots and performs authenticated point queries for affected state, then
+delivers ordinary replica syncs over the port. Rejected transactions and
+catch-up reads do not appear as accepted commits; callback failures are
+contained and disposal unregisters the callback. The callback's per-space
+`order` is process-local wake ordering, not the reconnectable execution-control
+feed defined in §6.4/W0.6.
 
-The executor's scheduler trigger index is its subscription; the engine tells
-it "space S, commit at seq N, docs D1..Dk changed". The provider buffers a
-claimed transaction until whole-action scope validation succeeds (§5.B.2).
+W1.1 adds the `ExecutionLease` record and generation, host-derived
+`onBehalfOf`, and atomic fence validation to this same canonical transaction
+path. The provider buffers a claimed transaction until whole-action scope
+validation succeeds (§5.B.2).
 
 ### 6.3 What runs: demand, not pieces
 
@@ -1232,7 +1236,7 @@ means a design doc/decision is required before implementation.
 
 | # | Gap | Blocks | Status |
 | --- | --- | --- | --- |
-| G0 | Executor-grade provider with canonical ACL/CFC/conflict/apply hooks and commit invalidations | shadow | needs-impl; loopback proves the seam |
+| G0 | Executor-grade provider with canonical ACL/CFC/conflict/apply hooks and commit invalidations | shadow | implemented; W1.1 adds atomic lease fencing |
 | G1 | `SchedulerExecutionContextKey` and effective scope-qualified snapshots/state/indexes (§3.2.1) | server reliance on durable state | prerequisite; needs-impl |
 | G2 | Branch-qualified authenticated `ExecutionDemand`, sticky sponsor selection, and fenced `ExecutionLease` | shadow | needs-impl |
 | G3 | Branch-qualified ephemeral per-action `ExecutionClaim` with worker lease generation + independent claim generation, revocation, and required client handshake | B | needs-impl |

--- a/docs/specs/server-side-execution/implementation-plan.md
+++ b/docs/specs/server-side-execution/implementation-plan.md
@@ -451,16 +451,17 @@ provenance, hook, and notification path as a remote client.
 5. Preserve remote and in-process behavioral equivalence with a differential
    fixture, including scheduler observations and rejected commits. Compare
    exact user operations/data, then normalize legitimate session ids,
-   sequences, lease generations, and transport metadata before comparing
-   scheduler semantics; assert the expected identity/fence fields separately.
+   sequences, and transport metadata before comparing scheduler semantics.
+   W1.1 extends the fixture with lease generation and host-derived provenance
+   assertions once those fields exist.
 6. Ensure provider disposal unregisters callbacks and cannot outlive its lease.
 
 **Success criteria:**
 
 - [x] Differential fixture produces identical user operations/data and
       normalized-equivalent scheduler semantics through remote/loopback and
-      host-provider paths; expected session/provenance/fence differences are
-      asserted explicitly.
+      host-provider paths; expected session/transport differences are asserted
+      explicitly.
 - [x] ACL denial, CFC denial, and conflict produce the same atomic rejection
       shape with no partial apply.
 - [ ] A revoked/fenced lease produces the same atomic rejection shape with no
@@ -468,7 +469,9 @@ provenance, hook, and notification path as a remote client.
       record and generation in the canonical transaction.
 - [x] An ordinary client commit invalidates and re-settles the Worker without a
       watch/poll loop.
-- [x] Worker termination releases callbacks and pending requests.
+- [x] Worker-controller termination plus channel disposal releases callbacks
+      and pending requests, including host-first disposal during an in-flight
+      read.
 - [x] A test guard proves no provider path calls Engine.applyCommit directly.
 
 ---

--- a/docs/specs/server-side-execution/implementation-plan.md
+++ b/docs/specs/server-side-execution/implementation-plan.md
@@ -418,6 +418,10 @@ that it settled.
 **Depends on:** #4288.
 **Unblocks:** leases and executor Workers.
 
+**Status:** provider substrate implemented. Atomic ExecutionLease fencing is a
+W1.1 integration criterion because the lease record and compare-and-swap
+generation do not exist before that work package.
+
 **Decision:** low-overhead server execution may be in-process, but every read
 and commit must traverse the same authenticated authorization, conflict, CFC,
 provenance, hook, and notification path as a remote client.
@@ -441,8 +445,9 @@ provenance, hook, and notification path as a remote client.
 3. Route reads through the authenticated Server read path and commits through
    normal transact validation. Push post-commit invalidations to the Worker;
    do not poll.
-4. Allow the host to attach a current ExecutionLease and fence generation to
-   each commit. W1.1 supplies and validates the lease.
+4. Bind the provider channel to an exact space, branch, and opaque executor
+   principal. W1.1 supplies the current ExecutionLease and fence generation
+   and adds their atomic validation to the canonical commit path.
 5. Preserve remote and in-process behavioral equivalence with a differential
    fixture, including scheduler observations and rejected commits. Compare
    exact user operations/data, then normalize legitimate session ids,
@@ -452,16 +457,19 @@ provenance, hook, and notification path as a remote client.
 
 **Success criteria:**
 
-- [ ] Differential fixture produces identical user operations/data and
+- [x] Differential fixture produces identical user operations/data and
       normalized-equivalent scheduler semantics through remote/loopback and
       host-provider paths; expected session/provenance/fence differences are
       asserted explicitly.
-- [ ] ACL denial, CFC denial, conflict, and revoked/fenced lease each produce
-      the same atomic rejection shape; no partial apply.
-- [ ] An ordinary client commit invalidates and re-settles the Worker without a
+- [x] ACL denial, CFC denial, and conflict produce the same atomic rejection
+      shape with no partial apply.
+- [ ] A revoked/fenced lease produces the same atomic rejection shape with no
+      partial apply. Deferred to W1.1, which defines and validates the lease
+      record and generation in the canonical transaction.
+- [x] An ordinary client commit invalidates and re-settles the Worker without a
       watch/poll loop.
-- [ ] Worker termination releases callbacks and pending requests.
-- [ ] A test guard proves no provider path calls Engine.applyCommit directly.
+- [x] Worker termination releases callbacks and pending requests.
+- [x] A test guard proves no provider path calls Engine.applyCommit directly.
 
 ---
 

--- a/packages/memory/test/v2-accepted-commit-feed-test.ts
+++ b/packages/memory/test/v2-accepted-commit-feed-test.ts
@@ -28,6 +28,26 @@ const commit = (
   }],
 });
 
+const schedulerObservation = (actionId: string) => ({
+  version: 1,
+  branch: "",
+  pieceId: "of:accepted-feed:piece",
+  processGeneration: 1,
+  actionId,
+  actionKind: "computation",
+  implementationFingerprint: "impl:accepted-feed",
+  runtimeFingerprint: "runtime:accepted-feed",
+  observedAtSeq: 0,
+  transactionKind: "action-run",
+  reads: [],
+  shallowReads: [],
+  actualChangedWrites: [],
+  currentKnownWrites: [],
+  declaredWrites: [],
+  materializerWriteEnvelopes: [],
+  status: "success",
+});
+
 Deno.test("memory v2 accepted-commit feed publishes canonical commits exactly once", async () => {
   const server = new Server({
     authorizeSessionOpen: () => "did:key:z6Mk-accepted-commit-principal",
@@ -106,6 +126,94 @@ Deno.test("memory v2 accepted-commit feed contains listener failures and omits r
   }
 });
 
+Deno.test("memory v2 accepted-commit feed isolates listener payload mutation", async () => {
+  const server = new Server({
+    authorizeSessionOpen: () => "did:key:z6Mk-accepted-commit-principal",
+    sessionOpenAuth: testSessionOpenAuth,
+  });
+  const client = await MemoryClient.connect({
+    transport: MemoryClient.loopback(server),
+  });
+  const session = await client.mount(
+    SPACE,
+    {},
+    testSessionOpenAuthFactory,
+  );
+  let observed: AcceptedCommitEvent | undefined;
+  server.subscribeAcceptedCommits(SPACE, (event) => {
+    event.commit.seq = 999;
+    event.commit.revisions.length = 0;
+  });
+  server.subscribeAcceptedCommits(SPACE, (event) => {
+    observed = event;
+  });
+
+  try {
+    const applied = await session.transact(commit(1, 1));
+    assertEquals(applied.seq, 1);
+    assertEquals(applied.revisions.length, 1);
+    assertEquals(observed?.commit.seq, 1);
+    assertEquals(observed?.commit.revisions.length, 1);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 accepted-commit feed omits data and observation replays", async () => {
+  const server = new Server({
+    authorizeSessionOpen: () => "did:key:z6Mk-accepted-commit-principal",
+    sessionOpenAuth: testSessionOpenAuth,
+  });
+  const client = await MemoryClient.connect({
+    transport: MemoryClient.loopback(server),
+  });
+  const session = await client.mount(
+    SPACE,
+    {},
+    testSessionOpenAuthFactory,
+  );
+  const events: AcceptedCommitEvent[] = [];
+  server.subscribeAcceptedCommits(SPACE, (event) => {
+    events.push(event);
+  });
+
+  try {
+    const dataCommit = commit(1, 1);
+    const firstData = await session.transact(dataCommit);
+    const replayedData = await session.transact(dataCommit);
+    assertEquals(replayedData.seq, firstData.seq);
+
+    const observationCommit: ClientCommit = {
+      localSeq: 2,
+      reads: { confirmed: [], pending: [] },
+      operations: [],
+      schedulerObservation: schedulerObservation("action:replayed"),
+    };
+    const firstObservation = await session.transact(observationCommit);
+    const replayedObservation = await session.transact(observationCommit);
+    assertEquals(
+      replayedObservation.schedulerObservationId,
+      firstObservation.schedulerObservationId,
+    );
+
+    assertEquals(
+      events.map((event) => ({
+        order: event.order,
+        dataSeq: event.commit.seq,
+        observations: event.commit.schedulerObservationResults?.length ?? 0,
+      })),
+      [
+        { order: 1, dataSeq: 1, observations: 0 },
+        { order: 2, dataSeq: 1, observations: 1 },
+      ],
+    );
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
 Deno.test("memory v2 accepted-commit feed includes successful direct host writes", async () => {
   const server = new Server({
     authorizeSessionOpen: () => "did:key:z6Mk-accepted-commit-principal",
@@ -150,38 +258,18 @@ Deno.test("memory v2 accepted-commit feed orders observation-only commits sharin
   server.subscribeAcceptedCommits(SPACE, (event) => {
     events.push(event);
   });
-  const observation = (actionId: string) => ({
-    version: 1,
-    branch: "",
-    pieceId: "of:accepted-feed:piece",
-    processGeneration: 1,
-    actionId,
-    actionKind: "computation",
-    implementationFingerprint: "impl:accepted-feed",
-    runtimeFingerprint: "runtime:accepted-feed",
-    observedAtSeq: 0,
-    transactionKind: "action-run",
-    reads: [],
-    shallowReads: [],
-    actualChangedWrites: [],
-    currentKnownWrites: [],
-    declaredWrites: [],
-    materializerWriteEnvelopes: [],
-    status: "success",
-  });
-
   try {
     await session.transact({
       localSeq: 1,
       reads: { confirmed: [], pending: [] },
       operations: [],
-      schedulerObservation: observation("action:first"),
+      schedulerObservation: schedulerObservation("action:first"),
     });
     await session.transact({
       localSeq: 2,
       reads: { confirmed: [], pending: [] },
       operations: [],
-      schedulerObservation: observation("action:second"),
+      schedulerObservation: schedulerObservation("action:second"),
     });
 
     assertEquals(

--- a/packages/memory/test/v2-accepted-commit-feed-test.ts
+++ b/packages/memory/test/v2-accepted-commit-feed-test.ts
@@ -1,12 +1,6 @@
-import {
-  assertEquals,
-  assertRejects,
-} from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import * as MemoryClient from "../v2/client.ts";
-import {
-  type AcceptedCommitEvent,
-  Server,
-} from "../v2/server.ts";
+import { type AcceptedCommitEvent, Server } from "../v2/server.ts";
 import { type ClientCommit, toDocumentPath } from "../v2.ts";
 import {
   testSessionOpenAuth,
@@ -50,7 +44,9 @@ Deno.test("memory v2 accepted-commit feed publishes canonical commits exactly on
   const events: AcceptedCommitEvent[] = [];
   const unsubscribe = server.subscribeAcceptedCommits(
     SPACE,
-    (event) => events.push(event),
+    (event) => {
+      events.push(event);
+    },
   );
 
   try {
@@ -88,20 +84,44 @@ Deno.test("memory v2 accepted-commit feed contains listener failures and omits r
   server.subscribeAcceptedCommits(SPACE, () => {
     throw new Error("listener failure");
   });
-  server.subscribeAcceptedCommits(SPACE, () => delivered++);
+  server.subscribeAcceptedCommits(SPACE, () => {
+    delivered++;
+  });
 
   try {
     await session.transact(commit(1, 1));
     assertEquals(delivered, 1);
 
-    await assertRejects(
+    const rejection = await assertRejects(
       () => session.transact(commit(2, 2, 0)),
       Error,
-      "Conflict",
     );
+    assertEquals(rejection.name, "ConflictError");
     assertEquals(delivered, 1);
   } finally {
     await client.close();
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 accepted-commit feed includes successful direct host writes", async () => {
+  const server = new Server({
+    authorizeSessionOpen: () => "did:key:z6Mk-accepted-commit-principal",
+    sessionOpenAuth: testSessionOpenAuth,
+  });
+  const events: AcceptedCommitEvent[] = [];
+  server.subscribeAcceptedCommits(SPACE, (event) => {
+    events.push(event);
+  });
+
+  try {
+    const applied = await server.writeDocument(
+      SPACE,
+      "of:direct:1",
+      { direct: true },
+    );
+    assertEquals(events, [{ space: SPACE, commit: applied }]);
+  } finally {
     await server.close();
   }
 });

--- a/packages/memory/test/v2-accepted-commit-feed-test.ts
+++ b/packages/memory/test/v2-accepted-commit-feed-test.ts
@@ -53,6 +53,8 @@ Deno.test("memory v2 accepted-commit feed publishes canonical commits exactly on
     const applied = await session.transact(commit(1, 1));
 
     assertEquals(events, [{
+      order: 1,
+      deliverySeq: applied.seq,
       space: SPACE,
       originSessionId: session.sessionId,
       commit: applied,
@@ -120,8 +122,81 @@ Deno.test("memory v2 accepted-commit feed includes successful direct host writes
       "of:direct:1",
       { direct: true },
     );
-    assertEquals(events, [{ space: SPACE, commit: applied }]);
+    assertEquals(events, [{
+      order: 1,
+      deliverySeq: applied.seq,
+      space: SPACE,
+      commit: applied,
+    }]);
   } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 accepted-commit feed orders observation-only commits sharing a delivery slot", async () => {
+  const server = new Server({
+    authorizeSessionOpen: () => "did:key:z6Mk-accepted-commit-principal",
+    sessionOpenAuth: testSessionOpenAuth,
+  });
+  const client = await MemoryClient.connect({
+    transport: MemoryClient.loopback(server),
+  });
+  const session = await client.mount(
+    SPACE,
+    {},
+    testSessionOpenAuthFactory,
+  );
+  const events: AcceptedCommitEvent[] = [];
+  server.subscribeAcceptedCommits(SPACE, (event) => {
+    events.push(event);
+  });
+  const observation = (actionId: string) => ({
+    version: 1,
+    branch: "",
+    pieceId: "of:accepted-feed:piece",
+    processGeneration: 1,
+    actionId,
+    actionKind: "computation",
+    implementationFingerprint: "impl:accepted-feed",
+    runtimeFingerprint: "runtime:accepted-feed",
+    observedAtSeq: 0,
+    transactionKind: "action-run",
+    reads: [],
+    shallowReads: [],
+    actualChangedWrites: [],
+    currentKnownWrites: [],
+    declaredWrites: [],
+    materializerWriteEnvelopes: [],
+    status: "success",
+  });
+
+  try {
+    await session.transact({
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [],
+      schedulerObservation: observation("action:first"),
+    });
+    await session.transact({
+      localSeq: 2,
+      reads: { confirmed: [], pending: [] },
+      operations: [],
+      schedulerObservation: observation("action:second"),
+    });
+
+    assertEquals(
+      events.map((event) => ({
+        order: event.order,
+        deliverySeq: event.deliverySeq,
+        dataSeq: event.commit.seq,
+      })),
+      [
+        { order: 1, deliverySeq: 1, dataSeq: 0 },
+        { order: 2, deliverySeq: 1, dataSeq: 0 },
+      ],
+    );
+  } finally {
+    await client.close();
     await server.close();
   }
 });

--- a/packages/memory/test/v2-accepted-commit-feed-test.ts
+++ b/packages/memory/test/v2-accepted-commit-feed-test.ts
@@ -1,0 +1,107 @@
+import {
+  assertEquals,
+  assertRejects,
+} from "@std/assert";
+import * as MemoryClient from "../v2/client.ts";
+import {
+  type AcceptedCommitEvent,
+  Server,
+} from "../v2/server.ts";
+import { type ClientCommit, toDocumentPath } from "../v2.ts";
+import {
+  testSessionOpenAuth,
+  testSessionOpenAuthFactory,
+} from "./v2-auth-test-helpers.ts";
+
+const SPACE = "did:key:z6Mk-memory-v2-accepted-commit-feed";
+
+const commit = (
+  localSeq: number,
+  value: number,
+  confirmedSeq?: number,
+): ClientCommit => ({
+  localSeq,
+  reads: {
+    confirmed: confirmedSeq === undefined
+      ? []
+      : [{ id: "of:doc:1", path: toDocumentPath([]), seq: confirmedSeq }],
+    pending: [],
+  },
+  operations: [{
+    op: "set",
+    id: "of:doc:1",
+    value: { value: { value } },
+  }],
+});
+
+Deno.test("memory v2 accepted-commit feed publishes canonical commits exactly once", async () => {
+  const server = new Server({
+    authorizeSessionOpen: () => "did:key:z6Mk-accepted-commit-principal",
+    sessionOpenAuth: testSessionOpenAuth,
+  });
+  const client = await MemoryClient.connect({
+    transport: MemoryClient.loopback(server),
+  });
+  const session = await client.mount(
+    SPACE,
+    {},
+    testSessionOpenAuthFactory,
+  );
+  const events: AcceptedCommitEvent[] = [];
+  const unsubscribe = server.subscribeAcceptedCommits(
+    SPACE,
+    (event) => events.push(event),
+  );
+
+  try {
+    const applied = await session.transact(commit(1, 1));
+
+    assertEquals(events, [{
+      space: SPACE,
+      originSessionId: session.sessionId,
+      commit: applied,
+    }]);
+
+    unsubscribe();
+    await session.transact(commit(2, 2));
+    assertEquals(events.length, 1);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 accepted-commit feed contains listener failures and omits rejected commits", async () => {
+  const server = new Server({
+    authorizeSessionOpen: () => "did:key:z6Mk-accepted-commit-principal",
+    sessionOpenAuth: testSessionOpenAuth,
+  });
+  const client = await MemoryClient.connect({
+    transport: MemoryClient.loopback(server),
+  });
+  const session = await client.mount(
+    SPACE,
+    {},
+    testSessionOpenAuthFactory,
+  );
+  let delivered = 0;
+  server.subscribeAcceptedCommits(SPACE, () => {
+    throw new Error("listener failure");
+  });
+  server.subscribeAcceptedCommits(SPACE, () => delivered++);
+
+  try {
+    await session.transact(commit(1, 1));
+    assertEquals(delivered, 1);
+
+    await assertRejects(
+      () => session.transact(commit(2, 2, 0)),
+      Error,
+      "Conflict",
+    );
+    assertEquals(delivered, 1);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});

--- a/packages/memory/test/v2-accepted-commit-feed-test.ts
+++ b/packages/memory/test/v2-accepted-commit-feed-test.ts
@@ -77,7 +77,16 @@ Deno.test("memory v2 accepted-commit feed publishes canonical commits exactly on
       deliverySeq: applied.seq,
       space: SPACE,
       originSessionId: session.sessionId,
-      commit: applied,
+      branch: applied.branch,
+      dataSeq: applied.seq,
+      revisions: applied.revisions.map((revision) => ({
+        branch: revision.branch,
+        id: revision.id,
+        ...(revision.scope !== undefined ? { scope: revision.scope } : {}),
+        seq: revision.seq,
+        op: revision.op,
+      })),
+      schedulerUpdateIds: [],
     }]);
 
     unsubscribe();
@@ -141,8 +150,21 @@ Deno.test("memory v2 accepted-commit feed isolates listener payload mutation", a
   );
   let observed: AcceptedCommitEvent | undefined;
   server.subscribeAcceptedCommits(SPACE, (event) => {
-    event.commit.seq = 999;
-    event.commit.revisions.length = 0;
+    try {
+      (event as { dataSeq: number }).dataSeq = 999;
+    } catch {
+      // Frozen host events reject mutation in strict mode.
+    }
+    try {
+      (event.revisions[0] as { seq: number }).seq = 999;
+    } catch {
+      // Nested scalar metadata is frozen too.
+    }
+    try {
+      (event.schedulerUpdateIds as number[]).push(999);
+    } catch {
+      // Arrays are immutable across listeners.
+    }
   });
   server.subscribeAcceptedCommits(SPACE, (event) => {
     observed = event;
@@ -152,8 +174,9 @@ Deno.test("memory v2 accepted-commit feed isolates listener payload mutation", a
     const applied = await session.transact(commit(1, 1));
     assertEquals(applied.seq, 1);
     assertEquals(applied.revisions.length, 1);
-    assertEquals(observed?.commit.seq, 1);
-    assertEquals(observed?.commit.revisions.length, 1);
+    assertEquals(observed?.dataSeq, 1);
+    assertEquals(observed?.revisions[0]?.seq, 1);
+    assertEquals(observed?.schedulerUpdateIds, []);
   } finally {
     await client.close();
     await server.close();
@@ -200,8 +223,8 @@ Deno.test("memory v2 accepted-commit feed omits data and observation replays", a
     assertEquals(
       events.map((event) => ({
         order: event.order,
-        dataSeq: event.commit.seq,
-        observations: event.commit.schedulerObservationResults?.length ?? 0,
+        dataSeq: event.dataSeq,
+        observations: event.schedulerUpdateIds.length,
       })),
       [
         { order: 1, dataSeq: 1, observations: 0 },
@@ -234,7 +257,16 @@ Deno.test("memory v2 accepted-commit feed includes successful direct host writes
       order: 1,
       deliverySeq: applied.seq,
       space: SPACE,
-      commit: applied,
+      branch: applied.branch,
+      dataSeq: applied.seq,
+      revisions: applied.revisions.map((revision) => ({
+        branch: revision.branch,
+        id: revision.id,
+        ...(revision.scope !== undefined ? { scope: revision.scope } : {}),
+        seq: revision.seq,
+        op: revision.op,
+      })),
+      schedulerUpdateIds: [],
     }]);
   } finally {
     await server.close();
@@ -276,7 +308,7 @@ Deno.test("memory v2 accepted-commit feed orders observation-only commits sharin
       events.map((event) => ({
         order: event.order,
         deliverySeq: event.deliverySeq,
-        dataSeq: event.commit.seq,
+        dataSeq: event.dataSeq,
       })),
       [
         { order: 1, deliverySeq: 1, dataSeq: 0 },

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -852,6 +852,20 @@ export interface AppliedCommit {
   schedulerDirtiedReaders?: SchedulerReaderIndexEntry[];
 }
 
+// Replay status is process-local engine metadata, deliberately kept outside
+// AppliedCommit's serialized shape. The canonical response to a replay stays
+// byte-compatible while host-side post-commit feeds can avoid publishing the
+// same accepted transaction twice.
+const replayedAppliedCommits = new WeakSet<AppliedCommit>();
+
+const markAppliedCommitReplay = (commit: AppliedCommit): AppliedCommit => {
+  replayedAppliedCommits.add(commit);
+  return commit;
+};
+
+export const isAppliedCommitReplay = (commit: AppliedCommit): boolean =>
+  replayedAppliedCommits.has(commit);
+
 export type SchedulerActionKind =
   | "computation"
   | "effect"
@@ -5225,7 +5239,7 @@ const applyCommitTransaction = (
         observationReplay,
       )
       : undefined;
-    return {
+    return markAppliedCommitReplay({
       seq: existing.seq,
       branch: existing.branch,
       revisions: selectCommitRevisions(engine, existing.seq),
@@ -5235,7 +5249,7 @@ const applyCommitTransaction = (
       ...(observationResult
         ? { schedulerObservationResults: [observationResult] }
         : {}),
-    };
+    });
   }
 
   // Preconditions gate every commit shape, including the observation-only
@@ -5936,7 +5950,7 @@ const applySchedulerObservationOnlyCommit = (
       localSeq,
       existingReplay,
     );
-    return {
+    return markAppliedCommitReplay({
       seq: existingReplay.observed_at_seq,
       branch,
       revisions: [],
@@ -5944,7 +5958,7 @@ const applySchedulerObservationOnlyCommit = (
         ? { schedulerObservationId: replayed.schedulerObservationId }
         : {}),
       schedulerObservationResults: [replayed],
-    };
+    });
   }
 
   const dropReason = schedulerObservationReadDropReason(engine, {
@@ -6025,6 +6039,7 @@ const applySchedulerObservationBatchCommit = (
   },
 ): AppliedCommit => {
   const results: AppliedSchedulerObservationResult[] = [];
+  let hasNewObservation = false;
   for (const item of batch) {
     const result = applySchedulerObservationOnlyCommit(engine, {
       sessionId,
@@ -6037,15 +6052,17 @@ const applySchedulerObservationBatchCommit = (
       schedulerObservation: item
         .schedulerObservation as SchedulerActionObservation,
     });
+    hasNewObservation ||= !isAppliedCommitReplay(result);
     results.push(result.schedulerObservationResults![0]);
   }
 
-  return {
+  const commit: AppliedCommit = {
     seq: headSeq(engine, branch),
     branch,
     revisions: [],
     schedulerObservationResults: results,
   };
+  return hasNewObservation ? commit : markAppliedCommitReplay(commit);
 };
 
 // The COMMIT conflict matcher uses LEAF-ONLY touched paths (no add/remove/move

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -2,6 +2,7 @@ import * as FS from "@std/fs";
 import * as Path from "@std/path";
 import { resolveSpaceStoreUrl } from "./storage-path.ts";
 import {
+  type BranchName,
   type CellScope,
   type ClientCommit,
   type ClientMessage,
@@ -365,14 +366,27 @@ type DirtyOrigin = {
 export interface AcceptedCommitEvent {
   /** Ephemeral per-space callback order. W0.6 replaces this with the durable
    *  reconnectable execution-feed sequence. */
-  order: number;
+  readonly order: number;
   /** Data/adoption window through which this commit is visible. Metadata-only
    *  scheduler observations may reserve a future delivery slot without
    *  advancing the semantic branch head. */
-  deliverySeq: number;
-  space: string;
-  originSessionId?: string;
-  commit: Engine.AppliedCommit;
+  readonly deliverySeq: number;
+  readonly space: string;
+  readonly originSessionId?: string;
+  readonly branch: BranchName;
+  readonly dataSeq: number;
+  /** Detached scalar revision metadata; document payloads never enter the
+   *  host callback surface. */
+  readonly revisions: readonly Readonly<{
+    branch: BranchName;
+    id: string;
+    scope?: CellScope;
+    seq: number;
+    op: Operation["op"];
+  }>[];
+  /** Scheduler snapshot rows changed by this accepted transaction, whether by
+   *  re-observation or by a semantic write dirtying a reader. */
+  readonly schedulerUpdateIds: readonly number[];
 }
 
 export type AcceptedCommitListener = (
@@ -1330,11 +1344,51 @@ export class Server {
   }
 
   #publishAcceptedCommit(
-    event: Omit<AcceptedCommitEvent, "order">,
+    event: {
+      space: string;
+      originSessionId?: string;
+      deliverySeq: number;
+      commit: Engine.AppliedCommit;
+    },
   ): void {
     const order = (this.#acceptedCommitOrderBySpace.get(event.space) ?? 0) + 1;
     this.#acceptedCommitOrderBySpace.set(event.space, order);
-    const orderedEvent: AcceptedCommitEvent = { ...event, order };
+    const revisions = Object.freeze(
+      event.commit.revisions.map((revision) =>
+        Object.freeze({
+          branch: revision.branch,
+          id: revision.id,
+          ...(revision.scope !== undefined ? { scope: revision.scope } : {}),
+          seq: revision.seq,
+          op: revision.op,
+        })
+      ),
+    );
+    const schedulerUpdateIds = Object.freeze([
+      ...new Set([
+        ...(event.commit.schedulerObservationResults ?? []).flatMap((result) =>
+          result.status === "kept" &&
+            result.schedulerObservationId !== undefined
+            ? [result.schedulerObservationId]
+            : []
+        ),
+        ...(event.commit.schedulerDirtiedReaders ?? []).map((reader) =>
+          reader.observationId
+        ),
+      ]),
+    ].sort((left, right) => left - right));
+    const orderedEvent: AcceptedCommitEvent = Object.freeze({
+      order,
+      deliverySeq: event.deliverySeq,
+      space: event.space,
+      ...(event.originSessionId !== undefined
+        ? { originSessionId: event.originSessionId }
+        : {}),
+      branch: event.commit.branch,
+      dataSeq: event.commit.seq,
+      revisions,
+      schedulerUpdateIds,
+    });
     for (
       const listener of this.#acceptedCommitListeners.get(event.space) ?? []
     ) {
@@ -2194,12 +2248,14 @@ export class Server {
             previousReadSpaces,
             session,
           );
-          this.#publishAcceptedCommit({
-            space: message.space,
-            originSessionId: message.sessionId,
-            deliverySeq: acceptedDeliverySeq,
-            commit,
-          });
+          if (!Engine.isAppliedCommitReplay(commit)) {
+            this.#publishAcceptedCommit({
+              space: message.space,
+              originSessionId: message.sessionId,
+              deliverySeq: acceptedDeliverySeq,
+              commit,
+            });
+          }
           this.markSpaceDirty(
             message.space,
             message.commit.operations

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -363,6 +363,13 @@ type DirtyOrigin = {
  * carries rejected-commit catch-up and may coalesce several commits.
  */
 export interface AcceptedCommitEvent {
+  /** Ephemeral per-space callback order. W0.6 replaces this with the durable
+   *  reconnectable execution-feed sequence. */
+  order: number;
+  /** Data/adoption window through which this commit is visible. Metadata-only
+   *  scheduler observations may reserve a future delivery slot without
+   *  advancing the semantic branch head. */
+  deliverySeq: number;
   space: string;
   originSessionId?: string;
   commit: Engine.AppliedCommit;
@@ -879,6 +886,7 @@ export class Server {
   #refreshing: Promise<void> | null = null;
   #lastRefreshDurationMs = 0;
   #acceptedCommitListeners = new Map<string, Set<AcceptedCommitListener>>();
+  #acceptedCommitOrderBySpace = new Map<string, number>();
   #store?: URL;
   // Injected on-disk SQLite sources (Phase 7), keyed by handle cell id. A
   // registered id is attached read-only from its descriptor path instead of the
@@ -1289,6 +1297,7 @@ export class Server {
     this.#engines.clear();
     this.#connections.clear();
     this.#acceptedCommitListeners.clear();
+    this.#acceptedCommitOrderBySpace.clear();
     this.#readPool.close();
   }
 
@@ -1320,12 +1329,17 @@ export class Server {
     };
   }
 
-  #publishAcceptedCommit(event: AcceptedCommitEvent): void {
+  #publishAcceptedCommit(
+    event: Omit<AcceptedCommitEvent, "order">,
+  ): void {
+    const order = (this.#acceptedCommitOrderBySpace.get(event.space) ?? 0) + 1;
+    this.#acceptedCommitOrderBySpace.set(event.space, order);
+    const orderedEvent: AcceptedCommitEvent = { ...event, order };
     for (
       const listener of this.#acceptedCommitListeners.get(event.space) ?? []
     ) {
       try {
-        const result = listener(event);
+        const result = listener(orderedEvent);
         if (result instanceof Promise) {
           void result.catch((error) => {
             console.warn("accepted commit listener failed", error);
@@ -1409,7 +1423,11 @@ export class Server {
       new Map(),
       undefined,
     );
-    this.#publishAcceptedCommit({ space, commit });
+    this.#publishAcceptedCommit({
+      space,
+      deliverySeq: commit.seq,
+      commit,
+    });
     this.markSpaceDirty(space, [toDirtyKey(id)]);
     return commit;
   }
@@ -2151,6 +2169,12 @@ export class Server {
               detachDatabase(engine.database, alias);
             }
           }
+          const acceptedDeliverySeq = commitPayload.operations.length === 0 &&
+              commit.schedulerObservationResults?.some((result) =>
+                result.status === "kept"
+              )
+            ? Engine.serverSeq(engine) + 1
+            : commit.seq;
           if (aclTouched) {
             this.#invalidateAclCapabilities(message.space);
             // Pass the writing session so it isn't sent the terminal revocation
@@ -2173,6 +2197,7 @@ export class Server {
           this.#publishAcceptedCommit({
             space: message.space,
             originSessionId: message.sessionId,
+            deliverySeq: acceptedDeliverySeq,
             commit,
           });
           this.markSpaceDirty(

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -356,6 +356,22 @@ type DirtyOrigin = {
   seq: number;
 };
 
+/**
+ * Host-only notification emitted after a commit has passed the canonical
+ * server transaction path and its scheduler side effects have run. This is
+ * deliberately distinct from the dirty-session refresh queue: that queue also
+ * carries rejected-commit catch-up and may coalesce several commits.
+ */
+export interface AcceptedCommitEvent {
+  space: string;
+  originSessionId?: string;
+  commit: Engine.AppliedCommit;
+}
+
+export type AcceptedCommitListener = (
+  event: AcceptedCommitEvent,
+) => void | Promise<void>;
+
 class Connection {
   #ready = false;
   #closed = false;
@@ -862,6 +878,7 @@ export class Server {
   #refreshTimer: ReturnType<typeof setTimeout> | null = null;
   #refreshing: Promise<void> | null = null;
   #lastRefreshDurationMs = 0;
+  #acceptedCommitListeners = new Map<string, Set<AcceptedCommitListener>>();
   #store?: URL;
   // Injected on-disk SQLite sources (Phase 7), keyed by handle cell id. A
   // registered id is attached read-only from its descriptor path instead of the
@@ -1271,7 +1288,53 @@ export class Server {
     }
     this.#engines.clear();
     this.#connections.clear();
+    this.#acceptedCommitListeners.clear();
     this.#readPool.close();
+  }
+
+  /**
+   * Subscribe to accepted commits for one exact space. The callback is a
+   * host-side execution primitive, not a client protocol surface. Listener
+   * failures are contained because a commit is already durable by the time it
+   * is published and must never be reported as rejected afterward.
+   */
+  subscribeAcceptedCommits(
+    space: string,
+    listener: AcceptedCommitListener,
+  ): () => void {
+    let listeners = this.#acceptedCommitListeners.get(space);
+    if (listeners === undefined) {
+      listeners = new Set();
+      this.#acceptedCommitListeners.set(space, listeners);
+    }
+    listeners.add(listener);
+    let subscribed = true;
+    return () => {
+      if (!subscribed) return;
+      subscribed = false;
+      const current = this.#acceptedCommitListeners.get(space);
+      current?.delete(listener);
+      if (current?.size === 0) {
+        this.#acceptedCommitListeners.delete(space);
+      }
+    };
+  }
+
+  #publishAcceptedCommit(event: AcceptedCommitEvent): void {
+    for (
+      const listener of this.#acceptedCommitListeners.get(event.space) ?? []
+    ) {
+      try {
+        const result = listener(event);
+        if (result instanceof Promise) {
+          void result.catch((error) => {
+            console.warn("accepted commit listener failed", error);
+          });
+        }
+      } catch (error) {
+        console.warn("accepted commit listener failed", error);
+      }
+    }
   }
 
   /**
@@ -1346,6 +1409,7 @@ export class Server {
       new Map(),
       undefined,
     );
+    this.#publishAcceptedCommit({ space, commit });
     this.markSpaceDirty(space, [toDirtyKey(id)]);
     return commit;
   }
@@ -2106,6 +2170,11 @@ export class Server {
             previousReadSpaces,
             session,
           );
+          this.#publishAcceptedCommit({
+            space: message.space,
+            originSessionId: message.sessionId,
+            commit,
+          });
           this.markSpaceDirty(
             message.space,
             message.commit.operations

--- a/packages/runner/deno.jsonc
+++ b/packages/runner/deno.jsonc
@@ -20,6 +20,7 @@
     "./schemas": "./src/schemas.ts",
     "./telemetry-otel-bridge": "./src/telemetry-otel-bridge.ts",
     "./storage/inspector": "./src/storage/inspector.ts",
+    "./storage/host-provider": "./src/storage/v2-host-provider.ts",
     "./storage/telemetry": "./src/storage/telemetry.ts",
     "./storage/write-stack-trace": "./src/storage/write-stack-trace.ts",
     "./traverse": "./src/traverse.ts",

--- a/packages/runner/integration/sync-schema-path.test.ts
+++ b/packages/runner/integration/sync-schema-path.test.ts
@@ -14,7 +14,13 @@ const { API_URL } = env;
 const keyConfig: IdentityCreateConfig = {
   implementation: "noble",
 };
-const identity = await Identity.fromPassphrase("test operator", keyConfig);
+// This test writes fixed cell causes into a persistent integration store. Use a
+// fresh space per invocation so rerunning the suite cannot inherit stale cells
+// from an earlier server process.
+const identity = await Identity.fromPassphrase(
+  `sync schema path ${crypto.randomUUID()}`,
+  keyConfig,
+);
 
 console.log("\n=== TEST: Sync Schema uses Path ===");
 

--- a/packages/runner/src/storage/v2-host-provider.ts
+++ b/packages/runner/src/storage/v2-host-provider.ts
@@ -441,7 +441,10 @@ class HostReplicaSession implements ReplicaSession {
       this.#mutation = refresh.catch((error) => {
         if (
           !(error instanceof Error) ||
-          !error.message.includes("memory session closed")
+          (!error.message.includes("memory session closed") &&
+            !error.message.includes("memory client closed") &&
+            !error.message.includes("memory client is closed") &&
+            !error.message.includes("transport closed"))
         ) {
           console.warn("executor accepted-commit refresh failed", error);
         }
@@ -461,8 +464,31 @@ class HostReplicaSession implements ReplicaSession {
     return this.session.serverSeq;
   }
 
-  transact(commit: ClientCommit) {
-    return this.session.transact({ ...commit, branch: this.branch });
+  async transact(commit: ClientCommit) {
+    try {
+      return await this.session.transact({ ...commit, branch: this.branch });
+    } catch (error) {
+      const readyToRetry = (error as { readyToRetry?: unknown })
+        ?.readyToRetry;
+      if (
+        error instanceof Error && error.name === "ConflictError" &&
+        typeof readyToRetry === "function"
+      ) {
+        (error as Error & { readyToRetry: () => Promise<void> }).readyToRetry =
+          async () => {
+            await Promise.resolve(readyToRetry.call(error));
+            this.#view?.applySync({
+              type: "sync",
+              fromSeq: this.session.serverSeq,
+              toSeq: this.session.serverSeq,
+              caughtUpLocalSeq: commit.localSeq,
+              upserts: [],
+              removes: [],
+            }, true);
+          };
+      }
+      throw error;
+    }
   }
 
   queryGraph(query: GraphQuery): Promise<GraphQueryResult> {

--- a/packages/runner/src/storage/v2-host-provider.ts
+++ b/packages/runner/src/storage/v2-host-provider.ts
@@ -1,21 +1,52 @@
 import type { MemorySpace, Signer } from "@commonfabric/memory/interface";
 import {
+  type ClientCommit,
   encodeMemoryBoundary,
+  type EntitySnapshot,
+  type GraphQuery,
+  type GraphQueryResult,
   type HelloOkMessage,
   type ResponseMessage,
+  type SchedulerActionSnapshotQuery,
+  type SchedulerSnapshotListResult,
+  type SchedulerWritersForTargetsQuery,
+  type SchedulerWritersForTargetsResult,
   type SessionOpenRequest,
+  type SessionSync,
+  type SqliteDbRef,
+  type SqliteParamsWire,
+  type SqliteQueryResult,
+  type SqliteRegisterDiskSourceResult,
   type V2Error,
+  type WatchSpec,
 } from "@commonfabric/memory/v2";
 import * as MemoryClient from "@commonfabric/memory/v2/client";
 import {
+  type AcceptedCommitEvent,
   parseClientMessage,
   type Server,
 } from "@commonfabric/memory/v2/server";
+import type { AppliedCommit } from "@commonfabric/memory/v2/engine";
 import type { BranchName } from "@commonfabric/memory/v2";
 import { type Options, type SessionFactory, StorageManager } from "./v2.ts";
+import type { ReplicaSession } from "./v2-replica-session.ts";
+
+interface AcceptedCommitNotice {
+  space: string;
+  branch: BranchName;
+  seq: number;
+  originSessionId?: string;
+  revisions: {
+    branch: BranchName;
+    id: string;
+    scope?: string;
+    seq: number;
+  }[];
+}
 
 type ProviderPortMessage =
   | { type: "memory"; payload: string }
+  | { type: "accepted-commit"; notice: AcceptedCommitNotice }
   | { type: "close"; message?: string };
 
 export interface HostProviderChannelOptions {
@@ -52,6 +83,23 @@ const requestIdOf = (message: unknown): string =>
 
 const messageSpace = (message: ReturnType<typeof parseClientMessage>) =>
   message !== null && "space" in message ? message.space : undefined;
+
+const toAcceptedCommitNotice = (
+  event: AcceptedCommitEvent,
+): AcceptedCommitNotice => ({
+  space: event.space,
+  branch: event.commit.branch,
+  seq: event.commit.seq,
+  ...(event.originSessionId !== undefined
+    ? { originSessionId: event.originSessionId }
+    : {}),
+  revisions: event.commit.revisions.map((revision) => ({
+    branch: revision.branch,
+    id: revision.id,
+    ...(revision.scope !== undefined ? { scope: revision.scope } : {}),
+    seq: revision.seq,
+  })),
+});
 
 /**
  * Normalize every branch-bearing request onto the host-owned lane. Messages
@@ -112,6 +160,7 @@ export function createHostProviderChannel(
   let authContext: MemoryClient.SessionOpenAuthContext | null = null;
   let disposed = false;
   let receiving = Promise.resolve();
+  let unsubscribeAcceptedCommits = () => {};
 
   const connection = options.server.connect((message) => {
     if (disposed) return;
@@ -132,6 +181,7 @@ export function createHostProviderChannel(
   const closeHost = (message?: string) => {
     if (disposed) return;
     disposed = true;
+    unsubscribeAcceptedCommits();
     connection.close();
     if (message !== undefined) {
       try {
@@ -235,6 +285,22 @@ export function createHostProviderChannel(
   });
   hostPort.start();
 
+  // Register before returning the Worker endpoint. MessagePort queues notices
+  // until its peer starts, which closes the initial point-read race without a
+  // server graph watch.
+  unsubscribeAcceptedCommits = options.server.subscribeAcceptedCommits(
+    options.space,
+    (event) => {
+      if (disposed || event.commit.branch !== branch) return;
+      hostPort.postMessage(
+        {
+          type: "accepted-commit",
+          notice: toAcceptedCommitNotice(event),
+        } satisfies ProviderPortMessage,
+      );
+    },
+  );
+
   return {
     port: channel.port2,
     async dispose() {
@@ -248,12 +314,23 @@ class MessagePortTransport implements MemoryClient.Transport {
   #receiver: (payload: string) => void = () => {};
   #closeReceiver: (error?: Error) => void = () => {};
   #closed = false;
+  #acceptedCommitReceiver: ((notice: AcceptedCommitNotice) => void) | null =
+    null;
+  #bufferedAcceptedCommits: AcceptedCommitNotice[] = [];
 
   constructor(private readonly port: MessagePort) {
     port.addEventListener("message", (event: MessageEvent<unknown>) => {
       const message = event.data as Partial<ProviderPortMessage>;
       if (message.type === "memory" && typeof message.payload === "string") {
         this.#receiver(message.payload);
+      } else if (
+        message.type === "accepted-commit" && message.notice !== undefined
+      ) {
+        if (this.#acceptedCommitReceiver === null) {
+          this.#bufferedAcceptedCommits.push(message.notice);
+        } else {
+          this.#acceptedCommitReceiver(message.notice);
+        }
       } else if (message.type === "close") {
         this.closeFromHost(message.message);
       } else {
@@ -272,6 +349,15 @@ class MessagePortTransport implements MemoryClient.Transport {
 
   setCloseReceiver(receiver: (error?: Error) => void): void {
     this.#closeReceiver = receiver;
+  }
+
+  setAcceptedCommitReceiver(
+    receiver: (notice: AcceptedCommitNotice) => void,
+  ): void {
+    this.#acceptedCommitReceiver = receiver;
+    const buffered = this.#bufferedAcceptedCommits;
+    this.#bufferedAcceptedCommits = [];
+    for (const notice of buffered) receiver(notice);
   }
 
   send(payload: string): Promise<void> {
@@ -303,10 +389,228 @@ class MessagePortTransport implements MemoryClient.Transport {
   }
 }
 
+const snapshotKey = (snapshot: {
+  branch: string;
+  id: string;
+  scope?: string;
+}): string =>
+  `${snapshot.branch}\0${snapshot.scope ?? "space"}\0${snapshot.id}`;
+
+const syncUpsert = (snapshot: EntitySnapshot) => ({
+  branch: snapshot.branch,
+  id: snapshot.id,
+  ...(snapshot.scope !== undefined ? { scope: snapshot.scope } : {}),
+  seq: snapshot.seq,
+  ...(snapshot.document === null
+    ? { deleted: true as const }
+    : { doc: snapshot.document }),
+});
+
+/**
+ * Worker-side session facade. Authenticated operations still use the ordinary
+ * memory session, while graph subscriptions are replaced by host-pushed
+ * accepted-commit notices and exact point reads.
+ */
+class HostReplicaSession implements ReplicaSession {
+  #watches = new Map<string, WatchSpec>();
+  #watchEntities = new Map<string, Map<string, EntitySnapshot>>();
+  #view: MemoryClient.WatchView | null = null;
+  #mutation = Promise.resolve();
+  #appliedSeq: number;
+  #closed = false;
+
+  constructor(
+    private readonly session: MemoryClient.SpaceSession,
+    transport: MessagePortTransport,
+    private readonly branch: BranchName,
+  ) {
+    this.#appliedSeq = session.serverSeq;
+    transport.setAcceptedCommitReceiver((notice) => {
+      this.#mutation = this.#mutation.then(
+        () => this.refreshAcceptedCommit(notice),
+        () => this.refreshAcceptedCommit(notice),
+      );
+    });
+  }
+
+  get sessionId(): string {
+    return this.session.sessionId;
+  }
+
+  get sessionToken(): string | undefined {
+    return this.session.sessionToken;
+  }
+
+  get serverSeq(): number {
+    return this.session.serverSeq;
+  }
+
+  transact(commit: ClientCommit): Promise<AppliedCommit> {
+    return this.session.transact({ ...commit, branch: this.branch });
+  }
+
+  queryGraph(query: GraphQuery): Promise<GraphQueryResult> {
+    return this.session.queryGraph({ ...query, branch: this.branch });
+  }
+
+  sqliteQuery(
+    db: SqliteDbRef,
+    sql: string,
+    params?: SqliteParamsWire,
+  ): Promise<SqliteQueryResult> {
+    return this.session.sqliteQuery(db, sql, params);
+  }
+
+  registerSqliteDiskSource(
+    id: string,
+    path: string,
+  ): Promise<SqliteRegisterDiskSourceResult> {
+    return this.session.registerSqliteDiskSource(id, path);
+  }
+
+  listSchedulerActionSnapshots(
+    query: SchedulerActionSnapshotQuery = {},
+  ): Promise<SchedulerSnapshotListResult> {
+    return this.session.listSchedulerActionSnapshots({
+      ...query,
+      branch: this.branch,
+    });
+  }
+
+  writersForTargets(
+    query: SchedulerWritersForTargetsQuery,
+  ): Promise<SchedulerWritersForTargetsResult> {
+    return this.session.writersForTargets({
+      ...query,
+      branch: this.branch,
+    });
+  }
+
+  watchAddSync(watches: WatchSpec[]): Promise<{
+    view: MemoryClient.WatchView;
+    sync: SessionSync;
+  }> {
+    let result!: { view: MemoryClient.WatchView; sync: SessionSync };
+    this.#mutation = this.#mutation.then(async () => {
+      if (this.#closed) throw new Error("executor provider session closed");
+      for (const watch of watches) this.#watches.set(watch.id, watch);
+      const fromSeq = this.#appliedSeq;
+      await this.refreshWatches(watches.map((watch) => watch.id));
+      const sync = this.fullSync(fromSeq, this.#appliedSeq);
+      if (this.#view === null) {
+        this.#view = MemoryClient.WatchView.fromSync(sync);
+      } else {
+        this.#view.applySync(sync, false);
+      }
+      result = { view: this.#view, sync };
+    });
+    return this.#mutation.then(() => result);
+  }
+
+  private async refreshAcceptedCommit(
+    notice: AcceptedCommitNotice,
+  ): Promise<void> {
+    if (
+      this.#closed || notice.space !== this.session.space ||
+      notice.branch !== this.branch || notice.seq <= this.#appliedSeq ||
+      this.#watches.size === 0
+    ) {
+      return;
+    }
+    const dirty = new Set(notice.revisions.map(snapshotKey));
+    const affected: string[] = [];
+    for (const [watchId, watch] of this.#watches) {
+      const previous = this.#watchEntities.get(watchId);
+      const rootDirty = watch.query.roots.some((root) =>
+        dirty.has(snapshotKey({
+          branch: this.branch,
+          id: root.id,
+          scope: root.scope,
+        }))
+      );
+      const trackedDirty = previous !== undefined &&
+        [...previous.keys()].some((key) => dirty.has(key));
+      if (rootDirty || trackedDirty) affected.push(watchId);
+    }
+    if (affected.length === 0) {
+      this.#appliedSeq = notice.seq;
+      return;
+    }
+
+    const before = this.allEntities();
+    const fromSeq = this.#appliedSeq;
+    await this.refreshWatches(affected, notice.seq);
+    this.#appliedSeq = notice.seq;
+    const after = this.allEntities();
+    const sync: SessionSync = {
+      type: "sync",
+      fromSeq,
+      toSeq: notice.seq,
+      upserts: [...after.values()].map(syncUpsert),
+      removes: [...before.values()]
+        .filter((snapshot) => !after.has(snapshotKey(snapshot)))
+        .map((snapshot) => ({
+          branch: snapshot.branch,
+          id: snapshot.id,
+          ...(snapshot.scope !== undefined ? { scope: snapshot.scope } : {}),
+        })),
+    };
+    this.#view?.applySync(sync, true);
+  }
+
+  private async refreshWatches(
+    watchIds: readonly string[],
+    atSeq?: number,
+  ): Promise<void> {
+    for (const watchId of watchIds) {
+      const watch = this.#watches.get(watchId);
+      if (watch === undefined) continue;
+      const result = await this.queryGraph({
+        ...watch.query,
+        ...(atSeq !== undefined ? { atSeq } : {}),
+      });
+      if (atSeq === undefined) {
+        this.#appliedSeq = Math.max(this.#appliedSeq, result.serverSeq);
+      }
+      this.#watchEntities.set(
+        watchId,
+        new Map(result.entities.map((snapshot) => [
+          snapshotKey(snapshot),
+          snapshot,
+        ])),
+      );
+    }
+  }
+
+  private allEntities(): Map<string, EntitySnapshot> {
+    const entities = new Map<string, EntitySnapshot>();
+    for (const snapshots of this.#watchEntities.values()) {
+      for (const [key, snapshot] of snapshots) {
+        const previous = entities.get(key);
+        if (previous === undefined || previous.seq <= snapshot.seq) {
+          entities.set(key, snapshot);
+        }
+      }
+    }
+    return entities;
+  }
+
+  private fullSync(fromSeq: number, toSeq: number): SessionSync {
+    return {
+      type: "sync",
+      fromSeq,
+      toSeq,
+      upserts: [...this.allEntities().values()].map(syncUpsert),
+      removes: [],
+    };
+  }
+}
+
 class HostSessionFactory implements SessionFactory {
   constructor(
     private readonly port: MessagePort,
     private readonly space: MemorySpace,
+    private readonly branch: BranchName,
   ) {}
 
   async create(
@@ -317,11 +621,13 @@ class HostSessionFactory implements SessionFactory {
     if (space !== this.space) {
       throw new Error(`executor provider is bound to ${this.space}`);
     }
-    const client = await MemoryClient.connect({
-      transport: new MessagePortTransport(this.port),
-    });
+    const transport = new MessagePortTransport(this.port);
+    const client = await MemoryClient.connect({ transport });
     const session = await client.mount(space, mountOptions);
-    return { client, session };
+    return {
+      client,
+      session: new HostReplicaSession(session, transport, this.branch),
+    };
   }
 }
 
@@ -343,6 +649,7 @@ export interface HostStorageManagerOptions {
   port: MessagePort;
   principal: MemorySpace;
   space: MemorySpace;
+  branch?: BranchName;
   id?: string;
   settings?: Options["settings"];
 }
@@ -359,7 +666,11 @@ export class HostStorageManager extends StorageManager {
         // The host channel is already pinned to the memory Server.
         memoryHost: new URL("memory://executor-provider"),
       },
-      new HostSessionFactory(options.port, options.space),
+      new HostSessionFactory(
+        options.port,
+        options.space,
+        options.branch ?? "",
+      ),
     );
   }
 }

--- a/packages/runner/src/storage/v2-host-provider.ts
+++ b/packages/runner/src/storage/v2-host-provider.ts
@@ -8,6 +8,7 @@ import {
   type HelloOkMessage,
   type ResponseMessage,
   type SchedulerActionSnapshotQuery,
+  type SchedulerActionSnapshotResult,
   type SchedulerSnapshotListResult,
   type SchedulerWritersForTargetsQuery,
   type SchedulerWritersForTargetsResult,
@@ -26,7 +27,6 @@ import {
   parseClientMessage,
   type Server,
 } from "@commonfabric/memory/v2/server";
-import type { AppliedCommit } from "@commonfabric/memory/v2/engine";
 import type { BranchName } from "@commonfabric/memory/v2";
 import { type Options, type SessionFactory, StorageManager } from "./v2.ts";
 import type { ReplicaSession } from "./v2-replica-session.ts";
@@ -34,7 +34,9 @@ import type { ReplicaSession } from "./v2-replica-session.ts";
 interface AcceptedCommitNotice {
   space: string;
   branch: BranchName;
-  seq: number;
+  order: number;
+  dataSeq: number;
+  deliverySeq: number;
   originSessionId?: string;
   revisions: {
     branch: BranchName;
@@ -89,7 +91,9 @@ const toAcceptedCommitNotice = (
 ): AcceptedCommitNotice => ({
   space: event.space,
   branch: event.commit.branch,
-  seq: event.commit.seq,
+  order: event.order,
+  dataSeq: event.commit.seq,
+  deliverySeq: event.deliverySeq,
   ...(event.originSessionId !== undefined
     ? { originSessionId: event.originSessionId }
     : {}),
@@ -417,6 +421,9 @@ class HostReplicaSession implements ReplicaSession {
   #view: MemoryClient.WatchView | null = null;
   #mutation = Promise.resolve();
   #appliedSeq: number;
+  #acceptedOrder = 0;
+  #schedulerDeliverySeq: number;
+  #seenObservationIds = new Set<number>();
   #closed = false;
 
   constructor(
@@ -425,11 +432,20 @@ class HostReplicaSession implements ReplicaSession {
     private readonly branch: BranchName,
   ) {
     this.#appliedSeq = session.serverSeq;
+    this.#schedulerDeliverySeq = session.serverSeq;
     transport.setAcceptedCommitReceiver((notice) => {
-      this.#mutation = this.#mutation.then(
+      const refresh = this.#mutation.then(
         () => this.refreshAcceptedCommit(notice),
         () => this.refreshAcceptedCommit(notice),
       );
+      this.#mutation = refresh.catch((error) => {
+        if (
+          !(error instanceof Error) ||
+          !error.message.includes("memory session closed")
+        ) {
+          console.warn("executor accepted-commit refresh failed", error);
+        }
+      });
     });
   }
 
@@ -445,7 +461,7 @@ class HostReplicaSession implements ReplicaSession {
     return this.session.serverSeq;
   }
 
-  transact(commit: ClientCommit): Promise<AppliedCommit> {
+  transact(commit: ClientCommit) {
     return this.session.transact({ ...commit, branch: this.branch });
   }
 
@@ -468,13 +484,23 @@ class HostReplicaSession implements ReplicaSession {
     return this.session.registerSqliteDiskSource(id, path);
   }
 
-  listSchedulerActionSnapshots(
+  async listSchedulerActionSnapshots(
     query: SchedulerActionSnapshotQuery = {},
   ): Promise<SchedulerSnapshotListResult> {
-    return this.session.listSchedulerActionSnapshots({
+    const result = await this.session.listSchedulerActionSnapshots({
       ...query,
       branch: this.branch,
     });
+    for (const snapshot of result.snapshots) {
+      this.#seenObservationIds.add(snapshot.observationId);
+      if (snapshot.commitSeq !== null) {
+        this.#schedulerDeliverySeq = Math.max(
+          this.#schedulerDeliverySeq,
+          snapshot.commitSeq,
+        );
+      }
+    }
+    return result;
   }
 
   writersForTargets(
@@ -512,9 +538,17 @@ class HostReplicaSession implements ReplicaSession {
   ): Promise<void> {
     if (
       this.#closed || notice.space !== this.session.space ||
-      notice.branch !== this.branch || notice.seq <= this.#appliedSeq ||
-      this.#watches.size === 0
+      notice.branch !== this.branch || notice.order <= this.#acceptedOrder
     ) {
+      return;
+    }
+    const fromSeq = this.#appliedSeq;
+    const observations = notice.originSessionId === this.sessionId
+      ? []
+      : await this.adoptionObservations(notice.deliverySeq);
+    if (this.#watches.size === 0) {
+      this.#acceptedOrder = notice.order;
+      this.#appliedSeq = Math.max(this.#appliedSeq, notice.dataSeq);
       return;
     }
     const dirty = new Set(notice.revisions.map(snapshotKey));
@@ -532,20 +566,31 @@ class HostReplicaSession implements ReplicaSession {
         [...previous.keys()].some((key) => dirty.has(key));
       if (rootDirty || trackedDirty) affected.push(watchId);
     }
-    if (affected.length === 0) {
-      this.#appliedSeq = notice.seq;
+    if (notice.dataSeq <= this.#appliedSeq || affected.length === 0) {
+      this.#acceptedOrder = notice.order;
+      this.#appliedSeq = Math.max(this.#appliedSeq, notice.dataSeq);
+      if (observations.length > 0) {
+        this.#view?.applySync({
+          type: "sync",
+          fromSeq,
+          toSeq: this.#appliedSeq,
+          upserts: [],
+          removes: [],
+          observations,
+        }, true);
+      }
       return;
     }
 
     const before = this.allEntities();
-    const fromSeq = this.#appliedSeq;
-    await this.refreshWatches(affected, notice.seq);
-    this.#appliedSeq = notice.seq;
+    await this.refreshWatches(affected, notice.dataSeq);
+    this.#acceptedOrder = notice.order;
+    this.#appliedSeq = Math.max(this.#appliedSeq, notice.dataSeq);
     const after = this.allEntities();
     const sync: SessionSync = {
       type: "sync",
       fromSeq,
-      toSeq: notice.seq,
+      toSeq: this.#appliedSeq,
       upserts: [...after.values()].map(syncUpsert),
       removes: [...before.values()]
         .filter((snapshot) => !after.has(snapshotKey(snapshot)))
@@ -554,8 +599,39 @@ class HostReplicaSession implements ReplicaSession {
           id: snapshot.id,
           ...(snapshot.scope !== undefined ? { scope: snapshot.scope } : {}),
         })),
+      ...(observations.length > 0 ? { observations } : {}),
     };
     this.#view?.applySync(sync, true);
+  }
+
+  private async adoptionObservations(
+    throughSeq: number,
+  ): Promise<SchedulerActionSnapshotResult[]> {
+    const snapshots: SchedulerActionSnapshotResult[] = [];
+    const sinceCommitSeq = throughSeq <= this.#schedulerDeliverySeq
+      ? Math.max(-1, throughSeq - 1)
+      : this.#schedulerDeliverySeq;
+    let cursor: SchedulerActionSnapshotQuery["cursor"];
+    do {
+      const page = await this.session.listSchedulerActionSnapshots({
+        branch: this.branch,
+        sinceCommitSeq,
+        throughCommitSeq: throughSeq,
+        limit: 1_000,
+        ...(cursor !== undefined ? { cursor } : {}),
+      });
+      for (const snapshot of page.snapshots) {
+        if (this.#seenObservationIds.has(snapshot.observationId)) continue;
+        this.#seenObservationIds.add(snapshot.observationId);
+        snapshots.push(snapshot);
+      }
+      cursor = page.nextCursor;
+    } while (cursor !== undefined);
+    this.#schedulerDeliverySeq = Math.max(
+      this.#schedulerDeliverySeq,
+      throughSeq,
+    );
+    return snapshots;
   }
 
   private async refreshWatches(

--- a/packages/runner/src/storage/v2-host-provider.ts
+++ b/packages/runner/src/storage/v2-host-provider.ts
@@ -1,0 +1,365 @@
+import type { MemorySpace, Signer } from "@commonfabric/memory/interface";
+import {
+  encodeMemoryBoundary,
+  type HelloOkMessage,
+  type ResponseMessage,
+  type SessionOpenRequest,
+  type V2Error,
+} from "@commonfabric/memory/v2";
+import * as MemoryClient from "@commonfabric/memory/v2/client";
+import {
+  parseClientMessage,
+  type Server,
+} from "@commonfabric/memory/v2/server";
+import type { BranchName } from "@commonfabric/memory/v2";
+import { type Options, type SessionFactory, StorageManager } from "./v2.ts";
+
+type ProviderPortMessage =
+  | { type: "memory"; payload: string }
+  | { type: "close"; message?: string };
+
+export interface HostProviderChannelOptions {
+  server: Server;
+  space: MemorySpace;
+  branch?: BranchName;
+  /** Host-owned grant creation. This callback and its credentials never cross
+   *  the MessagePort into the Worker. */
+  authorizeSessionOpen: MemoryClient.SessionOpenAuthFactory;
+}
+
+export interface HostProviderChannel {
+  /** Opaque endpoint transferred to the executor Worker. */
+  readonly port: MessagePort;
+  dispose(): Promise<void>;
+}
+
+const responseError = (
+  requestId: string,
+  name: string,
+  message: string,
+): ResponseMessage<never> => ({
+  type: "response",
+  requestId,
+  error: { name, message },
+});
+
+const requestIdOf = (message: unknown): string =>
+  typeof message === "object" && message !== null &&
+    "requestId" in message &&
+    typeof (message as { requestId?: unknown }).requestId === "string"
+    ? (message as { requestId: string }).requestId
+    : "host-provider";
+
+const messageSpace = (message: ReturnType<typeof parseClientMessage>) =>
+  message !== null && "space" in message ? message.space : undefined;
+
+/**
+ * Normalize every branch-bearing request onto the host-owned lane. Messages
+ * without a branch surface (session lifecycle and SQLite v1) remain bound by
+ * the exact space and authenticated connection.
+ */
+const pinBranch = (
+  message: NonNullable<ReturnType<typeof parseClientMessage>>,
+  branch: BranchName,
+): NonNullable<ReturnType<typeof parseClientMessage>> => {
+  switch (message.type) {
+    case "transact":
+      return {
+        ...message,
+        commit: { ...message.commit, branch },
+      };
+    case "graph.query":
+      return {
+        ...message,
+        query: { ...message.query, branch },
+      };
+    case "scheduler.snapshot.list":
+      return {
+        ...message,
+        query: { ...message.query, branch },
+      };
+    case "scheduler.writer.list":
+      return {
+        ...message,
+        query: { ...message.query, branch },
+      };
+    case "session.watch.set":
+    case "session.watch.add":
+      return {
+        ...message,
+        watches: message.watches.map((watch) => ({
+          ...watch,
+          query: { ...watch.query, branch },
+        })),
+      };
+    default:
+      return message;
+  }
+};
+
+/**
+ * Create the host half of an executor provider. All memory frames still enter
+ * through Server.connect/Connection.receive, preserving handshake ordering,
+ * session ownership, ACL/CFC/conflict checks, and post-commit hooks. The host
+ * overwrites session.open authorization with its own grant callback.
+ */
+export function createHostProviderChannel(
+  options: HostProviderChannelOptions,
+): HostProviderChannel {
+  const channel = new MessageChannel();
+  const hostPort = channel.port1;
+  const branch = options.branch ?? "";
+  let authContext: MemoryClient.SessionOpenAuthContext | null = null;
+  let disposed = false;
+  let receiving = Promise.resolve();
+
+  const connection = options.server.connect((message) => {
+    if (disposed) return;
+    if (message.type === "hello.ok") {
+      const hello = message as HelloOkMessage;
+      if (hello.sessionOpen !== undefined) {
+        authContext = hello.sessionOpen;
+      }
+    }
+    hostPort.postMessage(
+      {
+        type: "memory",
+        payload: encodeMemoryBoundary(message),
+      } satisfies ProviderPortMessage,
+    );
+  });
+
+  const closeHost = (message?: string) => {
+    if (disposed) return;
+    disposed = true;
+    connection.close();
+    if (message !== undefined) {
+      try {
+        hostPort.postMessage(
+          { type: "close", message } satisfies ProviderPortMessage,
+        );
+      } catch {
+        // The Worker may already have closed its transferred endpoint.
+      }
+    }
+    hostPort.close();
+  };
+
+  const sendError = (requestId: string, error: V2Error) => {
+    if (disposed) return;
+    hostPort.postMessage(
+      {
+        type: "memory",
+        payload: encodeMemoryBoundary(
+          responseError(requestId, error.name, error.message),
+        ),
+      } satisfies ProviderPortMessage,
+    );
+  };
+
+  const receive = async (payload: string): Promise<void> => {
+    const parsed = parseClientMessage(payload);
+    if (parsed === null) {
+      // Let the canonical parser produce its normal InvalidMessageError.
+      await connection.receive(payload);
+      return;
+    }
+    const requestedSpace = messageSpace(parsed);
+    if (requestedSpace !== undefined && requestedSpace !== options.space) {
+      sendError(requestIdOf(parsed), {
+        name: "AuthorizationError",
+        message: `executor provider is bound to ${options.space}`,
+      });
+      return;
+    }
+    if (parsed.type === "session.open") {
+      if (authContext === null) {
+        sendError(parsed.requestId, {
+          name: "ProtocolError",
+          message: "executor provider has no active session challenge",
+        });
+        return;
+      }
+      let auth: MemoryClient.SessionOpenAuth | undefined;
+      try {
+        auth = await options.authorizeSessionOpen(
+          parsed.space,
+          parsed.session,
+          authContext,
+        );
+      } catch (error) {
+        sendError(parsed.requestId, {
+          name: "AuthorizationError",
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return;
+      }
+      if (auth === undefined) {
+        sendError(parsed.requestId, {
+          name: "AuthorizationError",
+          message: "executor provider host did not grant the session",
+        });
+        return;
+      }
+      const authenticated: SessionOpenRequest = {
+        ...parsed,
+        invocation: auth.invocation,
+        authorization: auth
+          .authorization as SessionOpenRequest["authorization"],
+      };
+      await connection.receive(encodeMemoryBoundary(authenticated));
+      return;
+    }
+    await connection.receive(encodeMemoryBoundary(pinBranch(parsed, branch)));
+  };
+
+  hostPort.addEventListener("message", (event: MessageEvent<unknown>) => {
+    const message = event.data as Partial<ProviderPortMessage>;
+    if (message.type === "close") {
+      closeHost();
+      return;
+    }
+    if (message.type !== "memory" || typeof message.payload !== "string") {
+      closeHost("invalid executor provider message");
+      return;
+    }
+    receiving = receiving.then(
+      () => receive(message.payload!),
+      () => receive(message.payload!),
+    ).catch((error) => {
+      closeHost(error instanceof Error ? error.message : String(error));
+    });
+  });
+  hostPort.addEventListener("messageerror", () => {
+    closeHost("executor provider message decoding failed");
+  });
+  hostPort.start();
+
+  return {
+    port: channel.port2,
+    async dispose() {
+      closeHost();
+      await receiving.catch(() => undefined);
+    },
+  };
+}
+
+class MessagePortTransport implements MemoryClient.Transport {
+  #receiver: (payload: string) => void = () => {};
+  #closeReceiver: (error?: Error) => void = () => {};
+  #closed = false;
+
+  constructor(private readonly port: MessagePort) {
+    port.addEventListener("message", (event: MessageEvent<unknown>) => {
+      const message = event.data as Partial<ProviderPortMessage>;
+      if (message.type === "memory" && typeof message.payload === "string") {
+        this.#receiver(message.payload);
+      } else if (message.type === "close") {
+        this.closeFromHost(message.message);
+      } else {
+        this.closeFromHost("invalid host provider message");
+      }
+    });
+    port.addEventListener("messageerror", () => {
+      this.closeFromHost("host provider message decoding failed");
+    });
+    port.start();
+  }
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(receiver: (error?: Error) => void): void {
+    this.#closeReceiver = receiver;
+  }
+
+  send(payload: string): Promise<void> {
+    if (this.#closed) {
+      return Promise.reject(new Error("executor provider transport closed"));
+    }
+    this.port.postMessage(
+      { type: "memory", payload } satisfies ProviderPortMessage,
+    );
+    return Promise.resolve();
+  }
+
+  close(): Promise<void> {
+    if (this.#closed) return Promise.resolve();
+    this.#closed = true;
+    try {
+      this.port.postMessage({ type: "close" } satisfies ProviderPortMessage);
+    } finally {
+      this.port.close();
+    }
+    return Promise.resolve();
+  }
+
+  private closeFromHost(message?: string): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.port.close();
+    this.#closeReceiver(new Error(message ?? "executor provider host closed"));
+  }
+}
+
+class HostSessionFactory implements SessionFactory {
+  constructor(
+    private readonly port: MessagePort,
+    private readonly space: MemorySpace,
+  ) {}
+
+  async create(
+    space: MemorySpace,
+    _signer?: Signer,
+    mountOptions: MemoryClient.MountOptions = {},
+  ) {
+    if (space !== this.space) {
+      throw new Error(`executor provider is bound to ${this.space}`);
+    }
+    const client = await MemoryClient.connect({
+      transport: new MessagePortTransport(this.port),
+    });
+    const session = await client.mount(space, mountOptions);
+    return { client, session };
+  }
+}
+
+const opaquePrincipal = (principal: MemorySpace): Signer => {
+  const unavailable = () => ({
+    error: new Error("executor provider principal has no Worker signing key"),
+  });
+  return {
+    did: () => principal,
+    sign: unavailable,
+    verifier: {
+      did: () => principal,
+      verify: unavailable,
+    },
+  } as Signer;
+};
+
+export interface HostStorageManagerOptions {
+  port: MessagePort;
+  principal: MemorySpace;
+  space: MemorySpace;
+  id?: string;
+  settings?: Options["settings"];
+}
+
+/** StorageManager construction available inside the executor Worker. */
+export class HostStorageManager extends StorageManager {
+  static connect(options: HostStorageManagerOptions): HostStorageManager {
+    const as = opaquePrincipal(options.principal);
+    return new HostStorageManager(
+      {
+        as,
+        id: options.id,
+        settings: options.settings,
+        // The host channel is already pinned to the memory Server.
+        memoryHost: new URL("memory://executor-provider"),
+      },
+      new HostSessionFactory(options.port, options.space),
+    );
+  }
+}

--- a/packages/runner/src/storage/v2-host-provider.ts
+++ b/packages/runner/src/storage/v2-host-provider.ts
@@ -307,9 +307,14 @@ export function createHostProviderChannel(
 
   return {
     port: channel.port2,
-    async dispose() {
+    dispose() {
       closeHost();
-      await receiving.catch(() => undefined);
+      // Connection.close detaches the authenticated session and suppresses any
+      // late response. A read already executing inside the Server may still
+      // unwind, but disposal must not wait for that non-cancellable work or a
+      // terminated Worker could strand its host lease/channel indefinitely.
+      void receiving.catch(() => undefined);
+      return Promise.resolve();
     },
   };
 }

--- a/packages/runner/src/storage/v2-host-provider.ts
+++ b/packages/runner/src/storage/v2-host-provider.ts
@@ -44,6 +44,7 @@ interface AcceptedCommitNotice {
     scope?: string;
     seq: number;
   }[];
+  schedulerUpdateIds: number[];
 }
 
 type ProviderPortMessage =
@@ -90,19 +91,20 @@ const toAcceptedCommitNotice = (
   event: AcceptedCommitEvent,
 ): AcceptedCommitNotice => ({
   space: event.space,
-  branch: event.commit.branch,
+  branch: event.branch,
   order: event.order,
-  dataSeq: event.commit.seq,
+  dataSeq: event.dataSeq,
   deliverySeq: event.deliverySeq,
   ...(event.originSessionId !== undefined
     ? { originSessionId: event.originSessionId }
     : {}),
-  revisions: event.commit.revisions.map((revision) => ({
+  revisions: event.revisions.map((revision) => ({
     branch: revision.branch,
     id: revision.id,
     ...(revision.scope !== undefined ? { scope: revision.scope } : {}),
     seq: revision.seq,
   })),
+  schedulerUpdateIds: [...event.schedulerUpdateIds],
 });
 
 /**
@@ -187,14 +189,15 @@ export function createHostProviderChannel(
     disposed = true;
     unsubscribeAcceptedCommits();
     connection.close();
-    if (message !== undefined) {
-      try {
-        hostPort.postMessage(
-          { type: "close", message } satisfies ProviderPortMessage,
-        );
-      } catch {
-        // The Worker may already have closed its transferred endpoint.
-      }
+    try {
+      hostPort.postMessage(
+        {
+          type: "close",
+          ...(message !== undefined ? { message } : {}),
+        } satisfies ProviderPortMessage,
+      );
+    } catch {
+      // The Worker may already have closed its transferred endpoint.
     }
     hostPort.close();
   };
@@ -295,7 +298,7 @@ export function createHostProviderChannel(
   unsubscribeAcceptedCommits = options.server.subscribeAcceptedCommits(
     options.space,
     (event) => {
-      if (disposed || event.commit.branch !== branch) return;
+      if (disposed || event.branch !== branch) return;
       hostPort.postMessage(
         {
           type: "accepted-commit",
@@ -405,6 +408,11 @@ const snapshotKey = (snapshot: {
 }): string =>
   `${snapshot.branch}\0${snapshot.scope ?? "space"}\0${snapshot.id}`;
 
+const dirtyEntityKey = (snapshot: {
+  id: string;
+  scope?: string;
+}): string => `${snapshot.scope ?? "space"}\0${snapshot.id}`;
+
 const syncUpsert = (snapshot: EntitySnapshot) => ({
   branch: snapshot.branch,
   id: snapshot.id,
@@ -428,7 +436,7 @@ class HostReplicaSession implements ReplicaSession {
   #appliedSeq: number;
   #acceptedOrder = 0;
   #schedulerDeliverySeq: number;
-  #seenObservationIds = new Set<number>();
+  #seenObservationVersions = new Map<number, string>();
   #closed = false;
 
   constructor(
@@ -523,7 +531,10 @@ class HostReplicaSession implements ReplicaSession {
       branch: this.branch,
     });
     for (const snapshot of result.snapshots) {
-      this.#seenObservationIds.add(snapshot.observationId);
+      this.#seenObservationVersions.set(
+        snapshot.observationId,
+        encodeMemoryBoundary(snapshot),
+      );
       if (snapshot.commitSeq !== null) {
         this.#schedulerDeliverySeq = Math.max(
           this.#schedulerDeliverySeq,
@@ -574,27 +585,41 @@ class HostReplicaSession implements ReplicaSession {
       return;
     }
     const fromSeq = this.#appliedSeq;
-    const observations = notice.originSessionId === this.sessionId
-      ? []
-      : await this.adoptionObservations(notice.deliverySeq);
+    let observations: SchedulerActionSnapshotResult[] = [];
+    if (
+      notice.originSessionId !== this.sessionId &&
+      notice.schedulerUpdateIds.length > 0
+    ) {
+      try {
+        observations = await this.adoptionObservations(
+          notice.deliverySeq,
+          new Set(notice.schedulerUpdateIds),
+        );
+      } catch (error) {
+        // Scheduler adoption is optional. Keep its cursor unchanged and still
+        // deliver the required document invalidation for this accepted commit.
+        console.warn("executor scheduler adoption failed", error);
+      }
+    }
     if (this.#watches.size === 0) {
       this.#acceptedOrder = notice.order;
       this.#appliedSeq = Math.max(this.#appliedSeq, notice.dataSeq);
       return;
     }
-    const dirty = new Set(notice.revisions.map(snapshotKey));
+    const dirty = new Set(notice.revisions.map(dirtyEntityKey));
     const affected: string[] = [];
     for (const [watchId, watch] of this.#watches) {
       const previous = this.#watchEntities.get(watchId);
       const rootDirty = watch.query.roots.some((root) =>
-        dirty.has(snapshotKey({
-          branch: this.branch,
+        dirty.has(dirtyEntityKey({
           id: root.id,
           scope: root.scope,
         }))
       );
       const trackedDirty = previous !== undefined &&
-        [...previous.keys()].some((key) => dirty.has(key));
+        [...previous.values()].some((snapshot) =>
+          dirty.has(dirtyEntityKey(snapshot))
+        );
       if (rootDirty || trackedDirty) affected.push(watchId);
     }
     if (notice.dataSeq <= this.#appliedSeq || affected.length === 0) {
@@ -637,8 +662,10 @@ class HostReplicaSession implements ReplicaSession {
 
   private async adoptionObservations(
     throughSeq: number,
+    allowedObservationIds: ReadonlySet<number>,
   ): Promise<SchedulerActionSnapshotResult[]> {
     const snapshots: SchedulerActionSnapshotResult[] = [];
+    const nextVersions = new Map<number, string>();
     const sinceCommitSeq = throughSeq <= this.#schedulerDeliverySeq
       ? Math.max(-1, throughSeq - 1)
       : this.#schedulerDeliverySeq;
@@ -652,12 +679,19 @@ class HostReplicaSession implements ReplicaSession {
         ...(cursor !== undefined ? { cursor } : {}),
       });
       for (const snapshot of page.snapshots) {
-        if (this.#seenObservationIds.has(snapshot.observationId)) continue;
-        this.#seenObservationIds.add(snapshot.observationId);
+        if (!allowedObservationIds.has(snapshot.observationId)) continue;
+        const version = encodeMemoryBoundary(snapshot);
+        if (
+          this.#seenObservationVersions.get(snapshot.observationId) === version
+        ) continue;
+        nextVersions.set(snapshot.observationId, version);
         snapshots.push(snapshot);
       }
       cursor = page.nextCursor;
     } while (cursor !== undefined);
+    for (const [observationId, version] of nextVersions) {
+      this.#seenObservationVersions.set(observationId, version);
+    }
     this.#schedulerDeliverySeq = Math.max(
       this.#schedulerDeliverySeq,
       throughSeq,
@@ -730,6 +764,13 @@ class HostSessionFactory implements SessionFactory {
     }
     const transport = new MessagePortTransport(this.port);
     const client = await MemoryClient.connect({ transport });
+    // This transferred channel is a lease-bound one-shot transport, not a
+    // reconnectable network endpoint. A host close is terminal: close the
+    // client so pending requests reject without starting the generic memory
+    // client's reconnect loop against an already-disposed MessagePort.
+    transport.setCloseReceiver(() => {
+      void client.close().catch(() => undefined);
+    });
     const session = await client.mount(space, mountOptions);
     return {
       client,

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -3,6 +3,7 @@ import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { type MemorySpace, type Signer } from "@commonfabric/memory/interface";
 import * as MemoryClient from "@commonfabric/memory/v2/client";
 import { MEMORY_PROTOCOL } from "@commonfabric/memory/v2";
+import type { ReplicaSessionHandle } from "./v2-replica-session.ts";
 
 export interface SessionFactory {
   /** Opt in to StorageManager's ACL genesis handshake. Scripted factories used
@@ -13,10 +14,7 @@ export interface SessionFactory {
     space: MemorySpace,
     signer?: Signer,
     mountOptions?: MemoryClient.MountOptions,
-  ): Promise<{
-    client: MemoryClient.Client;
-    session: MemoryClient.SpaceSession;
-  }>;
+  ): Promise<ReplicaSessionHandle>;
 }
 
 export const toWebSocketAddress = (address: URL): URL => {

--- a/packages/runner/src/storage/v2-replica-session.ts
+++ b/packages/runner/src/storage/v2-replica-session.ts
@@ -1,0 +1,66 @@
+import type {
+  ClientCommit,
+  GraphQuery,
+  GraphQueryResult,
+  MemoryProtocolFlags,
+  SchedulerActionSnapshotQuery,
+  SchedulerSnapshotListResult,
+  SchedulerWritersForTargetsQuery,
+  SchedulerWritersForTargetsResult,
+  SessionSync,
+  SqliteDbRef,
+  SqliteParamsWire,
+  SqliteQueryResult,
+  SqliteRegisterDiskSourceResult,
+  WatchSpec,
+} from "@commonfabric/memory/v2";
+import type { AppliedCommit } from "@commonfabric/memory/v2/engine";
+
+/** Worker-local view of a replica update stream. */
+export interface ReplicaWatchView {
+  close(): void;
+  subscribeSync(): AsyncIterator<SessionSync>;
+}
+
+/**
+ * The authenticated storage operations SpaceReplica needs from its backend.
+ * Remote memory sessions and the executor MessagePort backend both implement
+ * this interface; the synchronous replica/cache remains in the Worker.
+ */
+export interface ReplicaSession {
+  readonly sessionId: string;
+  readonly sessionToken: string | undefined;
+  readonly serverSeq: number;
+  transact(commit: ClientCommit): Promise<AppliedCommit>;
+  queryGraph(query: GraphQuery): Promise<GraphQueryResult>;
+  watchAddSync(watches: WatchSpec[]): Promise<{
+    view: ReplicaWatchView;
+    sync: SessionSync;
+  }>;
+  sqliteQuery(
+    db: SqliteDbRef,
+    sql: string,
+    params?: SqliteParamsWire,
+  ): Promise<SqliteQueryResult>;
+  registerSqliteDiskSource(
+    id: string,
+    path: string,
+  ): Promise<SqliteRegisterDiskSourceResult>;
+  listSchedulerActionSnapshots(
+    query?: SchedulerActionSnapshotQuery,
+  ): Promise<SchedulerSnapshotListResult>;
+  writersForTargets(
+    query: SchedulerWritersForTargetsQuery,
+  ): Promise<SchedulerWritersForTargetsResult>;
+}
+
+/** Connection lifecycle and negotiated capabilities used by SpaceReplica. */
+export interface ReplicaClient {
+  readonly serverFlags: MemoryProtocolFlags | null;
+  close(): Promise<void>;
+}
+
+export interface ReplicaSessionHandle {
+  client: ReplicaClient;
+  session: ReplicaSession;
+}

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -135,9 +135,20 @@ import {
 } from "./v2-remote-session.ts";
 import * as V2Transaction from "./v2-transaction.ts";
 import { normalizeCellScope } from "../scope.ts";
+import type {
+  ReplicaClient,
+  ReplicaSessionHandle,
+  ReplicaWatchView,
+} from "./v2-replica-session.ts";
 
 export { watchIdForEntry } from "./v2-watch.ts";
 export type { SessionFactory } from "./v2-remote-session.ts";
+export type {
+  ReplicaClient,
+  ReplicaSession,
+  ReplicaSessionHandle,
+  ReplicaWatchView,
+} from "./v2-replica-session.ts";
 
 const logger = getLogger("storage.v2", {
   enabled: true,
@@ -851,10 +862,7 @@ export class StorageManager implements IStorageManager {
   async #createInitializedSession(
     space: MemorySpace,
     signer: Signer,
-  ): Promise<{
-    client: MemoryV2Client.Client;
-    session: MemoryV2Client.SpaceSession;
-  }> {
+  ): Promise<ReplicaSessionHandle> {
     const normal = await this.#sessionFactory.create(space, signer, {
       sessionId: this.#sessionId,
     });
@@ -1388,10 +1396,7 @@ type ProviderOptions = {
   space: MemorySpace;
   settings: IRemoteStorageProviderSettings;
   subscription: IStorageSubscription;
-  createSession: () => Promise<{
-    client: MemoryV2Client.Client;
-    session: MemoryV2Client.SpaceSession;
-  }>;
+  createSession: () => Promise<ReplicaSessionHandle>;
 };
 
 class Provider implements IStorageProviderWithReplica {
@@ -1543,17 +1548,11 @@ const docKey = (id: URI, scope?: CellScope): string =>
 class SpaceReplica implements ISpaceReplica {
   readonly #space: MemorySpace;
   readonly #subscription: IStorageSubscription;
-  readonly #createSession: () => Promise<{
-    client: MemoryV2Client.Client;
-    session: MemoryV2Client.SpaceSession;
-  }>;
-  #sessionHandle?: Promise<{
-    client: MemoryV2Client.Client;
-    session: MemoryV2Client.SpaceSession;
-  }>;
+  readonly #createSession: () => Promise<ReplicaSessionHandle>;
+  #sessionHandle?: Promise<ReplicaSessionHandle>;
   /** The client of the last RESOLVED session handle — for synchronous
    *  capability reads (`sqliteServerCommitRowLabelEval`). */
-  #sessionClient?: MemoryV2Client.Client;
+  #sessionClient?: ReplicaClient;
   readonly #docs = new Map<string, DocumentRecord>();
   readonly #syncTasks = new Map<string, SyncTask>();
   readonly #commitPromises = new Set<
@@ -1570,14 +1569,14 @@ class SpaceReplica implements ISpaceReplica {
     string,
     Set<(document: EntityDocument | undefined) => void>
   >();
-  #watchView: MemoryV2Client.WatchView | null = null;
+  #watchView: ReplicaWatchView | null = null;
   // The specific view instance that `consumeUpdates` is iterating. This can
   // diverge from `#watchView` (the client may hand back a fresh view instance
   // on a later refresh while the original consumer keeps running), so teardown
   // must close *this* view to settle the consumer's pending `next()`. Closing
   // only `#watchView` can leave the consumer's view open, hanging dispose() on
   // `Promise.allSettled([...#updatePromises])`.
-  #subscribedWatchView: MemoryV2Client.WatchView | null = null;
+  #subscribedWatchView: ReplicaWatchView | null = null;
   #watchSelectorTracker = new SelectorTracker<Result<Unit, PullError>>();
   #watchedIds = new Set<string>();
   #nextLocalSeq = 1;
@@ -1798,10 +1797,7 @@ class SpaceReplica implements ISpaceReplica {
     this.#sessionHandle = undefined;
     if (sessionHandle) {
       let resolved:
-        | {
-          client: MemoryV2Client.Client;
-          session: MemoryV2Client.SpaceSession;
-        }
+        | ReplicaSessionHandle
         | undefined;
       try {
         resolved = await sessionHandle;
@@ -3282,10 +3278,7 @@ class SpaceReplica implements ISpaceReplica {
     return false;
   }
 
-  private sessionHandle(): Promise<{
-    client: MemoryV2Client.Client;
-    session: MemoryV2Client.SpaceSession;
-  }> {
+  private sessionHandle(): Promise<ReplicaSessionHandle> {
     if (this.#sessionHandle === undefined) {
       // Defer the factory call until after #sessionHandle is installed. Session
       // setup can synchronously re-enter provider work (notably home-space ACL

--- a/packages/runner/test/executor-provider-parity.test.ts
+++ b/packages/runner/test/executor-provider-parity.test.ts
@@ -23,6 +23,30 @@ class WatchCountingServer extends Server {
   }
 }
 
+class GatedGraphServer extends WatchCountingServer {
+  graphQueryStarted = Promise.withResolvers<void>();
+  releaseGraphQuery = Promise.withResolvers<void>();
+  #gateNextGraphQuery = false;
+
+  gateNextGraphQuery(): void {
+    this.graphQueryStarted = Promise.withResolvers<void>();
+    this.releaseGraphQuery = Promise.withResolvers<void>();
+    this.#gateNextGraphQuery = true;
+  }
+
+  override async graphQuery(
+    message: Parameters<Server["graphQuery"]>[0],
+  ): ReturnType<Server["graphQuery"]> {
+    const response = await super.graphQuery(message);
+    if (this.#gateNextGraphQuery) {
+      this.#gateNextGraphQuery = false;
+      this.graphQueryStarted.resolve();
+      await this.releaseGraphQuery.promise;
+    }
+    return response;
+  }
+}
+
 Deno.test("executor host provider commits through authenticated memory without a Worker key", async () => {
   const hostSigner = await Identity.fromPassphrase(
     `executor host provider ${crypto.randomUUID()}`,
@@ -376,4 +400,120 @@ Deno.test("executor host provider source has no engine mutation bypass", async (
   assertEquals(source.includes("applyCommit"), false);
   assertEquals(source.includes("/v2/engine"), false);
   assertEquals(source.includes("this.session.watchAddSync"), false);
+});
+
+Deno.test("executor host provider closes the initial read and invalidation race", async () => {
+  const principal = await Identity.fromPassphrase(
+    "executor initial read race " + crypto.randomUUID(),
+  );
+  const space = principal.did();
+  const server = new GatedGraphServer({
+    authorizeSessionOpen(message) {
+      const value = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof value === "string" ? value : undefined;
+    },
+    sessionOpenAuth: {
+      audience: "did:key:z6Mk-executor-initial-race-test",
+    },
+  });
+  const authorizeSessionOpen: MemoryClient.SessionOpenAuthFactory = (
+    _space,
+    _session,
+    context,
+  ) => ({
+    invocation: {
+      aud: context.audience,
+      challenge: context.challenge.value,
+    },
+    authorization: { principal: principal.did() },
+  });
+  const writerClient = await MemoryClient.connect({
+    transport: MemoryClient.loopback(server),
+  });
+  const writer = await writerClient.mount(
+    space,
+    {},
+    authorizeSessionOpen,
+  );
+  const channel = createHostProviderChannel({
+    server,
+    space,
+    authorizeSessionOpen,
+  });
+  const storage = HostStorageManager.connect({
+    port: channel.port,
+    principal: principal.did(),
+    space,
+  });
+  const uri = "of:executor-provider:initial-race" as URI;
+  const address = {
+    id: uri,
+    type: "application/json" as MIME,
+    path: [],
+  };
+
+  try {
+    await writer.transact({
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: uri,
+        value: { value: { version: 1 } },
+      }],
+    });
+    const provider = storage.open(space);
+    const integrated = Promise.withResolvers<void>();
+    storage.subscribe({
+      next(notification) {
+        if (
+          notification.type === "integrate" &&
+          JSON.stringify(provider.replica.get(address)?.is) ===
+            JSON.stringify({ value: { version: 2 } })
+        ) {
+          integrated.resolve();
+        }
+        return { done: false };
+      },
+    });
+
+    server.gateNextGraphQuery();
+    const initialRead = provider.sync(uri);
+    await server.graphQueryStarted.promise;
+    await writer.transact({
+      localSeq: 2,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: uri,
+        value: { value: { version: 2 } },
+      }],
+    });
+    server.releaseGraphQuery.resolve();
+    assertEquals((await initialRead).error, undefined);
+
+    const timer = setTimeout(
+      () =>
+        integrated.reject(
+          new Error("commit racing the initial graph read was missed"),
+        ),
+      1_000,
+    );
+    try {
+      await integrated.promise;
+    } finally {
+      clearTimeout(timer);
+    }
+    assertEquals(provider.replica.get(address)?.is, {
+      value: { version: 2 },
+    });
+    assertEquals(server.watchAddCount, 0);
+  } finally {
+    server.releaseGraphQuery.resolve();
+    await storage.close();
+    await channel.dispose();
+    await writerClient.close();
+    await server.close();
+  }
 });

--- a/packages/runner/test/executor-provider-parity.test.ts
+++ b/packages/runner/test/executor-provider-parity.test.ts
@@ -1101,3 +1101,137 @@ Deno.test("executor host provider disposal releases callbacks and pending reads"
     await server.close();
   }
 });
+
+Deno.test("executor host provider transfers as an opaque channel to a real Worker", async () => {
+  const principal = await Identity.fromPassphrase(
+    "executor provider real worker " + crypto.randomUUID(),
+  );
+  const space = principal.did();
+  const server = new LifecycleServer({
+    authorizeSessionOpen(message) {
+      const value = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof value === "string" ? value : undefined;
+    },
+    sessionOpenAuth: {
+      audience: "did:key:z6Mk-executor-real-worker-test",
+    },
+  });
+  const authorizeSessionOpen: MemoryClient.SessionOpenAuthFactory = (
+    _space,
+    _session,
+    context,
+  ) => ({
+    invocation: {
+      aud: context.audience,
+      challenge: context.challenge.value,
+    },
+    authorization: { principal: principal.did() },
+  });
+  const writerClient = await MemoryClient.connect({
+    transport: MemoryClient.loopback(server),
+  });
+  const writer = await writerClient.mount(
+    space,
+    {},
+    authorizeSessionOpen,
+  );
+  const channel = createHostProviderChannel({
+    server,
+    space,
+    authorizeSessionOpen,
+  });
+  const worker = new Worker(
+    new URL(
+      "./fixtures/executor-provider-worker.ts",
+      import.meta.url,
+    ).href,
+    { type: "module" },
+  );
+  const queued: Record<string, unknown>[] = [];
+  const waiters: {
+    type: string;
+    pending: PromiseWithResolvers<Record<string, unknown>>;
+  }[] = [];
+  worker.addEventListener("message", (event: MessageEvent<unknown>) => {
+    const message = event.data as Record<string, unknown>;
+    if (message.type === "error") {
+      const error = new Error(String(message.message ?? "Worker failed"));
+      for (const waiter of waiters.splice(0)) {
+        waiter.pending.reject(error);
+      }
+      queued.push(message);
+      return;
+    }
+    const waiterIndex = waiters.findIndex((waiter) =>
+      waiter.type === message.type
+    );
+    if (waiterIndex === -1) {
+      queued.push(message);
+      return;
+    }
+    const [waiter] = waiters.splice(waiterIndex, 1);
+    waiter.pending.resolve(message);
+  });
+  worker.addEventListener("error", (event) => {
+    for (const waiter of waiters.splice(0)) {
+      waiter.pending.reject(event.error ?? new Error(event.message));
+    }
+  });
+  const nextMessage = (type: string): Promise<Record<string, unknown>> => {
+    const queuedIndex = queued.findIndex((message) => message.type === type);
+    if (queuedIndex !== -1) {
+      return Promise.resolve(queued.splice(queuedIndex, 1)[0]!);
+    }
+    const pending = Promise.withResolvers<Record<string, unknown>>();
+    waiters.push({ type, pending });
+    const timer = setTimeout(
+      () =>
+        pending.reject(
+          new Error(
+            "timed out waiting for Worker " + type + "; queued=" +
+              JSON.stringify(queued),
+          ),
+        ),
+      10_000,
+    );
+    return pending.promise.finally(() => clearTimeout(timer));
+  };
+
+  try {
+    await nextMessage("booted");
+    worker.postMessage({
+      type: "init",
+      port: channel.port,
+      principal: principal.did(),
+      space,
+    }, [channel.port]);
+    await nextMessage("committed");
+    assertEquals(
+      await server.readDocument(space, "of:executor-provider:worker"),
+      { value: { version: 1, realm: "worker" } },
+    );
+
+    await writer.transact({
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: "of:executor-provider:worker",
+        value: { value: { version: 2, realm: "external" } },
+      }],
+    });
+    await nextMessage("integrated");
+
+    worker.postMessage({ type: "dispose" });
+    await nextMessage("disposed");
+    await channel.dispose();
+    assertEquals(server.acceptedCommitSubscriptions, 0);
+    assertEquals(queued.find((message) => message.type === "error"), undefined);
+  } finally {
+    worker.terminate();
+    await channel.dispose();
+    await writerClient.close();
+    await server.close();
+  }
+});

--- a/packages/runner/test/executor-provider-parity.test.ts
+++ b/packages/runner/test/executor-provider-parity.test.ts
@@ -1,10 +1,24 @@
 import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
+import type { MIME, URI } from "@commonfabric/memory/interface";
+import * as MemoryClient from "@commonfabric/memory/v2/client";
 import { Server } from "@commonfabric/memory/v2/server";
+import type { StorageNotification } from "../src/storage/interface.ts";
 import {
   createHostProviderChannel,
   HostStorageManager,
 } from "../src/storage/v2-host-provider.ts";
+
+class WatchCountingServer extends Server {
+  watchAddCount = 0;
+
+  override async watchAdd(
+    message: Parameters<Server["watchAdd"]>[0],
+  ): ReturnType<Server["watchAdd"]> {
+    this.watchAddCount++;
+    return await super.watchAdd(message);
+  }
+}
 
 Deno.test("executor host provider commits through authenticated memory without a Worker key", async () => {
   const hostSigner = await Identity.fromPassphrase(
@@ -64,6 +78,118 @@ Deno.test("executor host provider commits through authenticated memory without a
   } finally {
     await storage.close();
     await channel.dispose();
+    await server.close();
+  }
+});
+
+Deno.test("executor host provider refreshes from accepted commits without memory watches", async () => {
+  const principal = await Identity.fromPassphrase(
+    `executor invalidation provider ${crypto.randomUUID()}`,
+  );
+  const space = principal.did();
+  const server = new WatchCountingServer({
+    authorizeSessionOpen(message) {
+      const value = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof value === "string" ? value : undefined;
+    },
+    sessionOpenAuth: {
+      audience: "did:key:z6Mk-executor-invalidation-test",
+    },
+  });
+  const authorizeSessionOpen: MemoryClient.SessionOpenAuthFactory = (
+    _space,
+    _session,
+    context,
+  ) => ({
+    invocation: {
+      aud: context.audience,
+      challenge: context.challenge.value,
+    },
+    authorization: { principal: principal.did() },
+  });
+  const writerClient = await MemoryClient.connect({
+    transport: MemoryClient.loopback(server),
+  });
+  const writer = await writerClient.mount(
+    space,
+    {},
+    authorizeSessionOpen,
+  );
+  const channel = createHostProviderChannel({
+    server,
+    space,
+    authorizeSessionOpen,
+  });
+  const storage = HostStorageManager.connect({
+    port: channel.port,
+    principal: principal.did(),
+    space,
+  });
+  const uri = "of:executor-provider:external" as URI;
+  const address = {
+    id: uri,
+    type: "application/json" as MIME,
+    path: [],
+  };
+
+  try {
+    await writer.transact({
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: uri,
+        value: { value: { version: 1 } },
+      }],
+    });
+    const provider = storage.open(space);
+    assertEquals((await provider.sync(uri)).error, undefined);
+    assertEquals(server.watchAddCount, 0);
+    assertEquals(provider.replica.get(address)?.is, {
+      value: { version: 1 },
+    });
+
+    const integrated = Promise.withResolvers<void>();
+    storage.subscribe({
+      next(notification: StorageNotification) {
+        if (
+          notification.type === "integrate" &&
+          provider.replica.get(address)?.is !== undefined &&
+          JSON.stringify(provider.replica.get(address)?.is) ===
+            JSON.stringify({ value: { version: 2 } })
+        ) {
+          integrated.resolve();
+        }
+        return { done: false };
+      },
+    });
+
+    await writer.transact({
+      localSeq: 2,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: uri,
+        value: { value: { version: 2 } },
+      }],
+    });
+    const timer = setTimeout(
+      () => integrated.reject(new Error("accepted commit was not integrated")),
+      1_000,
+    );
+    try {
+      await integrated.promise;
+    } finally {
+      clearTimeout(timer);
+    }
+    assertEquals(provider.replica.get(address)?.is, {
+      value: { version: 2 },
+    });
+  } finally {
+    await storage.close();
+    await channel.dispose();
+    await writerClient.close();
     await server.close();
   }
 });

--- a/packages/runner/test/executor-provider-parity.test.ts
+++ b/packages/runner/test/executor-provider-parity.test.ts
@@ -1,4 +1,5 @@
 import { assert, assertEquals } from "@std/assert";
+import { toFileUrl } from "@std/path";
 import { Identity } from "@commonfabric/identity";
 import type {
   MemorySpace,
@@ -7,6 +8,8 @@ import type {
   URI,
 } from "@commonfabric/memory/interface";
 import * as MemoryClient from "@commonfabric/memory/v2/client";
+import * as MemoryEngine from "@commonfabric/memory/v2/engine";
+import { resolveSpaceStoreUrl } from "@commonfabric/memory/v2/storage-path";
 import {
   type AcceptedCommitEvent,
   type AcceptedCommitListener,
@@ -38,6 +41,27 @@ class WatchCountingServer extends Server {
   ): ReturnType<Server["watchAdd"]> {
     this.watchAddCount++;
     return await super.watchAdd(message);
+  }
+}
+
+class FailingSchedulerListServer extends WatchCountingServer {
+  failNextSchedulerList = false;
+
+  override listSchedulerActionSnapshots(
+    message: Parameters<Server["listSchedulerActionSnapshots"]>[0],
+  ): ReturnType<Server["listSchedulerActionSnapshots"]> {
+    if (this.failNextSchedulerList) {
+      this.failNextSchedulerList = false;
+      return Promise.resolve({
+        type: "response",
+        requestId: message.requestId,
+        error: {
+          name: "QueryError",
+          message: "injected scheduler adoption failure",
+        },
+      });
+    }
+    return super.listSchedulerActionSnapshots(message);
   }
 }
 
@@ -122,6 +146,63 @@ class LoopbackStorageManager extends StorageManager {
   }
 }
 
+const schedulerObservationFor = (space: MemorySpace, actionId: string) => ({
+  version: 2,
+  ownerSpace: space,
+  branch: "",
+  pieceId: "space:of:executor-provider:echo-piece",
+  processGeneration: 1,
+  actionId,
+  actionKind: "computation",
+  implementationFingerprint: "impl:executor-provider-echo",
+  runtimeFingerprint: "runtime:executor-provider-echo",
+  observedAtSeq: 0,
+  transactionKind: "action-run",
+  reads: [],
+  shallowReads: [],
+  actualChangedWrites: [],
+  currentKnownWrites: [{
+    space,
+    id: "of:executor-provider:echo-root",
+    scope: "space",
+    path: [],
+  }],
+  declaredWrites: [{
+    space,
+    id: "of:executor-provider:echo-root",
+    scope: "space",
+    path: [],
+  }],
+  materializerWriteEnvelopes: [],
+  completeActionScopeSummary: {
+    version: 1,
+    complete: true,
+    implementationFingerprint: "impl:executor-provider-echo",
+    runtimeFingerprint: "runtime:executor-provider-echo",
+    piece: {
+      space,
+      id: "of:executor-provider:echo-piece",
+      scope: "space",
+      path: [],
+    },
+    reads: [],
+    writes: [{
+      space,
+      id: "of:executor-provider:echo-root",
+      scope: "space",
+      path: [],
+    }],
+    materializerWriteEnvelopes: [],
+    directOutputs: [{
+      space,
+      id: "of:executor-provider:echo-root",
+      scope: "space",
+      path: [],
+    }],
+  },
+  status: "success",
+});
+
 Deno.test("executor host provider commits through authenticated memory without a Worker key", async () => {
   const hostSigner = await Identity.fromPassphrase(
     `executor host provider ${crypto.randomUUID()}`,
@@ -183,12 +264,12 @@ Deno.test("executor host provider commits through authenticated memory without a
   }
 });
 
-Deno.test("executor host provider refreshes from accepted commits without memory watches", async () => {
+Deno.test("executor host provider refreshes without watches when scheduler adoption fails", async () => {
   const principal = await Identity.fromPassphrase(
     `executor invalidation provider ${crypto.randomUUID()}`,
   );
   const space = principal.did();
-  const server = new WatchCountingServer({
+  const server = new FailingSchedulerListServer({
     authorizeSessionOpen(message) {
       const value = (message.authorization as { principal?: unknown })
         ?.principal;
@@ -243,6 +324,31 @@ Deno.test("executor host provider refreshes from accepted commits without memory
         id: uri,
         value: { value: { version: 1 } },
       }],
+      schedulerObservation: {
+        version: 1,
+        ownerSpace: space,
+        branch: "",
+        pieceId: "space:of:executor-provider:fail-open-piece",
+        processGeneration: 1,
+        actionId: "action:fail-open-reader",
+        actionKind: "computation",
+        implementationFingerprint: "impl:fail-open-reader",
+        runtimeFingerprint: "runtime:fail-open-reader",
+        observedAtSeq: 0,
+        transactionKind: "action-run",
+        reads: [{
+          space,
+          id: uri,
+          scope: "space",
+          path: [],
+        }],
+        shallowReads: [],
+        actualChangedWrites: [],
+        currentKnownWrites: [],
+        declaredWrites: [],
+        materializerWriteEnvelopes: [],
+        status: "success",
+      },
     });
     const provider = storage.open(space);
     assertEquals((await provider.sync(uri)).error, undefined);
@@ -266,6 +372,7 @@ Deno.test("executor host provider refreshes from accepted commits without memory
       },
     });
 
+    server.failNextSchedulerList = true;
     await writer.transact({
       localSeq: 2,
       reads: { confirmed: [], pending: [] },
@@ -292,6 +399,161 @@ Deno.test("executor host provider refreshes from accepted commits without memory
     await channel.dispose();
     await writerClient.close();
     await server.close();
+  }
+});
+
+Deno.test("executor host provider invalidates inherited linked entities on its branch lane", async () => {
+  const principal = await Identity.fromPassphrase(
+    `executor branch invalidation ${crypto.randomUUID()}`,
+  );
+  const space = principal.did();
+  const storePath = await Deno.makeTempDir();
+  const store = toFileUrl(`${storePath}/`);
+  await Deno.mkdir(new URL("./engine-v3/", store), { recursive: true });
+  const seedEngine = await MemoryEngine.open({
+    url: resolveSpaceStoreUrl(store, space),
+  });
+  const root = "of:executor-provider:branch-root" as URI;
+  const target = "of:executor-provider:branch-target" as URI;
+  try {
+    MemoryEngine.applyCommit(seedEngine, {
+      sessionId: "session:branch-seed",
+      space,
+      principal: principal.did(),
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: root,
+          value: {
+            value: {
+              child: {
+                "/": { "link@1": { id: target, path: [], space } },
+              },
+            },
+          },
+        }, {
+          op: "set",
+          id: target,
+          value: { value: { version: 1 } },
+        }],
+      },
+    });
+    MemoryEngine.createBranch(seedEngine, "feature");
+  } finally {
+    MemoryEngine.close(seedEngine);
+  }
+
+  const server = new WatchCountingServer({
+    store,
+    authorizeSessionOpen(message) {
+      const value = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof value === "string" ? value : undefined;
+    },
+    sessionOpenAuth: {
+      audience: "did:key:z6Mk-executor-branch-invalidation-test",
+    },
+  });
+  const authorizeSessionOpen: MemoryClient.SessionOpenAuthFactory = (
+    _space,
+    _session,
+    context,
+  ) => ({
+    invocation: {
+      aud: context.audience,
+      challenge: context.challenge.value,
+    },
+    authorization: { principal: principal.did() },
+  });
+  const writerClient = await MemoryClient.connect({
+    transport: MemoryClient.loopback(server),
+  });
+  const writer = await writerClient.mount(space, {}, authorizeSessionOpen);
+  const channel = createHostProviderChannel({
+    server,
+    space,
+    branch: "feature",
+    authorizeSessionOpen,
+  });
+  const storage = HostStorageManager.connect({
+    port: channel.port,
+    principal: principal.did(),
+    space,
+    branch: "feature",
+  });
+  const targetAddress = {
+    id: target,
+    type: "application/json" as MIME,
+    path: [],
+  };
+
+  try {
+    const provider = storage.open(space);
+    assertEquals(
+      (await provider.sync(root, {
+        path: [],
+        schema: {
+          type: "object",
+          properties: {
+            child: {
+              type: "object",
+              properties: { version: { type: "number" } },
+              required: ["version"],
+            },
+          },
+          required: ["child"],
+        },
+      })).error,
+      undefined,
+    );
+    assertEquals(provider.replica.get(targetAddress)?.is, {
+      value: { version: 1 },
+    });
+    assertEquals(server.watchAddCount, 0);
+
+    const integrated = Promise.withResolvers<void>();
+    storage.subscribe({
+      next(notification) {
+        if (
+          notification.type === "integrate" &&
+          JSON.stringify(provider.replica.get(targetAddress)?.is) ===
+            JSON.stringify({ value: { version: 2 } })
+        ) {
+          integrated.resolve();
+        }
+        return { done: false };
+      },
+    });
+    await writer.transact({
+      branch: "feature",
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: target,
+        value: { value: { version: 2 } },
+      }],
+    });
+    const timer = setTimeout(
+      () => integrated.reject(new Error("feature target was not integrated")),
+      1_000,
+    );
+    try {
+      await integrated.promise;
+    } finally {
+      clearTimeout(timer);
+    }
+    assertEquals(provider.replica.get(targetAddress)?.is, {
+      value: { version: 2 },
+    });
+  } finally {
+    await storage.close();
+    await channel.dispose();
+    await writerClient.close();
+    await server.close();
+    await Deno.remove(storePath, { recursive: true });
   }
 });
 
@@ -519,6 +781,132 @@ Deno.test("executor host provider carries authenticated scheduler observations o
       },
     );
     assertEquals(accepted.length, 2);
+  } finally {
+    await storage.close();
+    await channel.dispose();
+    await writerClient.close();
+    await server.close();
+  }
+});
+
+Deno.test("executor host provider suppresses only same-session observation echoes", async () => {
+  const principal = await Identity.fromPassphrase(
+    `executor observation echo ${crypto.randomUUID()}`,
+  );
+  const space = principal.did();
+  const server = new WatchCountingServer({
+    authorizeSessionOpen(message) {
+      const value = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof value === "string" ? value : undefined;
+    },
+    sessionOpenAuth: {
+      audience: "did:key:z6Mk-executor-observation-echo-test",
+    },
+  });
+  const authorizeSessionOpen: MemoryClient.SessionOpenAuthFactory = (
+    _space,
+    _session,
+    context,
+  ) => ({
+    invocation: {
+      aud: context.audience,
+      challenge: context.challenge.value,
+    },
+    authorization: { principal: principal.did() },
+  });
+  const writerClient = await MemoryClient.connect({
+    transport: MemoryClient.loopback(server),
+  });
+  const writer = await writerClient.mount(space, {}, authorizeSessionOpen);
+  const channel = createHostProviderChannel({
+    server,
+    space,
+    authorizeSessionOpen,
+  });
+  const storage = HostStorageManager.connect({
+    port: channel.port,
+    principal: principal.did(),
+    space,
+  });
+  const accepted: AcceptedCommitEvent[] = [];
+  server.subscribeAcceptedCommits(space, (event) => {
+    accepted.push(event);
+  });
+
+  try {
+    const provider = storage.open(space);
+    assertEquals(
+      (await provider.sync("of:executor-provider:echo-root")).error,
+      undefined,
+    );
+    const adopted = Promise.withResolvers<StorageNotification>();
+    storage.subscribe({
+      next(notification) {
+        if (notification.type === "scheduler-observations") {
+          adopted.resolve(notification);
+        }
+        return { done: false };
+      },
+    });
+
+    const replica = provider.replica;
+    assert(replica.commitNative);
+    assertEquals(
+      (await replica.commitNative({
+        operations: [],
+        schedulerObservation: schedulerObservationFor(
+          space,
+          "action:provider-own",
+        ),
+      })).error,
+      undefined,
+    );
+    await writer.transact({
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [],
+      schedulerObservation: schedulerObservationFor(
+        space,
+        "action:external",
+      ),
+    });
+
+    assertEquals(
+      accepted.map((event) => ({
+        own: event.originSessionId === storage.id,
+        schedulerUpdateIds: event.schedulerUpdateIds,
+      })),
+      [
+        { own: true, schedulerUpdateIds: [1] },
+        { own: false, schedulerUpdateIds: [2] },
+      ],
+    );
+    const persisted = await writer.listSchedulerActionSnapshots();
+    assertEquals(
+      persisted.snapshots.map((snapshot) =>
+        (snapshot.observation as { actionId?: string }).actionId
+      ).sort(),
+      ["action:external", "action:provider-own"],
+    );
+
+    const timer = setTimeout(
+      () => adopted.reject(new Error("external observation was not adopted")),
+      1_000,
+    );
+    let notification: StorageNotification;
+    try {
+      notification = await adopted.promise;
+    } finally {
+      clearTimeout(timer);
+    }
+    assert(notification.type === "scheduler-observations");
+    assertEquals(
+      notification.observations.map((snapshot) =>
+        (snapshot.observation as { actionId?: string }).actionId
+      ),
+      ["action:external"],
+    );
   } finally {
     await storage.close();
     await channel.dispose();
@@ -921,10 +1309,8 @@ const runProviderTrace = async (kind: ProviderKind) => {
       accepted: accepted.map((event) => ({
         order: event.order,
         deliverySeq: event.deliverySeq,
-        revisionOps: event.commit.revisions.map((revision) => revision.op),
-        schedulerStatuses: event.commit.schedulerObservationResults?.map(
-          (result) => result.status,
-        ) ?? [],
+        revisionOps: event.revisions.map((revision) => revision.op),
+        schedulerUpdateIds: event.schedulerUpdateIds,
       })),
       watchAdds: server.watchAddCount,
     };
@@ -1288,8 +1674,10 @@ Deno.test("executor host provider transfers as an opaque channel to a real Worke
     });
     await nextMessage("integrated");
 
-    worker.postMessage({ type: "dispose" });
-    await nextMessage("disposed");
+    // The worker controller owns this pairing: an abrupt realm termination is
+    // immediately followed by host-channel disposal, which releases the
+    // authenticated connection and accepted-commit callback.
+    worker.terminate();
     await channel.dispose();
     assertEquals(server.acceptedCommitSubscriptions, 0);
     assertEquals(queued.find((message) => message.type === "error"), undefined);

--- a/packages/runner/test/executor-provider-parity.test.ts
+++ b/packages/runner/test/executor-provider-parity.test.ts
@@ -1,0 +1,69 @@
+import { assert, assertEquals } from "@std/assert";
+import { Identity } from "@commonfabric/identity";
+import { Server } from "@commonfabric/memory/v2/server";
+import {
+  createHostProviderChannel,
+  HostStorageManager,
+} from "../src/storage/v2-host-provider.ts";
+
+Deno.test("executor host provider commits through authenticated memory without a Worker key", async () => {
+  const hostSigner = await Identity.fromPassphrase(
+    `executor host provider ${crypto.randomUUID()}`,
+  );
+  const space = hostSigner.did();
+  const server = new Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: {
+      audience: "did:key:z6Mk-executor-provider-test",
+    },
+  });
+  const channel = createHostProviderChannel({
+    server,
+    space,
+    authorizeSessionOpen: (_space, _session, context) => ({
+      invocation: {
+        aud: context.audience,
+        challenge: context.challenge.value,
+      },
+      authorization: { principal: hostSigner.did() },
+    }),
+  });
+  const storage = HostStorageManager.open({
+    port: channel.port,
+    principal: hostSigner.did(),
+    space,
+  });
+
+  try {
+    const signing = await storage.as.sign(new Uint8Array() as never);
+    assert(signing.error instanceof Error);
+    assertEquals(
+      signing.error.message,
+      "executor provider principal has no Worker signing key",
+    );
+
+    const replica = storage.open(space).replica;
+    assert(replica.commitNative);
+    const result = await replica.commitNative({
+      operations: [{
+        op: "set",
+        id: "of:executor-provider:test",
+        type: "application/json",
+        value: { value: { authenticated: true } },
+      }],
+    });
+    assertEquals(result.error, undefined);
+    assertEquals(
+      await server.readDocument(space, "of:executor-provider:test"),
+      { value: { authenticated: true } },
+    );
+  } finally {
+    await storage.close();
+    await channel.dispose();
+    await server.close();
+  }
+});

--- a/packages/runner/test/executor-provider-parity.test.ts
+++ b/packages/runner/test/executor-provider-parity.test.ts
@@ -2,7 +2,10 @@ import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
 import type { MIME, URI } from "@commonfabric/memory/interface";
 import * as MemoryClient from "@commonfabric/memory/v2/client";
-import { Server } from "@commonfabric/memory/v2/server";
+import {
+  type AcceptedCommitEvent,
+  Server,
+} from "@commonfabric/memory/v2/server";
 import type { StorageNotification } from "../src/storage/interface.ts";
 import {
   createHostProviderChannel,
@@ -51,7 +54,6 @@ Deno.test("executor host provider commits through authenticated memory without a
     principal: hostSigner.did(),
     space,
   });
-
   try {
     const signing = await storage.as.sign(new Uint8Array() as never);
     assert(signing.error instanceof Error);
@@ -192,4 +194,186 @@ Deno.test("executor host provider refreshes from accepted commits without memory
     await writerClient.close();
     await server.close();
   }
+});
+
+Deno.test("executor host provider carries authenticated scheduler observations on its direct feed", async () => {
+  const principal = await Identity.fromPassphrase(
+    `executor observation provider ${crypto.randomUUID()}`,
+  );
+  const space = principal.did();
+  const server = new WatchCountingServer({
+    authorizeSessionOpen(message) {
+      const value = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof value === "string" ? value : undefined;
+    },
+    sessionOpenAuth: {
+      audience: "did:key:z6Mk-executor-observation-test",
+    },
+  });
+  const authorizeSessionOpen: MemoryClient.SessionOpenAuthFactory = (
+    _space,
+    _session,
+    context,
+  ) => ({
+    invocation: {
+      aud: context.audience,
+      challenge: context.challenge.value,
+    },
+    authorization: { principal: principal.did() },
+  });
+  const writerClient = await MemoryClient.connect({
+    transport: MemoryClient.loopback(server),
+  });
+  const writer = await writerClient.mount(
+    space,
+    {},
+    authorizeSessionOpen,
+  );
+  const channel = createHostProviderChannel({
+    server,
+    space,
+    authorizeSessionOpen,
+  });
+  const storage = HostStorageManager.connect({
+    port: channel.port,
+    principal: principal.did(),
+    space,
+  });
+  const accepted: AcceptedCommitEvent[] = [];
+  server.subscribeAcceptedCommits(space, (event) => {
+    accepted.push(event);
+  });
+
+  try {
+    const provider = storage.open(space);
+    assertEquals(
+      (await provider.sync("of:executor-provider:observation-root")).error,
+      undefined,
+    );
+    assertEquals(server.watchAddCount, 0);
+
+    const adopted = Promise.withResolvers<StorageNotification>();
+    const notifications: StorageNotification[] = [];
+    storage.subscribe({
+      next(notification) {
+        notifications.push(notification);
+        if (notification.type === "scheduler-observations") {
+          adopted.resolve(notification);
+        }
+        return { done: false };
+      },
+    });
+
+    await writer.transact({
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [],
+      schedulerObservation: {
+        version: 2,
+        ownerSpace: space,
+        branch: "",
+        pieceId: "space:of:executor-provider:piece",
+        processGeneration: 1,
+        actionId: "action:external",
+        actionKind: "computation",
+        implementationFingerprint: "impl:executor-provider",
+        runtimeFingerprint: "runtime:executor-provider",
+        observedAtSeq: 0,
+        transactionKind: "action-run",
+        reads: [],
+        shallowReads: [],
+        actualChangedWrites: [],
+        currentKnownWrites: [{
+          space,
+          id: "of:executor-provider:observation-root",
+          scope: "space",
+          path: [],
+        }],
+        declaredWrites: [{
+          space,
+          id: "of:executor-provider:observation-root",
+          scope: "space",
+          path: [],
+        }],
+        materializerWriteEnvelopes: [],
+        completeActionScopeSummary: {
+          version: 1,
+          complete: true,
+          implementationFingerprint: "impl:executor-provider",
+          runtimeFingerprint: "runtime:executor-provider",
+          piece: {
+            space,
+            id: "of:executor-provider:piece",
+            scope: "space",
+            path: [],
+          },
+          reads: [],
+          writes: [{
+            space,
+            id: "of:executor-provider:observation-root",
+            scope: "space",
+            path: [],
+          }],
+          materializerWriteEnvelopes: [],
+          directOutputs: [{
+            space,
+            id: "of:executor-provider:observation-root",
+            scope: "space",
+            path: [],
+          }],
+        },
+        status: "success",
+      },
+    });
+    assertEquals(accepted.length, 1);
+    assertEquals(accepted[0]?.deliverySeq, 1);
+    assertEquals(accepted[0]?.originSessionId === storage.id, false);
+    const persisted = await writer.listSchedulerActionSnapshots({
+      sinceCommitSeq: 0,
+      throughCommitSeq: 1,
+    });
+    assertEquals(
+      (persisted.snapshots[0]?.observation as { actionId?: string })?.actionId,
+      "action:external",
+    );
+    assertEquals(persisted.snapshots[0]?.executionContextKey, "space");
+
+    const timer = setTimeout(
+      () =>
+        adopted.reject(
+          new Error(
+            "scheduler observation was not adopted; notifications=" +
+              notifications.map((notification) => notification.type).join(","),
+          ),
+        ),
+      1_000,
+    );
+    let notification: StorageNotification;
+    try {
+      notification = await adopted.promise;
+    } finally {
+      clearTimeout(timer);
+    }
+    assert(notification.type === "scheduler-observations");
+    assertEquals(
+      (notification.observations[0]?.observation as { actionId?: string })
+        ?.actionId,
+      "action:external",
+    );
+  } finally {
+    await storage.close();
+    await channel.dispose();
+    await writerClient.close();
+    await server.close();
+  }
+});
+
+Deno.test("executor host provider source has no engine mutation bypass", async () => {
+  const source = await Deno.readTextFile(
+    new URL("../src/storage/v2-host-provider.ts", import.meta.url),
+  );
+  assertEquals(source.includes("applyCommit"), false);
+  assertEquals(source.includes("/v2/engine"), false);
+  assertEquals(source.includes("this.session.watchAddSync"), false);
 });

--- a/packages/runner/test/executor-provider-parity.test.ts
+++ b/packages/runner/test/executor-provider-parity.test.ts
@@ -353,77 +353,88 @@ Deno.test("executor host provider carries authenticated scheduler observations o
     assertEquals(server.watchAddCount, 0);
 
     const adopted = Promise.withResolvers<StorageNotification>();
+    const readopted = Promise.withResolvers<StorageNotification>();
     const notifications: StorageNotification[] = [];
     storage.subscribe({
       next(notification) {
         notifications.push(notification);
         if (notification.type === "scheduler-observations") {
-          adopted.resolve(notification);
+          const adoptionCount = notifications.filter((candidate) =>
+            candidate.type === "scheduler-observations"
+          ).length;
+          if (adoptionCount === 1) {
+            adopted.resolve(notification);
+          }
+          if (adoptionCount === 2) {
+            readopted.resolve(notification);
+          }
         }
         return { done: false };
       },
     });
 
+    const externalObservation = {
+      version: 2 as const,
+      ownerSpace: space,
+      branch: "",
+      pieceId: "space:of:executor-provider:piece",
+      processGeneration: 1,
+      actionId: "action:external",
+      actionKind: "computation" as const,
+      implementationFingerprint: "impl:executor-provider",
+      runtimeFingerprint: "runtime:executor-provider",
+      observedAtSeq: 0,
+      transactionKind: "action-run" as const,
+      reads: [],
+      shallowReads: [],
+      actualChangedWrites: [],
+      currentKnownWrites: [{
+        space,
+        id: "of:executor-provider:observation-root",
+        scope: "space" as const,
+        path: [],
+      }],
+      declaredWrites: [{
+        space,
+        id: "of:executor-provider:observation-root",
+        scope: "space" as const,
+        path: [],
+      }],
+      materializerWriteEnvelopes: [],
+      completeActionScopeSummary: {
+        version: 1 as const,
+        complete: true,
+        implementationFingerprint: "impl:executor-provider",
+        runtimeFingerprint: "runtime:executor-provider",
+        piece: {
+          space,
+          id: "of:executor-provider:piece",
+          scope: "space" as const,
+          path: [],
+        },
+        reads: [],
+        writes: [{
+          space,
+          id: "of:executor-provider:observation-root",
+          scope: "space" as const,
+          path: [],
+        }],
+        materializerWriteEnvelopes: [],
+        directOutputs: [{
+          space,
+          id: "of:executor-provider:observation-root",
+          scope: "space" as const,
+          path: [],
+        }],
+      },
+      status: "success" as const,
+    };
+
     await writer.transact({
       localSeq: 1,
       reads: { confirmed: [], pending: [] },
       operations: [],
-      schedulerObservation: {
-        version: 2,
-        ownerSpace: space,
-        branch: "",
-        pieceId: "space:of:executor-provider:piece",
-        processGeneration: 1,
-        actionId: "action:external",
-        actionKind: "computation",
-        implementationFingerprint: "impl:executor-provider",
-        runtimeFingerprint: "runtime:executor-provider",
-        observedAtSeq: 0,
-        transactionKind: "action-run",
-        reads: [],
-        shallowReads: [],
-        actualChangedWrites: [],
-        currentKnownWrites: [{
-          space,
-          id: "of:executor-provider:observation-root",
-          scope: "space",
-          path: [],
-        }],
-        declaredWrites: [{
-          space,
-          id: "of:executor-provider:observation-root",
-          scope: "space",
-          path: [],
-        }],
-        materializerWriteEnvelopes: [],
-        completeActionScopeSummary: {
-          version: 1,
-          complete: true,
-          implementationFingerprint: "impl:executor-provider",
-          runtimeFingerprint: "runtime:executor-provider",
-          piece: {
-            space,
-            id: "of:executor-provider:piece",
-            scope: "space",
-            path: [],
-          },
-          reads: [],
-          writes: [{
-            space,
-            id: "of:executor-provider:observation-root",
-            scope: "space",
-            path: [],
-          }],
-          materializerWriteEnvelopes: [],
-          directOutputs: [{
-            space,
-            id: "of:executor-provider:observation-root",
-            scope: "space",
-            path: [],
-          }],
-        },
-        status: "success",
-      },
+      schedulerObservation: externalObservation,
     });
     assertEquals(accepted.length, 1);
     assertEquals(accepted[0]?.deliverySeq, 1);
@@ -460,6 +471,54 @@ Deno.test("executor host provider carries authenticated scheduler observations o
         ?.actionId,
       "action:external",
     );
+
+    // Rehydration/listing sees the current version and must not permanently
+    // suppress a later payload-changing re-observation of the same action row.
+    const listed = await provider.listSchedulerActionSnapshots!();
+    assertEquals(
+      listed.snapshots[0]?.observationId,
+      persisted.snapshots[0]?.observationId,
+    );
+
+    await writer.transact({
+      localSeq: 2,
+      reads: { confirmed: [], pending: [] },
+      operations: [],
+      schedulerObservation: {
+        ...externalObservation,
+        status: "failed",
+        errorFingerprint: "error:second-observation",
+      },
+    });
+    const readoptionTimer = setTimeout(
+      () =>
+        readopted.reject(
+          new Error(
+            "updated scheduler observation was not adopted; notifications=" +
+              notifications.map((candidate) => candidate.type).join(","),
+          ),
+        ),
+      1_000,
+    );
+    let updatedNotification: StorageNotification;
+    try {
+      updatedNotification = await readopted.promise;
+    } finally {
+      clearTimeout(readoptionTimer);
+    }
+    assert(updatedNotification.type === "scheduler-observations");
+    assertEquals(
+      updatedNotification.observations[0]?.observation as {
+        status?: string;
+        errorFingerprint?: string;
+      },
+      {
+        ...externalObservation,
+        status: "failed",
+        errorFingerprint: "error:second-observation",
+      },
+    );
+    assertEquals(accepted.length, 2);
   } finally {
     await storage.close();
     await channel.dispose();
@@ -1082,10 +1141,6 @@ Deno.test("executor host provider disposal releases callbacks and pending reads"
     );
     await server.graphQueryStarted.promise;
 
-    await storage.close();
-    const readResult = await pendingRead;
-    assert(readResult.error);
-
     disposing = channel.dispose();
     const disposedPromptly = await Promise.race([
       disposing.then(() => true),
@@ -1093,6 +1148,16 @@ Deno.test("executor host provider disposal releases callbacks and pending reads"
     ]);
     assertEquals(disposedPromptly, true);
     assertEquals(server.acceptedCommitSubscriptions, 0);
+
+    const pendingResult = await Promise.race([
+      pendingRead.then((result) => ({ settled: true as const, result })),
+      new Promise<{ settled: false }>((resolve) =>
+        setTimeout(() => resolve({ settled: false }), 100)
+      ),
+    ]);
+    assert(pendingResult.settled, "host-first disposal stranded a Worker read");
+    assert(pendingResult.result.error);
+    await storage.close();
   } finally {
     server.releaseGraphQuery.resolve();
     await disposing;

--- a/packages/runner/test/executor-provider-parity.test.ts
+++ b/packages/runner/test/executor-provider-parity.test.ts
@@ -9,8 +9,15 @@ import type {
 import * as MemoryClient from "@commonfabric/memory/v2/client";
 import {
   type AcceptedCommitEvent,
+  type AcceptedCommitListener,
   Server,
 } from "@commonfabric/memory/v2/server";
+import { table } from "@commonfabric/memory/sqlite/schema";
+import {
+  all,
+  match,
+  principal as rowPrincipal,
+} from "@commonfabric/memory/sqlite/row-label";
 import type { StorageNotification } from "../src/storage/interface.ts";
 import type { NativeStorageCommit } from "../src/storage/interface.ts";
 import {
@@ -55,6 +62,25 @@ class GatedGraphServer extends WatchCountingServer {
       await this.releaseGraphQuery.promise;
     }
     return response;
+  }
+}
+
+class LifecycleServer extends GatedGraphServer {
+  acceptedCommitSubscriptions = 0;
+
+  override subscribeAcceptedCommits(
+    space: string,
+    listener: AcceptedCommitListener,
+  ): () => void {
+    this.acceptedCommitSubscriptions++;
+    const unsubscribe = super.subscribeAcceptedCommits(space, listener);
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+      this.acceptedCommitSubscriptions--;
+      unsubscribe();
+    };
   }
 }
 
@@ -770,6 +796,46 @@ const runProviderTrace = async (kind: ProviderKind) => {
       actionId: "action:differential",
     });
 
+    const atomicUri = "of:executor-provider:cfc-atomic" as URI;
+    const addr = /[^\s<>,;"]+@[^\s<>,;"]+/g;
+    const acceptedBeforeCfc = accepted.length;
+    const cfc = await commit({
+      operations: [{
+        op: "set",
+        id: atomicUri,
+        type,
+        value: { value: { mustRollback: true } },
+      }],
+      sqliteOps: [{
+        op: "sqlite",
+        db: {
+          id: ("of:executor-provider:cfc-" + crypto.randomUUID()) as URI,
+          owner: space,
+          tables: {
+            emails: table(
+              { id: "integer primary key", from_addr: "text", body: "text" },
+              (fields) => ({
+                confidentiality: all(
+                  rowPrincipal(
+                    "mailto",
+                    match(fields.from_addr, addr, { min: 1 }),
+                  ),
+                ),
+              }),
+            ),
+          },
+        },
+        sql: "INSERT INTO emails (from_addr, body) VALUES (?, ?)",
+        params: ["not an address", "must reject"],
+      }],
+    });
+    const cfcReplicaValue = replica.get({
+      id: atomicUri,
+      type,
+    })?.is;
+    const cfcServerValue = await server.readDocument(space, atomicUri);
+    const cfcAcceptedDelta = accepted.length - acceptedBeforeCfc;
+
     assertEquals(
       (await commit({
         operations: [{ op: "delete", id: uri, type }],
@@ -786,6 +852,12 @@ const runProviderTrace = async (kind: ProviderKind) => {
         executionContextKey: snapshot.executionContextKey,
         status: (snapshot.observation as { status?: string }).status,
       })),
+      cfc: {
+        name: cfc.error?.name as string | undefined,
+        replicaValue: cfcReplicaValue,
+        serverValue: cfcServerValue,
+        acceptedDelta: cfcAcceptedDelta,
+      },
       final: replica.get(address)?.is,
       accepted: accepted.map((event) => ({
         order: event.order,
@@ -812,6 +884,220 @@ Deno.test("executor host provider is behaviorally equivalent to authenticated lo
     { ...host, watchAdds: undefined },
     { ...loopback, watchAdds: undefined },
   );
+  assertEquals(host.afterExternal, {
+    value: { count: 3, external: true },
+  });
+  assertEquals(host.conflict, "ConflictError");
+  assertEquals(host.afterConflict, host.afterExternal);
+  assertEquals(host.scheduler, [{
+    actionId: "action:differential",
+    executionContextKey: "space",
+    status: "success",
+  }]);
+  assertEquals(host.cfc, {
+    name: "RowLabelCommitError",
+    replicaValue: undefined,
+    serverValue: null,
+    acceptedDelta: 0,
+  });
+  assertEquals(host.final, undefined);
   assertEquals(host.watchAdds, 0);
   assert(loopback.watchAdds > 0);
+});
+
+const runAclTrace = async (kind: ProviderKind) => {
+  const owner = await Identity.fromPassphrase(
+    "executor ACL owner " + kind + " " + crypto.randomUUID(),
+  );
+  const reader = await Identity.fromPassphrase(
+    "executor ACL reader " + kind + " " + crypto.randomUUID(),
+  );
+  const space = owner.did();
+  const server = new WatchCountingServer({
+    authorizeSessionOpen(message) {
+      const value = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof value === "string" ? value : undefined;
+    },
+    sessionOpenAuth: {
+      audience: "did:key:z6Mk-executor-acl-test",
+    },
+    acl: { mode: "enforce" },
+  });
+  const authFor = (
+    principal: string,
+  ): MemoryClient.SessionOpenAuthFactory =>
+  (_space, _session, context) => ({
+    invocation: {
+      aud: context.audience,
+      challenge: context.challenge.value,
+    },
+    authorization: { principal },
+  });
+  const ownerClient = await MemoryClient.connect({
+    transport: MemoryClient.loopback(server),
+  });
+  const ownerSession = await ownerClient.mount(
+    space,
+    {},
+    authFor(owner.did()),
+  );
+  const uri = "of:executor-provider:acl-data" as URI;
+  await ownerSession.transact({
+    localSeq: 1,
+    reads: { confirmed: [], pending: [] },
+    operations: [{
+      op: "set",
+      id: ("of:" + space) as URI,
+      value: {
+        value: {
+          [owner.did()]: "OWNER",
+          [reader.did()]: "READ",
+        },
+      },
+    }],
+  });
+  await ownerSession.transact({
+    localSeq: 2,
+    reads: { confirmed: [], pending: [] },
+    operations: [{
+      op: "set",
+      id: uri,
+      value: { value: { protected: true } },
+    }],
+  });
+
+  const channel = kind === "host"
+    ? createHostProviderChannel({
+      server,
+      space,
+      authorizeSessionOpen: authFor(reader.did()),
+    })
+    : undefined;
+  const storage: StorageManager = kind === "host"
+    ? HostStorageManager.connect({
+      port: channel!.port,
+      principal: reader.did(),
+      space,
+    })
+    : LoopbackStorageManager.connectTo(server, { as: reader });
+  const accepted: AcceptedCommitEvent[] = [];
+  server.subscribeAcceptedCommits(space, (event) => {
+    accepted.push(event);
+  });
+
+  try {
+    const provider = storage.open(space);
+    assertEquals((await provider.sync(uri)).error, undefined);
+    const replica = provider.replica;
+    assert(replica.commitNative);
+    const denied = await replica.commitNative({
+      operations: [{
+        op: "set",
+        id: uri,
+        type: "application/json",
+        value: { value: { protected: false } },
+      }],
+    });
+    return {
+      denial: {
+        name: denied.error?.name,
+        message: denied.error?.message.replace(/did:key:\S+/g, "<did>"),
+      },
+      replicaValue: replica.get({
+        id: uri,
+        type: "application/json",
+      })?.is,
+      serverValue: await server.readDocument(space, uri),
+      accepted: accepted.length,
+      watchAdds: server.watchAddCount,
+    };
+  } finally {
+    await storage.close();
+    await channel?.dispose();
+    await ownerClient.close();
+    await server.close();
+  }
+};
+
+Deno.test("executor host provider preserves ACL denial and atomic rollback parity", async () => {
+  const loopback = await runAclTrace("loopback");
+  const host = await runAclTrace("host");
+  assertEquals(
+    { ...host, watchAdds: undefined },
+    { ...loopback, watchAdds: undefined },
+  );
+  assertEquals(host.denial.name, "TransactionError");
+  assert(host.denial.message?.includes("lacks WRITE"));
+  assertEquals(host.replicaValue, { value: { protected: true } });
+  assertEquals(host.serverValue, { value: { protected: true } });
+  assertEquals(host.accepted, 0);
+  assertEquals(host.watchAdds, 0);
+  assert(loopback.watchAdds > 0);
+});
+
+Deno.test("executor host provider disposal releases callbacks and pending reads", async () => {
+  const principal = await Identity.fromPassphrase(
+    "executor provider disposal " + crypto.randomUUID(),
+  );
+  const space = principal.did();
+  const server = new LifecycleServer({
+    authorizeSessionOpen(message) {
+      const value = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof value === "string" ? value : undefined;
+    },
+    sessionOpenAuth: {
+      audience: "did:key:z6Mk-executor-disposal-test",
+    },
+  });
+  const authorizeSessionOpen: MemoryClient.SessionOpenAuthFactory = (
+    _space,
+    _session,
+    context,
+  ) => ({
+    invocation: {
+      aud: context.audience,
+      challenge: context.challenge.value,
+    },
+    authorization: { principal: principal.did() },
+  });
+  const channel = createHostProviderChannel({
+    server,
+    space,
+    authorizeSessionOpen,
+  });
+  const storage = HostStorageManager.connect({
+    port: channel.port,
+    principal: principal.did(),
+    space,
+  });
+  let disposing: Promise<void> | undefined;
+
+  try {
+    assertEquals(server.acceptedCommitSubscriptions, 1);
+    server.gateNextGraphQuery();
+    const pendingRead = storage.open(space).sync(
+      "of:executor-provider:pending-disposal",
+    );
+    await server.graphQueryStarted.promise;
+
+    await storage.close();
+    const readResult = await pendingRead;
+    assert(readResult.error);
+
+    disposing = channel.dispose();
+    const disposedPromptly = await Promise.race([
+      disposing.then(() => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 100)),
+    ]);
+    assertEquals(disposedPromptly, true);
+    assertEquals(server.acceptedCommitSubscriptions, 0);
+  } finally {
+    server.releaseGraphQuery.resolve();
+    await disposing;
+    await channel.dispose();
+    await storage.close();
+    await server.close();
+  }
 });

--- a/packages/runner/test/executor-provider-parity.test.ts
+++ b/packages/runner/test/executor-provider-parity.test.ts
@@ -32,7 +32,7 @@ Deno.test("executor host provider commits through authenticated memory without a
       authorization: { principal: hostSigner.did() },
     }),
   });
-  const storage = HostStorageManager.open({
+  const storage = HostStorageManager.connect({
     port: channel.port,
     principal: hostSigner.did(),
     space,

--- a/packages/runner/test/executor-provider-parity.test.ts
+++ b/packages/runner/test/executor-provider-parity.test.ts
@@ -1,12 +1,23 @@
 import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
-import type { MIME, URI } from "@commonfabric/memory/interface";
+import type {
+  MemorySpace,
+  MIME,
+  Signer,
+  URI,
+} from "@commonfabric/memory/interface";
 import * as MemoryClient from "@commonfabric/memory/v2/client";
 import {
   type AcceptedCommitEvent,
   Server,
 } from "@commonfabric/memory/v2/server";
 import type { StorageNotification } from "../src/storage/interface.ts";
+import type { NativeStorageCommit } from "../src/storage/interface.ts";
+import {
+  type Options,
+  type SessionFactory,
+  StorageManager,
+} from "../src/storage/v2.ts";
 import {
   createHostProviderChannel,
   HostStorageManager,
@@ -44,6 +55,44 @@ class GatedGraphServer extends WatchCountingServer {
       await this.releaseGraphQuery.promise;
     }
     return response;
+  }
+}
+
+class LoopbackSessionFactory implements SessionFactory {
+  constructor(private readonly server: Server) {}
+
+  async create(
+    space: MemorySpace,
+    signer?: Signer,
+    mountOptions: MemoryClient.MountOptions = {},
+  ) {
+    const client = await MemoryClient.connect({
+      transport: MemoryClient.loopback(this.server),
+    });
+    const session = await client.mount(
+      space,
+      mountOptions,
+      (_space, _session, context) => ({
+        invocation: {
+          aud: context.audience,
+          challenge: context.challenge.value,
+        },
+        authorization: { principal: signer?.did() },
+      }),
+    );
+    return { client, session };
+  }
+}
+
+class LoopbackStorageManager extends StorageManager {
+  static connectTo(
+    server: Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): LoopbackStorageManager {
+    return new LoopbackStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      new LoopbackSessionFactory(server),
+    );
   }
 }
 
@@ -516,4 +565,253 @@ Deno.test("executor host provider closes the initial read and invalidation race"
     await writerClient.close();
     await server.close();
   }
+});
+
+type ProviderKind = "loopback" | "host";
+
+const runProviderTrace = async (kind: ProviderKind) => {
+  const signer = await Identity.fromPassphrase(
+    "executor provider differential " + kind + " " + crypto.randomUUID(),
+  );
+  const space = signer.did();
+  const server = new WatchCountingServer({
+    authorizeSessionOpen(message) {
+      const value = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof value === "string" ? value : undefined;
+    },
+    sessionOpenAuth: {
+      audience: "did:key:z6Mk-executor-differential-test",
+    },
+  });
+  const authorizeSessionOpen: MemoryClient.SessionOpenAuthFactory = (
+    _space,
+    _session,
+    context,
+  ) => ({
+    invocation: {
+      aud: context.audience,
+      challenge: context.challenge.value,
+    },
+    authorization: { principal: signer.did() },
+  });
+  const writerClient = await MemoryClient.connect({
+    transport: MemoryClient.loopback(server),
+  });
+  const writer = await writerClient.mount(
+    space,
+    {},
+    authorizeSessionOpen,
+  );
+  const channel = kind === "host"
+    ? createHostProviderChannel({
+      server,
+      space,
+      authorizeSessionOpen,
+    })
+    : undefined;
+  const storage: StorageManager = kind === "host"
+    ? HostStorageManager.connect({
+      port: channel!.port,
+      principal: signer.did(),
+      space,
+    })
+    : LoopbackStorageManager.connectTo(server, { as: signer });
+  const accepted: AcceptedCommitEvent[] = [];
+  server.subscribeAcceptedCommits(space, (event) => {
+    accepted.push(event);
+  });
+  const uri = "of:executor-provider:differential" as URI;
+  const type = "application/json" as MIME;
+  const address = { id: uri, type, path: [] };
+
+  try {
+    const provider = storage.open(space);
+    const replica = provider.replica;
+    assert(replica.commitNative);
+    assertEquals((await provider.sync(uri)).error, undefined);
+
+    const commit = (
+      transaction: NativeStorageCommit,
+      source?: Parameters<NonNullable<typeof replica.commitNative>>[1],
+    ) => replica.commitNative!(transaction, source);
+
+    assertEquals(
+      (await commit({
+        operations: [{
+          op: "set",
+          id: uri,
+          type,
+          value: { value: { count: 1 } },
+        }],
+      })).error,
+      undefined,
+    );
+    assertEquals(
+      (await commit({
+        operations: [{
+          op: "patch",
+          id: uri,
+          type,
+          value: { value: { count: 2, label: "patched" } },
+          patches: [
+            { op: "replace", path: "/value/count", value: 2 },
+            { op: "add", path: "/value/label", value: "patched" },
+          ],
+        }],
+      })).error,
+      undefined,
+    );
+
+    const integrated = Promise.withResolvers<void>();
+    storage.subscribe({
+      next(notification) {
+        if (
+          notification.type === "integrate" &&
+          JSON.stringify(replica.get(address)?.is) ===
+            JSON.stringify({ value: { count: 3, external: true } })
+        ) {
+          integrated.resolve();
+        }
+        return { done: false };
+      },
+    });
+    await writer.transact({
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: uri,
+        value: { value: { count: 3, external: true } },
+      }],
+    });
+    const timer = setTimeout(
+      () => integrated.reject(new Error("differential external write missed")),
+      1_000,
+    );
+    try {
+      await integrated.promise;
+    } finally {
+      clearTimeout(timer);
+    }
+    const afterExternal = replica.get(address)?.is;
+
+    const staleSource = {
+      getReadActivities() {
+        return [{
+          space,
+          id: uri,
+          type,
+          path: [],
+          meta: { seq: 1 },
+        }];
+      },
+    } as unknown as Parameters<NonNullable<typeof replica.commitNative>>[1];
+    const conflict = await commit({
+      operations: [{
+        op: "set",
+        id: uri,
+        type,
+        value: { value: { count: 4, stale: true } },
+      }],
+    }, staleSource);
+    const afterConflict = replica.get(address)?.is;
+
+    const observationWrite = {
+      space,
+      id: uri,
+      scope: "space" as const,
+      path: [] as string[],
+    };
+    assertEquals(
+      (await commit({
+        operations: [],
+        schedulerObservation: {
+          version: 2,
+          ownerSpace: space,
+          branch: "",
+          pieceId: "space:of:executor-provider:differential-piece",
+          processGeneration: 1,
+          actionId: "action:differential",
+          actionKind: "computation",
+          implementationFingerprint: "impl:executor-differential",
+          runtimeFingerprint: "runtime:executor-differential",
+          observedAtSeq: 0,
+          transactionKind: "action-run",
+          reads: [],
+          shallowReads: [],
+          actualChangedWrites: [],
+          currentKnownWrites: [observationWrite],
+          declaredWrites: [observationWrite],
+          materializerWriteEnvelopes: [],
+          completeActionScopeSummary: {
+            version: 1,
+            complete: true,
+            implementationFingerprint: "impl:executor-differential",
+            runtimeFingerprint: "runtime:executor-differential",
+            piece: {
+              space,
+              id: "of:executor-provider:differential-piece",
+              scope: "space",
+              path: [],
+            },
+            reads: [],
+            writes: [observationWrite],
+            materializerWriteEnvelopes: [],
+            directOutputs: [observationWrite],
+          },
+          status: "success",
+        },
+      })).error,
+      undefined,
+    );
+    const scheduler = await provider.listSchedulerActionSnapshots!({
+      ownerSpace: space,
+      actionId: "action:differential",
+    });
+
+    assertEquals(
+      (await commit({
+        operations: [{ op: "delete", id: uri, type }],
+      })).error,
+      undefined,
+    );
+
+    return {
+      afterExternal,
+      conflict: conflict.error?.name,
+      afterConflict,
+      scheduler: scheduler.snapshots.map((snapshot) => ({
+        actionId: (snapshot.observation as { actionId?: string }).actionId,
+        executionContextKey: snapshot.executionContextKey,
+        status: (snapshot.observation as { status?: string }).status,
+      })),
+      final: replica.get(address)?.is,
+      accepted: accepted.map((event) => ({
+        order: event.order,
+        deliverySeq: event.deliverySeq,
+        revisionOps: event.commit.revisions.map((revision) => revision.op),
+        schedulerStatuses: event.commit.schedulerObservationResults?.map(
+          (result) => result.status,
+        ) ?? [],
+      })),
+      watchAdds: server.watchAddCount,
+    };
+  } finally {
+    await storage.close();
+    await channel?.dispose();
+    await writerClient.close();
+    await server.close();
+  }
+};
+
+Deno.test("executor host provider is behaviorally equivalent to authenticated loopback", async () => {
+  const loopback = await runProviderTrace("loopback");
+  const host = await runProviderTrace("host");
+  assertEquals(
+    { ...host, watchAdds: undefined },
+    { ...loopback, watchAdds: undefined },
+  );
+  assertEquals(host.watchAdds, 0);
+  assert(loopback.watchAdds > 0);
 });

--- a/packages/runner/test/fixtures/executor-provider-worker.ts
+++ b/packages/runner/test/fixtures/executor-provider-worker.ts
@@ -1,0 +1,78 @@
+/// <reference lib="webworker" />
+
+import type { MemorySpace, MIME, URI } from "@commonfabric/memory/interface";
+import { HostStorageManager } from "../../src/storage/v2-host-provider.ts";
+
+const worker = globalThis as unknown as DedicatedWorkerGlobalScope;
+const uri = "of:executor-provider:worker" as URI;
+const type = "application/json" as MIME;
+let storage: HostStorageManager | undefined;
+
+worker.addEventListener("message", (event: MessageEvent<unknown>) => {
+  void handleMessage(event.data).catch((error) => {
+    worker.postMessage({
+      type: "error",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  });
+});
+worker.postMessage({ type: "booted" });
+
+async function handleMessage(message: unknown): Promise<void> {
+  if (typeof message !== "object" || message === null) {
+    throw new Error("invalid executor provider worker message");
+  }
+  const input = message as Record<string, unknown>;
+  if (input.type === "dispose") {
+    await storage?.close();
+    storage = undefined;
+    worker.postMessage({ type: "disposed" });
+    return;
+  }
+  if (
+    input.type !== "init" || !(input.port instanceof MessagePort) ||
+    typeof input.principal !== "string" || typeof input.space !== "string"
+  ) {
+    throw new Error("invalid executor provider worker initialization");
+  }
+
+  storage = HostStorageManager.connect({
+    port: input.port,
+    principal: input.principal as MemorySpace,
+    space: input.space as MemorySpace,
+  });
+  const provider = storage.open(input.space as MemorySpace);
+  const replica = provider.replica;
+  if (!replica.commitNative) {
+    throw new Error("executor provider replica has no native commit path");
+  }
+  const sync = await provider.sync(uri);
+  if (sync.error) throw new Error(sync.error.message);
+  const committed = await replica.commitNative({
+    operations: [{
+      op: "set",
+      id: uri,
+      type,
+      value: { value: { version: 1, realm: "worker" } },
+    }],
+  });
+  if (committed.error) throw new Error(committed.error.message);
+
+  let reportedExternal = false;
+  storage.subscribe({
+    next(notification) {
+      const value = replica.get({ id: uri, type })?.is as
+        | { value?: { version?: number; realm?: string } }
+        | undefined;
+      if (
+        !reportedExternal && notification.type === "integrate" &&
+        value?.value?.version === 2 && value.value.realm === "external"
+      ) {
+        reportedExternal = true;
+        worker.postMessage({ type: "integrated" });
+      }
+      return { done: false };
+    },
+  });
+  worker.postMessage({ type: "committed" });
+}


### PR DESCRIPTION
## Summary

- add a host-owned MessagePort provider that keeps signer material and the memory Engine out of the Worker realm while preserving canonical authentication, ACL, CFC, conflict, and post-commit paths
- publish a frozen scalar-only accepted-commit feed and use authenticated point queries for invalidation, without session.watch
- abstract replica sessions and cover branch inheritance, scheduler snapshots, race ordering, failure containment, lifecycle cleanup, and loopback/provider parity

## Stack

- depends on #4686
- lease and fence validation remains the explicit W1.1 follow-up

## Validation

- deno fmt --check
- deno lint
- deno task check
- deno task check-docs
- focused provider and feed suites: 58 passed
- deno task test: passed
- deno task integration: 7/7 suites; all 89 pattern tests passed

## Review

Independent cf-review re-review found no remaining blockers after the provider hardening fixes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an authenticated host-side execution provider that runs over a MessagePort, keeping signer material and the memory Engine out of the Worker while preserving the canonical auth and commit paths. Adds an accepted-commit feed and direct invalidations so replicas refresh without `session.watch`.

- **New Features**
  - Introduced a host-backed provider (`HostStorageManager`) that bridges `@commonfabric/memory/v2` over a `MessagePort`, routes reads/writes through the server’s authenticated paths, and delivers ordered post-commit invalidations.
  - Server now emits an `AcceptedCommitEvent` feed; engine marks replayed commits to prevent duplicate deliveries; invalidation uses authenticated point queries instead of `session.watch`.
  - Abstracted replica sessions (`ReplicaSession`/`ReplicaClient`) so remote sessions and the host provider share the same interface; scheduler snapshots and SQLite passthrough supported.
  - Added parity and worker-realm tests to prove identical behavior vs loopback; integration test isolates spaces to avoid stale state. ExecutionLease fencing stays a W1.1 follow-up.

- **Bug Fixes**
  - Ordered observation delivery, hardened provider delivery, and ensured disposed channels are released to avoid races and leaks.

<sup>Written for commit d03f945683909e69a6c43b5574fe00ab36eba50e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

