### PR TITLE
feat(memory): record exact action execution provenance

### DIFF
--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -669,7 +669,15 @@ Claims and settlements are server-generated `SessionSync.execution.events`:
 type BranchId = string;
 interface ActionClaimKey {}
 interface ExecutionClaim extends ActionClaimKey {}
-interface ActionSettlement {}
+type InputBasisSeq = number; // nominal non-negative integer in TypeScript
+type AcceptedCommitSeq = number; // nominal positive integer in TypeScript
+interface ActionSettlement {
+  branch: BranchId;
+  claim: ExecutionClaim;
+  inputBasisSeq: InputBasisSeq;
+  outcome: "committed" | "no-op" | "failed" | "unserved";
+  acceptedCommitSeq?: AcceptedCommitSeq;
+}
 
 type ExecutionControlEvent =
   | { type: "session.execution.claim.set"; claim: ExecutionClaim }
@@ -698,6 +706,18 @@ execution. Settlements must match the exact branch, lease, and claim generation.
 forbid it. Client frames using these server-only message names are rejected by
 the strict parser. Retained events are filtered through the reconnecting
 session's current claim-routing/passivity sub-capabilities before replay.
+
+For an accepted scheduler action observation, memory derives `inputBasisSeq`
+from the exact confirmed read preconditions that passed validation plus pending
+reads translated to their accepted global commit sequence. It never substitutes
+the accepting head or trusts a Worker/client field. An executor-grade host
+connection may separately provide the exact live claim through a host-only
+apply option; memory then derives `onBehalfOf` from the authenticated session,
+stores canonical `ActionExecutionProvenance` with the observation, and emits an
+accepted action attempt. The normal Server path turns that attempt into a
+committed, no-op, or failed settlement only after acceptance. A committed
+settlement remains buffered until the local replica explicitly records that it
+applied `acceptedCommitSeq`; a transact response alone is not that barrier.
 
 ## 4.4 Selectors
 

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -667,8 +667,14 @@ Claims and settlements are server-generated `SessionSync.execution.events`:
 
 ```typescript
 type BranchId = string;
+type SchedulerExecutionContextKey = string;
 interface ActionClaimKey {}
 interface ExecutionClaim extends ActionClaimKey {}
+interface ExecutionClaimAssertion {
+  contextKey: SchedulerExecutionContextKey;
+  leaseGeneration: number;
+  claimGeneration: number;
+}
 type InputBasisSeq = number; // nominal non-negative integer in TypeScript
 type AcceptedCommitSeq = number; // nominal positive integer in TypeScript
 interface ActionSettlement {
@@ -711,11 +717,19 @@ For an accepted scheduler action observation, memory derives `inputBasisSeq`
 from the exact confirmed read preconditions that passed validation plus pending
 reads translated to their accepted global commit sequence. It never substitutes
 the accepting head or trusts a Worker/client field. An executor-grade host
-connection may separately provide the exact live claim through a host-only
-apply option; memory then derives `onBehalfOf` from the authenticated session,
-stores canonical `ActionExecutionProvenance` with the observation, and emits an
-accepted action attempt. The normal Server path turns that attempt into a
-committed, no-op, or failed settlement only after acceptance. A committed
+connection requires the scheduler observation's transient
+`executionClaimAssertion`, reconstructs the rest of the key from the same
+observation, and resolves the exact live claim through a host-only apply option.
+The assertion is only a selector: it is accepted only on the bound live
+connection/session-token/principal, stays in request replay identity, and is
+stripped from accepted scheduler state. Memory compares the engine-derived
+effective context to the claim, derives `onBehalfOf` from the authenticated
+session, stores canonical `ActionExecutionProvenance` with the observation, and
+emits an accepted action attempt. A stale/missing incarnation rejects the whole
+new attempt, while an exact accepted replay remains idempotent after revoke.
+Canonical accepted payload is reloaded for replay mirror fan-out, never rebuilt
+from client-supplied host fields. The normal Server path turns that attempt into
+a committed, no-op, or failed settlement only after acceptance. A committed
 settlement remains buffered until the local replica explicitly records that it
 applied `acceptedCommitSeq`; a transact response alone is not that barrier.
 

--- a/docs/specs/server-side-execution/README.md
+++ b/docs/specs/server-side-execution/README.md
@@ -541,6 +541,17 @@ the lease, the server appends trusted `ActionExecutionProvenance` —
 Those server-only fields are not inputs a client must predict to recognize a
 claim.
 
+Each executor action attempt does carry a transient
+`executionClaimAssertion` containing the effective context key and exact
+lease/claim generations captured when that attempt started. It is an untrusted
+selector, not provenance: the authenticated host reconstructs the rest of the
+key from the same scheduler observation, requires an exact live claim on the
+bound connection/session-token/principal, and the memory transaction verifies
+that the derived effective context equals the claim. The assertion is stripped
+from accepted scheduler state but retained in request replay identity. Thus a
+late generation cannot be relabeled onto a replacement claim, while an exact
+already-accepted replay remains idempotent after revoke.
+
 Initial eligibility is deliberately narrow: the complete action transaction
 must read and write only the same space's space-scoped cells. Static output
 bindings, declared reads/writes, materializer envelopes, and the writer index
@@ -734,7 +745,9 @@ and is separately attributable. It never signs client-pulled work.
   `ExecutionLease.leaseGeneration`; the provider rejects a stale generation.
   Within one lease, revoke names the action's live `claimGeneration` and the
   next claim issuance increments it, so delayed settlement cannot target the
-  new incarnation.
+  new incarnation. The attempt's exact assertion also prevents a delayed write
+  from being attributed to that new incarnation or silently becoming an
+  ordinary unclaimed write.
 - **Sponsor disconnect:** the worker finishes a bounded in-flight settle,
   drains, and restarts under another eligible requester. It does not change
   Runtime principal mid-settle.

--- a/docs/specs/server-side-execution/README.md
+++ b/docs/specs/server-side-execution/README.md
@@ -592,8 +592,12 @@ in which only the handler's *writes* ship, not the event itself.
 
 `observedAtSeq` is the sequence at which an observation commit was accepted;
 it is not proof of which inputs the action consumed. Each server run instead
-tracks `inputBasisSeq`, the maximum confirmed same-space input sequence
-actually read by that action. Derived patches carry that basis, and every
+tracks `inputBasisSeq`, the maximum same-space confirmed-read sequence accepted
+by the engine, with pending local reads translated to their server-assigned
+global sequence. Reads excluded from the canonical conflict set are excluded
+from the basis; no durable reads yields zero. The engine strips any supplied
+basis/provenance and authors the canonical values only after validation.
+Derived patches carry that basis, and every
 claimed run produces an `ActionSettlement` on the control/feed path:
 
 ```ts
@@ -1276,7 +1280,7 @@ means a design doc/decision is required before implementation.
 | G7 | Authenticated branch-qualified demand + reconnect claim snapshots + ordered doc-set delta feed carrying commit/settlement sequence barriers; closure export | B/feed | demand, reconnect snapshot, and ordered data/control barriers implemented; exact closure export remains later |
 | G8 | (retired — reactive interpreter de-scoped from this design, §3.4; its gates are tracked in its own specs) | — | retired |
 | G9 | Cross-space basis vectors, permissions, wake, and dual-space ownership | later expansion | explicitly client-authority in v1 |
-| G10 | Actual-read `inputBasisSeq` plus no-op/failure/unserved `ActionSettlement` and committed `acceptedCommitSeq` gating | B reconciliation | settlement protocol and client data gate implemented; actual basis/provenance and run emission are W0.4 |
+| G10 | Actual-read `inputBasisSeq` plus no-op/failure/unserved `ActionSettlement` and committed `acceptedCommitSeq` gating | B reconciliation | accepted-read basis, nominal sequence types, host-derived provenance, committed/no-op/failed run emission, and client data gate implemented; W1.3 emits unserved attempts |
 | G11 | Server builtin egress parity, relative serving-origin resolution, redirect/DNS revalidation | claimed async | needs-impl; full hardening may follow |
 | G12 | Durable streaming, quotas, circuit breakers, and cross-engine effect ledger | async hardening/failover | later; v1 preserves current behavior |
 | G13 | Signed event envelope format (serialize trusted-event provenance; replay protection; verify path) — design now, build in Phase 5 | dual handler execution (C) | needs-spec; request-proof precedent exists |

--- a/docs/specs/server-side-execution/implementation-plan.md
+++ b/docs/specs/server-side-execution/implementation-plan.md
@@ -345,6 +345,9 @@ surface; producer lookup uses declared, current-known, and materializer rows.
 
 **Depends on:** #4288.
 **Unblocks:** claim settlement and overlay reconciliation.
+**Status:** implemented. W1.1 replaces the dark generation-only provider
+binding with the durable fenced lease; W1.3 owns cross-space rejection and
+unserved-attempt production.
 
 **Problem:** the accepting commit/head sequence is not proof of which inputs an
 action consumed. A no-op action also produces no ordinary commit to acknowledge
@@ -360,7 +363,11 @@ that it settled.
 
 **Steps:**
 
-1. Track the revision sequence actually observed for every effective read. For
+1. Track the revision sequence actually observed for every effective read. An
+   effective read here means a same-space confirmed read precondition accepted
+   by the engine, plus a pending read translated from local sequence to its
+   accepted global sequence. Reads excluded from the canonical conflict set do
+   not enter the basis. For
    this same-space phase, inputBasisSeq is the maximum consumed same-space
    revision sequence, or zero for no durable reads. Do not substitute current
    head or accepting commit seq.
@@ -369,7 +376,8 @@ that it settled.
    - onBehalfOf user DID;
    - execution lease generation;
    - claimGeneration when the action is claimed;
-   - causedBy source commit sequence(s), when known;
+   - causedBy source commit sequence(s), as a sorted unique list when directly
+     known and an empty list otherwise (never substitute head or input basis);
    - inputBasisSeq.
 3. The host derives onBehalfOf from the authenticated sponsor lease and
    overwrites/rejects any worker- or client-supplied value. It means
@@ -395,20 +403,21 @@ that it settled.
 
 **Success criteria:**
 
-- [ ] An action reading an old revision while unrelated newer commits exist
+- [x] An action reading an old revision while unrelated newer commits exist
       records the old consumed basis, not head.
-- [ ] Two consumed inputs at S1 and S2 record max(S1,S2).
-- [ ] A no-op claimed action emits a settlement with its real basis despite
+- [x] Two consumed inputs at S1 and S2 record max(S1,S2); pending local reads
+      contribute their accepted global sequence and no durable reads yield zero.
+- [x] A no-op claimed action emits a settlement with its real basis despite
       producing no data commit.
-- [ ] A committed settlement cannot clear an overlay before the client has
+- [x] A committed settlement cannot clear an overlay before the client has
       applied the acceptedCommitSeq data patch, including forced reordering.
-- [ ] Commit seq and input basis are independently asserted and cannot be
+- [x] Commit seq and input basis are independently asserted and cannot be
       accidentally interchanged by type/API.
-- [ ] The store/control event records the sponsor user as onBehalfOf.
-- [ ] A forged onBehalfOf from worker IPC or a client is rejected/overwritten.
+- [x] The store/control event records the sponsor user as onBehalfOf.
+- [x] A forged onBehalfOf from worker IPC or a client is rejected/overwritten.
 - [ ] Cross-space input attempts are rejected by W1.3 rather than collapsed
       into this scalar.
-- [ ] Handler execution emits no new scheduler observation in this phase and
+- [x] Handler execution emits no new scheduler observation in this phase and
       preserves existing authenticated event/source provenance.
 
 ---

--- a/docs/specs/server-side-execution/implementation-plan.md
+++ b/docs/specs/server-side-execution/implementation-plan.md
@@ -389,9 +389,10 @@ that it settled.
    ActionClaimKey fields come from that same observation. A host-bound executor
    must match the exact live incarnation; revoke/reclaim, expiry, connection or
    session-token replacement, and effective-context mismatch reject the whole
-   attempt rather than relabeling or downgrading it. Strip the assertion before
-   persistence, but retain it in request replay identity. An exact accepted
-   replay remains idempotent after revoke.
+   attempt rather than relabeling or downgrading it. Strip the assertion from
+   accepted scheduler-state persistence, but retain it in the raw request's
+   replay/original-commit identity. An exact accepted replay remains idempotent
+   after revoke.
 5. Carry provenance through the normal validated transaction path and store it
    with scheduler observation/commit diagnostics.
 6. Separate acceptedCommitSeq from inputBasisSeq in types and tests.

--- a/docs/specs/server-side-execution/implementation-plan.md
+++ b/docs/specs/server-side-execution/implementation-plan.md
@@ -345,8 +345,9 @@ surface; producer lookup uses declared, current-known, and materializer rows.
 
 **Depends on:** #4288.
 **Unblocks:** claim settlement and overlay reconciliation.
-**Status:** implemented. W1.1 replaces the dark generation-only provider
-binding with the durable fenced lease; W1.3 owns cross-space rejection and
+**Status:** implemented. Each action attempt now carries an exact transient
+claim assertion while W1.1 still replaces the dark generation-only session
+binding with the durable fenced lease. W1.3 owns cross-space rejection and
 unserved-attempt production.
 
 **Problem:** the accepting commit/head sequence is not proof of which inputs an
@@ -383,19 +384,27 @@ that it settled.
    overwrites/rejects any worker- or client-supplied value. It means
    server-executed on behalf of this user, not semantic authorship of every
    input.
-4. Carry provenance through the normal validated transaction path and store it
+4. Capture a transient `executionClaimAssertion` when the action attempt starts:
+   effective context key, leaseGeneration, and claimGeneration. The remaining
+   ActionClaimKey fields come from that same observation. A host-bound executor
+   must match the exact live incarnation; revoke/reclaim, expiry, connection or
+   session-token replacement, and effective-context mismatch reject the whole
+   attempt rather than relabeling or downgrading it. Strip the assertion before
+   persistence, but retain it in request replay identity. An exact accepted
+   replay remains idempotent after revoke.
+5. Carry provenance through the normal validated transaction path and store it
    with scheduler observation/commit diagnostics.
-5. Separate acceptedCommitSeq from inputBasisSeq in types and tests.
-6. Add ActionSettlement emission for committed, no-op, failed, and unserved
+6. Separate acceptedCommitSeq from inputBasisSeq in types and tests.
+7. Add ActionSettlement emission for committed, no-op, failed, and unserved
    attempts. Settlement names the exact leaseGeneration + claimGeneration and
    inputBasisSeq. A committed settlement must carry acceptedCommitSeq; no-op
    has no data commit. Emit either only after the normal confirmed-read
    validation accepts the corresponding data or observation-only transaction.
-7. Co-order data patches and settlements on the session feed. A client may
+8. Co-order data patches and settlements on the session feed. A client may
    apply a committed settlement only after its confirmed/feed cursor reaches
    acceptedCommitSeq. No-op settlement follows the accepted observation-only
    transaction in that ordered stream.
-8. Do not add persistent scheduler observations for handler runs in this phase.
+9. Do not add persistent scheduler observations for handler runs in this phase.
    Handlers remain client-authoritative, their read sets do not participate in
    server-primary wake indexes, and existing event/source commit provenance
    remains unchanged. Phase 5 owns any handler-observation contract; handler
@@ -415,6 +424,14 @@ that it settled.
       accidentally interchanged by type/API.
 - [x] The store/control event records the sponsor user as onBehalfOf.
 - [x] A forged onBehalfOf from worker IPC or a client is rejected/overwritten.
+- [x] A delayed attempt cannot be relabeled onto a replacement
+      claimGeneration or downgraded after revoke; exact accepted replays remain
+      idempotent and a changed assertion replay-mismatches.
+- [x] Executor authority is bound to the exact live connection, session token,
+      and principal, and an effective context narrower than the claim rolls the
+      whole transaction back.
+- [x] Replay fan-out reloads the canonical accepted basis/provenance rather than
+      mirroring request-forged host fields.
 - [ ] Cross-space input attempts are rejected by W1.3 rather than collapsed
       into this scalar.
 - [x] Handler execution emits no new scheduler observation in this phase and

--- a/packages/memory/test/v2-execution-client-lifecycle-test.ts
+++ b/packages/memory/test/v2-execution-client-lifecycle-test.ts
@@ -8,6 +8,8 @@ import {
   type ActionSettlement,
   decodeMemoryBoundary,
   encodeMemoryBoundary,
+  toAcceptedCommitSeq,
+  toInputBasisSeq,
 } from "../v2.ts";
 import {
   TEST_SESSION_OPEN_AUDIENCE,
@@ -112,9 +114,9 @@ Deno.test("buffered settlements are dropped when their claim is replaced before 
       server.publishActionSettlement({
         branch: "",
         claim: first,
-        inputBasisSeq: commit.seq,
+        inputBasisSeq: toInputBasisSeq(commit.seq),
         outcome: "committed",
-        acceptedCommitSeq: commit.seq,
+        acceptedCommitSeq: toAcceptedCommitSeq(commit.seq),
       }),
       true,
     );

--- a/packages/memory/test/v2-execution-control-test.ts
+++ b/packages/memory/test/v2-execution-control-test.ts
@@ -185,7 +185,7 @@ const claimKey = (
   branch,
   space,
   contextKey: "space",
-  pieceId: "piece:one",
+  pieceId: "space:piece:one",
   actionId,
   actionKind: "computation",
   implementationFingerprint: "impl:v1",
@@ -205,7 +205,7 @@ const claimedSpaceObservation = (
   actionKind: claim.actionKind,
   implementationFingerprint: claim.implementationFingerprint,
   runtimeFingerprint: claim.runtimeFingerprint,
-  executionClaim: {
+  executionClaimAssertion: {
     contextKey: claim.contextKey,
     leaseGeneration: claim.leaseGeneration,
     claimGeneration: claim.claimGeneration,
@@ -218,7 +218,7 @@ const claimedSpaceObservation = (
     piece: {
       space: claim.space,
       scope: "space" as const,
-      id: claim.pieceId,
+      id: claim.pieceId.slice("space:".length),
       path: [],
     },
     reads: [],
@@ -829,7 +829,7 @@ Deno.test("accepted claimed runs derive provenance and settlements on the host",
       // This is an executor assertion about the exact claim incarnation under
       // which the attempt started. The host validates it against live control
       // state and never persists it as authority metadata.
-      executionClaim: {
+      executionClaimAssertion: {
         contextKey: claim.contextKey,
         leaseGeneration: claim.leaseGeneration,
         claimGeneration: claim.claimGeneration,
@@ -842,7 +842,7 @@ Deno.test("accepted claimed runs derive provenance and settlements on the host",
         piece: {
           space: POLICY_SPACE,
           scope: "space" as const,
-          id: claim.pieceId,
+          id: claim.pieceId.slice("space:".length),
           path: [],
         },
         reads: [{
@@ -1005,7 +1005,7 @@ Deno.test("accepted claimed runs derive provenance and settlements on the host",
     const failedObservation = {
       ...observation,
       actionId: failedClaim.actionId,
-      executionClaim: {
+      executionClaimAssertion: {
         contextKey: failedClaim.contextKey,
         leaseGeneration: failedClaim.leaseGeneration,
         claimGeneration: failedClaim.claimGeneration,
@@ -1241,6 +1241,105 @@ Deno.test("detached resumable sessions cannot acquire executor authority", async
       "live connection",
     );
   } finally {
+    await server.close();
+  }
+});
+
+Deno.test("an accepted claim replay stays idempotent after revoke", async () => {
+  const server = createControlServer("memory-v2-execution-replay-fence");
+  const client = await connectControlClient(server);
+  const session = await mount(client) as ExecutionSession;
+  let unbind = () => {};
+  try {
+    await setPolicy(session, true);
+    const firstClaim = server.setExecutionClaim({
+      ...claimKey(POLICY_SPACE, "", "action:replay-fence"),
+      leaseGeneration: 35,
+    });
+    unbind = server.bindExecutionSession(POLICY_SPACE, session.sessionId, {
+      leaseGeneration: firstClaim.leaseGeneration,
+    });
+    const commit = {
+      localSeq: 2,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set" as const,
+        id: "of:accepted-claim-replay",
+        value: { value: "accepted" },
+      }],
+      schedulerObservation: claimedSpaceObservation(
+        firstClaim,
+        "of:accepted-claim-replay",
+      ),
+    };
+    const accepted = await session.transact(commit);
+    assertEquals(accepted.actionAttempts?.[0]?.claim.claimGeneration, 1);
+    assertEquals(server.revokeExecutionClaim(firstClaim), true);
+
+    const replay = await session.transact(commit);
+    assertEquals(replay.seq, accepted.seq);
+    assertEquals(replay.actionAttempts, undefined);
+
+    const replacement = server.setExecutionClaim({
+      ...claimKey(POLICY_SPACE, "", "action:replay-fence"),
+      leaseGeneration: firstClaim.leaseGeneration,
+    });
+    await assertRejects(
+      () =>
+        session.transact({
+          ...commit,
+          schedulerObservation: claimedSpaceObservation(
+            replacement,
+            "of:accepted-claim-replay",
+          ),
+        }),
+      Error,
+      "replay mismatch",
+    );
+  } finally {
+    unbind();
+    await client.close();
+    await server.close();
+  }
+});
+
+Deno.test("an unbound client claim assertion cannot create executor provenance", async () => {
+  const server = createControlServer("memory-v2-execution-unbound-assertion");
+  const client = await connectControlClient(server);
+  const session = await mount(client) as ExecutionSession;
+  try {
+    await setPolicy(session, true);
+    const claim = server.setExecutionClaim({
+      ...claimKey(POLICY_SPACE, "", "action:unbound-assertion"),
+      leaseGeneration: 36,
+    });
+    await assertRejects(
+      () =>
+        session.transact({
+          localSeq: 2,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: "of:unbound-assertion-must-not-land",
+            value: { value: "forged" },
+          }],
+          schedulerObservation: claimedSpaceObservation(
+            claim,
+            "of:unbound-assertion-must-not-land",
+          ),
+        }),
+      Error,
+      "execution claim incarnation",
+    );
+    assertEquals(
+      await server.readDocument(
+        POLICY_SPACE,
+        "of:unbound-assertion-must-not-land",
+      ),
+      null,
+    );
+  } finally {
+    await client.close();
     await server.close();
   }
 });

--- a/packages/memory/test/v2-execution-control-test.ts
+++ b/packages/memory/test/v2-execution-control-test.ts
@@ -1,7 +1,11 @@
 import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import * as MemoryClient from "../v2/client.ts";
 import { parseClientMessage, Server } from "../v2/server.ts";
-import { decodeMemoryBoundary, encodeMemoryBoundary } from "../v2.ts";
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundary,
+  toDocumentPath,
+} from "../v2.ts";
 import {
   TEST_SESSION_OPEN_PRINCIPAL,
   testSessionOpenAuthFactory,
@@ -105,6 +109,11 @@ type ExecutionServer = Server & {
   expireExecutionClaims(now?: number): number;
   subscribeExecutionDemands(
     listener: (snapshot: ExecutionDemandSnapshot) => void,
+  ): () => void;
+  bindExecutionSession(
+    space: string,
+    sessionId: string,
+    authority: { leaseGeneration: number },
   ): () => void;
 };
 
@@ -686,6 +695,163 @@ Deno.test("committed settlement waits for its accepted data patch", async () => 
     unsubscribe();
     await writerClient.close();
     await observerClient.close();
+    await server.close();
+  }
+});
+
+Deno.test("accepted claimed runs derive provenance and settlements on the host", async () => {
+  const server = createControlServer("memory-v2-execution-provenance");
+  const client = await connectControlClient(server);
+  const session = await mount(client) as ExecutionSession;
+  const settlements: ActionSettlement[] = [];
+  const unsubscribeControl = session.subscribeExecutionControl((event) => {
+    if (event.type === "session.execution.settlement") {
+      settlements.push(event.settlement);
+    }
+  });
+  let unbind = () => {};
+  try {
+    await setPolicy(session, true);
+    const claim = server.setExecutionClaim({
+      ...claimKey(POLICY_SPACE, "", "action:provenance"),
+      leaseGeneration: 17,
+    });
+    unbind = server.bindExecutionSession(POLICY_SPACE, session.sessionId, {
+      leaseGeneration: claim.leaseGeneration,
+    });
+
+    const source = await session.transact({
+      localSeq: 2,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: "of:provenance-source",
+        value: { value: { count: 1 } },
+      }],
+    });
+    const observation = {
+      version: 2 as const,
+      ownerSpace: POLICY_SPACE,
+      branch: "",
+      pieceId: claim.pieceId,
+      processGeneration: 1,
+      actionId: claim.actionId,
+      actionKind: claim.actionKind,
+      implementationFingerprint: claim.implementationFingerprint,
+      runtimeFingerprint: claim.runtimeFingerprint,
+      observedAtSeq: 0,
+      // Both fields are deliberately forged. The host must derive/overwrite
+      // them from accepted reads and authenticated session authority.
+      inputBasisSeq: 999_999,
+      executionProvenance: {
+        claim,
+        onBehalfOf: "did:key:forged",
+        leaseGeneration: 999,
+        claimGeneration: 999,
+        causedBy: [999_999],
+        inputBasisSeq: 999_999,
+      },
+      transactionKind: "action-run" as const,
+      reads: [{
+        space: POLICY_SPACE,
+        scope: "space" as const,
+        id: "of:provenance-source",
+        path: ["value", "count"],
+      }],
+      shallowReads: [],
+      actualChangedWrites: [{
+        space: POLICY_SPACE,
+        scope: "space" as const,
+        id: "of:provenance-output",
+        path: ["value", "answer"],
+      }],
+      currentKnownWrites: [{
+        space: POLICY_SPACE,
+        scope: "space" as const,
+        id: "of:provenance-output",
+        path: ["value"],
+      }],
+      materializerWriteEnvelopes: [],
+      status: "success" as const,
+    };
+
+    const committed = await session.transact({
+      localSeq: 3,
+      reads: {
+        confirmed: [{
+          id: "of:provenance-source",
+          path: toDocumentPath(["value", "count"]),
+          seq: source.seq,
+        }],
+        pending: [],
+      },
+      operations: [{
+        op: "set",
+        id: "of:provenance-output",
+        value: { value: { answer: 2 } },
+      }],
+      schedulerObservation: observation,
+    });
+
+    const snapshots = await session.listSchedulerActionSnapshots({
+      actionId: claim.actionId,
+      pieceId: claim.pieceId,
+      processGeneration: 1,
+    });
+    const stored = snapshots.snapshots[0]?.observation as {
+      inputBasisSeq?: number;
+      executionProvenance?: {
+        claim: ActionClaimKey;
+        onBehalfOf: string;
+        leaseGeneration: number;
+        claimGeneration: number;
+        causedBy: number[];
+        inputBasisSeq: number;
+      };
+    };
+    assertEquals(stored.inputBasisSeq, source.seq);
+    assertEquals(stored.executionProvenance, {
+      claim: claimKey(POLICY_SPACE, "", "action:provenance"),
+      onBehalfOf: TEST_SESSION_OPEN_PRINCIPAL,
+      leaseGeneration: claim.leaseGeneration,
+      claimGeneration: claim.claimGeneration,
+      causedBy: [source.seq],
+      inputBasisSeq: source.seq,
+    });
+    assertEquals(settlements, [{
+      branch: "",
+      claim,
+      inputBasisSeq: source.seq,
+      outcome: "committed",
+      acceptedCommitSeq: committed.seq,
+    }]);
+
+    await session.transact({
+      localSeq: 4,
+      reads: {
+        confirmed: [{
+          id: "of:provenance-source",
+          path: toDocumentPath(["value", "count"]),
+          seq: source.seq,
+        }],
+        pending: [],
+      },
+      operations: [],
+      schedulerObservation: {
+        ...observation,
+        actualChangedWrites: [],
+      },
+    });
+    assertEquals(settlements.at(-1), {
+      branch: "",
+      claim,
+      inputBasisSeq: source.seq,
+      outcome: "no-op",
+    });
+  } finally {
+    unbind();
+    unsubscribeControl();
+    await client.close();
     await server.close();
   }
 });

--- a/packages/memory/test/v2-execution-control-test.ts
+++ b/packages/memory/test/v2-execution-control-test.ts
@@ -192,6 +192,76 @@ const claimKey = (
   runtimeFingerprint: "runtime:v1",
 });
 
+const claimedSpaceObservation = (
+  claim: ExecutionClaim,
+  outputId: string,
+) => ({
+  version: 2 as const,
+  ownerSpace: claim.space,
+  branch: claim.branch,
+  pieceId: claim.pieceId,
+  processGeneration: 1,
+  actionId: claim.actionId,
+  actionKind: claim.actionKind,
+  implementationFingerprint: claim.implementationFingerprint,
+  runtimeFingerprint: claim.runtimeFingerprint,
+  executionClaim: {
+    contextKey: claim.contextKey,
+    leaseGeneration: claim.leaseGeneration,
+    claimGeneration: claim.claimGeneration,
+  },
+  completeActionScopeSummary: {
+    version: 1 as const,
+    complete: true as const,
+    implementationFingerprint: claim.implementationFingerprint,
+    runtimeFingerprint: claim.runtimeFingerprint,
+    piece: {
+      space: claim.space,
+      scope: "space" as const,
+      id: claim.pieceId,
+      path: [],
+    },
+    reads: [],
+    writes: [{
+      space: claim.space,
+      scope: "space" as const,
+      id: outputId,
+      path: ["value"],
+    }],
+    materializerWriteEnvelopes: [],
+    directOutputs: [{
+      space: claim.space,
+      scope: "space" as const,
+      id: outputId,
+      path: ["value"],
+    }],
+  },
+  observedAtSeq: 0,
+  transactionKind: "action-run" as const,
+  reads: [],
+  shallowReads: [],
+  actualChangedWrites: [{
+    space: claim.space,
+    scope: "space" as const,
+    id: outputId,
+    path: ["value"],
+  }],
+  currentKnownWrites: [{
+    space: claim.space,
+    scope: "space" as const,
+    id: outputId,
+    path: ["value"],
+  }],
+  declaredWrites: [{
+    space: claim.space,
+    scope: "space" as const,
+    id: outputId,
+    path: ["value"],
+  }],
+  materializerWriteEnvelopes: [],
+  status: "success" as const,
+});
+
 class ReconnectableExecutionTransport implements MemoryClient.Transport {
   #receiver: (payload: string) => void = () => {};
   #closeReceiver: (error?: Error) => void = () => {};
@@ -756,6 +826,45 @@ Deno.test("accepted claimed runs derive provenance and settlements on the host",
       actionKind: claim.actionKind,
       implementationFingerprint: claim.implementationFingerprint,
       runtimeFingerprint: claim.runtimeFingerprint,
+      // This is an executor assertion about the exact claim incarnation under
+      // which the attempt started. The host validates it against live control
+      // state and never persists it as authority metadata.
+      executionClaim: {
+        contextKey: claim.contextKey,
+        leaseGeneration: claim.leaseGeneration,
+        claimGeneration: claim.claimGeneration,
+      },
+      completeActionScopeSummary: {
+        version: 1 as const,
+        complete: true as const,
+        implementationFingerprint: claim.implementationFingerprint,
+        runtimeFingerprint: claim.runtimeFingerprint,
+        piece: {
+          space: POLICY_SPACE,
+          scope: "space" as const,
+          id: claim.pieceId,
+          path: [],
+        },
+        reads: [{
+          space: POLICY_SPACE,
+          scope: "space" as const,
+          id: "of:provenance-source",
+          path: ["value", "count"],
+        }],
+        writes: [{
+          space: POLICY_SPACE,
+          scope: "space" as const,
+          id: "of:provenance-output",
+          path: ["value"],
+        }],
+        materializerWriteEnvelopes: [],
+        directOutputs: [{
+          space: POLICY_SPACE,
+          scope: "space" as const,
+          id: "of:provenance-output",
+          path: ["value"],
+        }],
+      },
       observedAtSeq: 0,
       // Both fields are deliberately forged. The host must derive/overwrite
       // them from accepted reads and authenticated session authority.
@@ -896,6 +1005,11 @@ Deno.test("accepted claimed runs derive provenance and settlements on the host",
     const failedObservation = {
       ...observation,
       actionId: failedClaim.actionId,
+      executionClaim: {
+        contextKey: failedClaim.contextKey,
+        leaseGeneration: failedClaim.leaseGeneration,
+        claimGeneration: failedClaim.claimGeneration,
+      },
       status: "failed" as const,
       errorFingerprint: "error:test",
       actualChangedWrites: [],
@@ -958,6 +1072,175 @@ Deno.test("accepted claimed runs derive provenance and settlements on the host",
     unbind();
     unsubscribeControl();
     await client.close();
+    await server.close();
+  }
+});
+
+Deno.test("bound executor rejects a delayed attempt after claim replacement", async () => {
+  const server = createControlServer("memory-v2-execution-stale-attempt");
+  const client = await connectControlClient(server);
+  const session = await mount(client) as ExecutionSession;
+  let unbind = () => {};
+  try {
+    await setPolicy(session, true);
+    const first = server.setExecutionClaim({
+      ...claimKey(POLICY_SPACE, "", "action:stale-attempt"),
+      leaseGeneration: 31,
+    });
+    unbind = server.bindExecutionSession(POLICY_SPACE, session.sessionId, {
+      leaseGeneration: first.leaseGeneration,
+    });
+    assertEquals(server.revokeExecutionClaim(first), true);
+    const replacement = server.setExecutionClaim({
+      ...claimKey(POLICY_SPACE, "", "action:stale-attempt"),
+      leaseGeneration: first.leaseGeneration,
+    });
+    assertEquals(replacement.claimGeneration, first.claimGeneration + 1);
+
+    await assertRejects(
+      () =>
+        session.transact({
+          localSeq: 2,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: "of:stale-attempt-must-not-land",
+            value: { value: "stale" },
+          }],
+          schedulerObservation: claimedSpaceObservation(
+            first,
+            "of:stale-attempt-must-not-land",
+          ),
+        }),
+      Error,
+      "execution claim incarnation",
+    );
+    assertEquals(
+      await server.readDocument(
+        POLICY_SPACE,
+        "of:stale-attempt-must-not-land",
+      ),
+      null,
+    );
+  } finally {
+    unbind();
+    await client.close();
+    await server.close();
+  }
+});
+
+Deno.test("bound executor never downgrades a revoked attempt to an ordinary write", async () => {
+  const server = createControlServer("memory-v2-execution-revoked-attempt");
+  const client = await connectControlClient(server);
+  const session = await mount(client) as ExecutionSession;
+  let unbind = () => {};
+  try {
+    await setPolicy(session, true);
+    const claim = server.setExecutionClaim({
+      ...claimKey(POLICY_SPACE, "", "action:revoked-attempt"),
+      leaseGeneration: 32,
+    });
+    unbind = server.bindExecutionSession(POLICY_SPACE, session.sessionId, {
+      leaseGeneration: claim.leaseGeneration,
+    });
+    assertEquals(server.revokeExecutionClaim(claim), true);
+
+    await assertRejects(
+      () =>
+        session.transact({
+          localSeq: 2,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: "of:revoked-attempt-must-not-land",
+            value: { value: "revoked" },
+          }],
+          schedulerObservation: claimedSpaceObservation(
+            claim,
+            "of:revoked-attempt-must-not-land",
+          ),
+        }),
+      Error,
+      "execution claim incarnation",
+    );
+    assertEquals(
+      await server.readDocument(
+        POLICY_SPACE,
+        "of:revoked-attempt-must-not-land",
+      ),
+      null,
+    );
+  } finally {
+    unbind();
+    await client.close();
+    await server.close();
+  }
+});
+
+Deno.test("claimed executor rejects an effective context narrower than its claim", async () => {
+  const server = createControlServer("memory-v2-execution-context-fence");
+  const client = await connectControlClient(server);
+  const session = await mount(client) as ExecutionSession;
+  let unbind = () => {};
+  try {
+    await setPolicy(session, true);
+    const claim = server.setExecutionClaim({
+      ...claimKey(POLICY_SPACE, "", "action:context-fence"),
+      leaseGeneration: 33,
+    });
+    unbind = server.bindExecutionSession(POLICY_SPACE, session.sessionId, {
+      leaseGeneration: claim.leaseGeneration,
+    });
+    const incomplete = claimedSpaceObservation(
+      claim,
+      "of:context-fence-must-not-land",
+    );
+    delete (incomplete as { completeActionScopeSummary?: unknown })
+      .completeActionScopeSummary;
+
+    await assertRejects(
+      () =>
+        session.transact({
+          localSeq: 2,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: "of:context-fence-must-not-land",
+            value: { value: "narrower" },
+          }],
+          schedulerObservation: incomplete,
+        }),
+      Error,
+      "execution claim context",
+    );
+    assertEquals(
+      await server.readDocument(POLICY_SPACE, "of:context-fence-must-not-land"),
+      null,
+    );
+  } finally {
+    unbind();
+    await client.close();
+    await server.close();
+  }
+});
+
+Deno.test("detached resumable sessions cannot acquire executor authority", async () => {
+  const server = createControlServer("memory-v2-execution-detached-binding");
+  const client = await connectControlClient(server);
+  const session = await mount(client) as ExecutionSession;
+  const sessionId = session.sessionId;
+  try {
+    await setPolicy(session, true);
+    await client.close();
+    assertThrows(
+      () =>
+        server.bindExecutionSession(POLICY_SPACE, sessionId, {
+          leaseGeneration: 34,
+        }),
+      Error,
+      "live connection",
+    );
+  } finally {
     await server.close();
   }
 });

--- a/packages/memory/test/v2-execution-control-test.ts
+++ b/packages/memory/test/v2-execution-control-test.ts
@@ -34,6 +34,7 @@ type ExecutionSession = MemoryClient.SpaceSession & {
   subscribeExecutionControl(
     listener: (event: ExecutionControlEvent) => void,
   ): () => void;
+  noteAppliedCommit(seq: number): void;
 };
 
 type ActionClaimKey = {
@@ -704,14 +705,28 @@ Deno.test("accepted claimed runs derive provenance and settlements on the host",
   const client = await connectControlClient(server);
   const session = await mount(client) as ExecutionSession;
   const settlements: ActionSettlement[] = [];
+  const firstSettlement = Promise.withResolvers<void>();
+  const secondSettlement = Promise.withResolvers<void>();
   const unsubscribeControl = session.subscribeExecutionControl((event) => {
     if (event.type === "session.execution.settlement") {
       settlements.push(event.settlement);
+      if (settlements.length === 1) firstSettlement.resolve();
+      if (settlements.length === 2) secondSettlement.resolve();
     }
   });
   let unbind = () => {};
   try {
     await setPolicy(session, true);
+    await session.watchSet([{
+      id: "provenance-output",
+      kind: "graph",
+      query: {
+        roots: [{
+          id: "of:provenance-output",
+          selector: { path: [], schema: true },
+        }],
+      },
+    }]);
     const claim = server.setExecutionClaim({
       ...claimKey(POLICY_SPACE, "", "action:provenance"),
       leaseGeneration: 17,
@@ -815,9 +830,19 @@ Deno.test("accepted claimed runs derive provenance and settlements on the host",
       onBehalfOf: TEST_SESSION_OPEN_PRINCIPAL,
       leaseGeneration: claim.leaseGeneration,
       claimGeneration: claim.claimGeneration,
-      causedBy: [source.seq],
+      causedBy: [],
       inputBasisSeq: source.seq,
     });
+    session.noteAppliedCommit(committed.seq);
+    await Promise.race([
+      firstSettlement.promise,
+      new Promise<never>((_resolve, reject) =>
+        setTimeout(
+          () => reject(new Error("committed settlement was not delivered")),
+          1_000,
+        )
+      ),
+    ]);
     assertEquals(settlements, [{
       branch: "",
       claim,
@@ -826,7 +851,7 @@ Deno.test("accepted claimed runs derive provenance and settlements on the host",
       acceptedCommitSeq: committed.seq,
     }]);
 
-    await session.transact({
+    const noop = await session.transact({
       localSeq: 4,
       reads: {
         confirmed: [{
@@ -842,6 +867,19 @@ Deno.test("accepted claimed runs derive provenance and settlements on the host",
         actualChangedWrites: [],
       },
     });
+    assertEquals(noop.actionAttempts?.map((attempt) => attempt.outcome), [
+      "no-op",
+    ]);
+    await server.flushSessions();
+    await Promise.race([
+      secondSettlement.promise,
+      new Promise<never>((_resolve, reject) =>
+        setTimeout(
+          () => reject(new Error("no-op settlement was not delivered")),
+          1_000,
+        )
+      ),
+    ]);
     assertEquals(settlements.at(-1), {
       branch: "",
       claim,

--- a/packages/memory/test/v2-execution-control-test.ts
+++ b/packages/memory/test/v2-execution-control-test.ts
@@ -707,11 +707,13 @@ Deno.test("accepted claimed runs derive provenance and settlements on the host",
   const settlements: ActionSettlement[] = [];
   const firstSettlement = Promise.withResolvers<void>();
   const secondSettlement = Promise.withResolvers<void>();
+  const thirdSettlement = Promise.withResolvers<void>();
   const unsubscribeControl = session.subscribeExecutionControl((event) => {
     if (event.type === "session.execution.settlement") {
       settlements.push(event.settlement);
       if (settlements.length === 1) firstSettlement.resolve();
       if (settlements.length === 2) secondSettlement.resolve();
+      if (settlements.length === 3) thirdSettlement.resolve();
     }
   });
   let unbind = () => {};
@@ -885,6 +887,72 @@ Deno.test("accepted claimed runs derive provenance and settlements on the host",
       claim,
       inputBasisSeq: source.seq,
       outcome: "no-op",
+    });
+
+    const failedClaim = server.setExecutionClaim({
+      ...claimKey(POLICY_SPACE, "", "action:provenance-failed"),
+      leaseGeneration: claim.leaseGeneration,
+    });
+    const failedObservation = {
+      ...observation,
+      actionId: failedClaim.actionId,
+      status: "failed" as const,
+      errorFingerprint: "error:test",
+      actualChangedWrites: [],
+    };
+    await assertRejects(
+      () =>
+        session.transact({
+          localSeq: 5,
+          reads: {
+            confirmed: [{
+              id: "of:provenance-source",
+              path: toDocumentPath(["value", "count"]),
+              seq: source.seq,
+            }],
+            pending: [],
+          },
+          operations: [{
+            op: "set",
+            id: "of:failed-must-not-land",
+            value: { value: true },
+          }],
+          schedulerObservation: failedObservation,
+        }),
+      Error,
+      "failed claimed actions must not include semantic operations",
+    );
+    assertEquals(
+      await server.readDocument(POLICY_SPACE, "of:failed-must-not-land"),
+      null,
+    );
+    await session.transact({
+      localSeq: 6,
+      reads: {
+        confirmed: [{
+          id: "of:provenance-source",
+          path: toDocumentPath(["value", "count"]),
+          seq: source.seq,
+        }],
+        pending: [],
+      },
+      operations: [],
+      schedulerObservation: failedObservation,
+    });
+    await Promise.race([
+      thirdSettlement.promise,
+      new Promise<never>((_resolve, reject) =>
+        setTimeout(
+          () => reject(new Error("failed settlement was not delivered")),
+          1_000,
+        )
+      ),
+    ]);
+    assertEquals(settlements.at(-1), {
+      branch: "",
+      claim: failedClaim,
+      inputBasisSeq: source.seq,
+      outcome: "failed",
     });
   } finally {
     unbind();

--- a/packages/memory/test/v2-execution-sequence-types-test.ts
+++ b/packages/memory/test/v2-execution-sequence-types-test.ts
@@ -1,0 +1,35 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  type ActionSettlement,
+  toAcceptedCommitSeq,
+  toInputBasisSeq,
+} from "../v2.ts";
+
+Deno.test("execution basis and accepted commit sequences stay nominally distinct", () => {
+  const inputBasisSeq = toInputBasisSeq(3);
+  const acceptedCommitSeq = toAcceptedCommitSeq(7);
+  assertEquals(Number(inputBasisSeq), 3);
+  assertEquals(Number(acceptedCommitSeq), 7);
+  assertThrows(() => toInputBasisSeq(-1), TypeError);
+  assertThrows(() => toAcceptedCommitSeq(0), TypeError);
+
+  type Committed = Extract<ActionSettlement, { outcome: "committed" }>;
+  const claim = {} as Committed["claim"];
+  const valid: Committed = {
+    branch: "",
+    claim,
+    inputBasisSeq,
+    outcome: "committed",
+    acceptedCommitSeq,
+  };
+  assertEquals(valid.inputBasisSeq, inputBasisSeq);
+
+  const swapped = {
+    ...valid,
+    // @ts-expect-error AcceptedCommitSeq must not satisfy InputBasisSeq.
+    inputBasisSeq: acceptedCommitSeq,
+    // @ts-expect-error InputBasisSeq must not satisfy AcceptedCommitSeq.
+    acceptedCommitSeq: inputBasisSeq,
+  } satisfies Committed;
+  void swapped;
+});

--- a/packages/memory/test/v2-scheduler-context-test.ts
+++ b/packages/memory/test/v2-scheduler-context-test.ts
@@ -1,7 +1,7 @@
 import { assert, assertEquals, assertExists } from "@std/assert";
 import { toFileUrl } from "@std/path";
 import { Database } from "@db/sqlite";
-import { encodeMemoryBoundary } from "../v2.ts";
+import { encodeMemoryBoundary, toInputBasisSeq } from "../v2.ts";
 import {
   applyCommit,
   close,
@@ -593,11 +593,17 @@ Deno.test("scheduler context keeps two PerSession rows for one principal", async
     });
 
     assertEquals(
-      storeObservation(engine, observation, ALICE_A).executionContextKey,
+      storeObservation(engine, {
+        ...observation,
+        inputBasisSeq: toInputBasisSeq(11),
+      }, ALICE_A).executionContextKey,
       ALICE_A_SESSION_KEY,
     );
     assertEquals(
-      storeObservation(engine, observation, ALICE_B).executionContextKey,
+      storeObservation(engine, {
+        ...observation,
+        inputBasisSeq: toInputBasisSeq(22),
+      }, ALICE_B).executionContextKey,
       ALICE_B_SESSION_KEY,
     );
     assertOwnedContexts(engine, actionId, [
@@ -625,6 +631,22 @@ Deno.test("scheduler context keeps two PerSession rows for one principal", async
       { write_scope_key: ALICE_A_SESSION_KEY },
       { write_scope_key: ALICE_B_SESSION_KEY },
     ]);
+    assertEquals(
+      listSchedulerActionSnapshots(engine, {
+        actionId,
+        applicableExecutionContextKeys: [
+          ALICE_A_SESSION_KEY,
+          ALICE_B_SESSION_KEY,
+        ],
+      }).snapshots.map((snapshot) => [
+        snapshot.executionContextKey,
+        Number(snapshot.observation.inputBasisSeq),
+      ]),
+      [
+        [ALICE_A_SESSION_KEY, 11],
+        [ALICE_B_SESSION_KEY, 22],
+      ],
+    );
   });
 });
 

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -3216,7 +3216,11 @@ Deno.test("memory v2 server does not resurrect a broader scheduler mirror on rep
     {},
     schedulerAuthFactoryFor(principal),
   );
-  await client.mount(readSpace, {}, schedulerAuthFactoryFor(principal));
+  const read = await client.mount(
+    readSpace,
+    {},
+    schedulerAuthFactoryFor(principal),
+  );
   const actionId = "pattern.tsx:computed:replay-mirror";
   const implementationFingerprint = `impl:${actionId}`;
   const piece = {
@@ -3254,6 +3258,24 @@ Deno.test("memory v2 server does not resurrect a broader scheduler mirror on rep
     pieceId: "space:of:piece",
     actionId,
     implementationFingerprint,
+    inputBasisSeq: 999 as never,
+    executionProvenance: {
+      claim: {
+        branch: "",
+        space: ownerSpace,
+        contextKey: "space" as const,
+        pieceId: "space:of:piece",
+        actionId,
+        actionKind: "computation" as const,
+        implementationFingerprint,
+        runtimeFingerprint: observation.runtimeFingerprint,
+      },
+      onBehalfOf: "did:key:forged-replay-principal",
+      leaseGeneration: 999,
+      claimGeneration: 999,
+      causedBy: [999],
+      inputBasisSeq: 999 as never,
+    },
     reads: [userRead],
     currentKnownWrites: [userWrite],
     completeActionScopeSummary: {
@@ -3299,6 +3321,26 @@ Deno.test("memory v2 server does not resurrect a broader scheduler mirror on rep
 
   try {
     await owner.transact(initialCommit);
+    await owner.transact(initialCommit);
+    const activeReplayMirror = await read.listSchedulerActionSnapshots({
+      actionId,
+      pieceId: userObservation.pieceId,
+      processGeneration: userObservation.processGeneration,
+    });
+    assertEquals(activeReplayMirror.snapshots.length, 1);
+    const mirroredObservation = activeReplayMirror.snapshots[0]
+      ?.observation as {
+        inputBasisSeq?: number;
+        executionProvenance?: unknown;
+      };
+    assertEquals(
+      mirroredObservation.inputBasisSeq,
+      0,
+    );
+    assertEquals(
+      mirroredObservation.executionProvenance,
+      undefined,
+    );
     const sessionResult = await owner.transact(sessionCommit);
     const changedSessionResult = await owner.transact({
       localSeq: 3,

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -570,6 +570,8 @@ Deno.test("memory v2 records the exact accepted input basis independently of hea
   const secondId = "of:basis-second";
   const semanticActionId = "basis:semantic";
   const noopActionId = "basis:no-op";
+  const pendingActionId = "basis:pending";
+  const zeroActionId = "basis:zero";
 
   try {
     const source = applyCommit(engine, {
@@ -691,6 +693,76 @@ Deno.test("memory v2 records the exact accepted input basis independently of hea
     );
     assertEquals(noopSnapshot?.observedAtSeq, noop.seq);
     assertEquals(noop.seq, semantic.seq);
+
+    const pendingSource = applyCommit(engine, {
+      sessionId: "session:basis-pending",
+      space: ownerSpace,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "of:basis-pending-source",
+          value: { value: 3 },
+        }],
+      },
+    });
+    applyCommit(engine, {
+      sessionId: "session:basis-pending",
+      space: ownerSpace,
+      commit: {
+        localSeq: 2,
+        reads: {
+          confirmed: [],
+          pending: [{
+            id: "of:basis-pending-source",
+            path: toDocumentPath(["value"]),
+            localSeq: 1,
+          }],
+        },
+        operations: [],
+        schedulerObservation: observationForAction(pendingActionId, {
+          ownerSpace,
+          actionKind: "effect",
+          reads: [{
+            space: ownerSpace,
+            scope: "space",
+            id: "of:basis-pending-source",
+            path: ["value"],
+          }],
+        }),
+      },
+    });
+    const pendingSnapshot = getLatestSchedulerActionSnapshot(engine, {
+      branch: "",
+      ownerSpace,
+      pieceId: observation.pieceId,
+      processGeneration: observation.processGeneration,
+      actionId: pendingActionId,
+    });
+    assertEquals(pendingSnapshot?.observation.inputBasisSeq, pendingSource.seq);
+
+    applyCommit(engine, {
+      sessionId: "session:basis-zero",
+      space: ownerSpace,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [],
+        schedulerObservation: observationForAction(zeroActionId, {
+          ownerSpace,
+          reads: [],
+        }),
+      },
+    });
+    const zeroSnapshot = getLatestSchedulerActionSnapshot(engine, {
+      branch: "",
+      ownerSpace,
+      pieceId: observation.pieceId,
+      processGeneration: observation.processGeneration,
+      actionId: zeroActionId,
+    });
+    assertEquals(zeroSnapshot?.observation.inputBasisSeq, 0);
   } finally {
     close(engine);
     await Deno.remove(path);

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -563,6 +563,140 @@ Deno.test("memory v2 accepts observation-only commits without semantic revisions
   }
 });
 
+Deno.test("memory v2 records the exact accepted input basis independently of head", async () => {
+  const { engine, path } = await createEngine();
+  const ownerSpace = "did:key:scheduler-input-basis";
+  const sourceId = "of:basis-source";
+  const secondId = "of:basis-second";
+  const semanticActionId = "basis:semantic";
+  const noopActionId = "basis:no-op";
+
+  try {
+    const source = applyCommit(engine, {
+      sessionId: "session:basis-source",
+      space: ownerSpace,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{ op: "set", id: sourceId, value: { value: 1 } }],
+      },
+    });
+    const second = applyCommit(engine, {
+      sessionId: "session:basis-source",
+      space: ownerSpace,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{ op: "set", id: secondId, value: { value: 2 } }],
+      },
+    });
+
+    const semantic = applyCommit(engine, {
+      sessionId: "session:basis-action",
+      space: ownerSpace,
+      commit: {
+        localSeq: 1,
+        reads: {
+          confirmed: [{
+            id: sourceId,
+            path: toDocumentPath(["value"]),
+            seq: source.seq,
+          }],
+          pending: [],
+        },
+        operations: [{
+          op: "set",
+          id: "of:basis-output",
+          value: { value: 10 },
+        }],
+        schedulerObservation: observationForAction(semanticActionId, {
+          ownerSpace,
+          reads: [{
+            space: ownerSpace,
+            scope: "space",
+            id: sourceId,
+            path: ["value"],
+          }],
+        }),
+      },
+    });
+    const semanticSnapshot = getLatestSchedulerActionSnapshot(engine, {
+      branch: "",
+      ownerSpace,
+      pieceId: observation.pieceId,
+      processGeneration: observation.processGeneration,
+      actionId: semanticActionId,
+    });
+    assertEquals(
+      (semanticSnapshot?.observation as
+        | (SchedulerActionObservation & { inputBasisSeq?: number })
+        | undefined)?.inputBasisSeq,
+      source.seq,
+    );
+    assertEquals(semanticSnapshot?.observedAtSeq, semantic.seq);
+    assertEquals(semantic.seq > second.seq, true);
+
+    const noop = applyCommit(engine, {
+      sessionId: "session:basis-action",
+      space: ownerSpace,
+      commit: {
+        localSeq: 2,
+        reads: {
+          confirmed: [
+            {
+              id: sourceId,
+              path: toDocumentPath(["value"]),
+              seq: source.seq,
+            },
+            {
+              id: secondId,
+              path: toDocumentPath(["value"]),
+              seq: second.seq,
+            },
+          ],
+          pending: [],
+        },
+        operations: [],
+        schedulerObservation: observationForAction(noopActionId, {
+          ownerSpace,
+          reads: [
+            {
+              space: ownerSpace,
+              scope: "space",
+              id: sourceId,
+              path: ["value"],
+            },
+            {
+              space: ownerSpace,
+              scope: "space",
+              id: secondId,
+              path: ["value"],
+            },
+          ],
+        }),
+      },
+    });
+    const noopSnapshot = getLatestSchedulerActionSnapshot(engine, {
+      branch: "",
+      ownerSpace,
+      pieceId: observation.pieceId,
+      processGeneration: observation.processGeneration,
+      actionId: noopActionId,
+    });
+    assertEquals(
+      (noopSnapshot?.observation as
+        | (SchedulerActionObservation & { inputBasisSeq?: number })
+        | undefined)?.inputBasisSeq,
+      second.seq,
+    );
+    assertEquals(noopSnapshot?.observedAtSeq, noop.seq);
+    assertEquals(noop.seq, semantic.seq);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
 Deno.test("memory v2 delivers first and changed no-op observations in the next commit window", async () => {
   const { engine, path } = await createEngine();
 

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -240,6 +240,82 @@ Deno.test("memory v2 migrates scheduler read indexes to include owner space", as
   }
 });
 
+Deno.test("memory v2 migrates canonical replay payload without changing snapshots", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  let engine = await openEngine({ url: toFileUrl(path) });
+  close(engine);
+
+  const legacyDb = new Database(path);
+  try {
+    legacyDb.exec(`
+      ALTER TABLE scheduler_observation_replay
+      DROP COLUMN accepted_payload;
+
+      INSERT INTO scheduler_observation_replay (
+        branch,
+        session_id,
+        local_seq,
+        status,
+        reason,
+        observation_id,
+        observed_at_seq,
+        payload
+      ) VALUES (
+        '',
+        'migration-session',
+        7,
+        'dropped',
+        'stale-confirmed-read',
+        NULL,
+        11,
+        '{}'
+      );
+    `);
+  } finally {
+    legacyDb.close();
+  }
+
+  engine = await openEngine({ url: toFileUrl(path) });
+  try {
+    const replayColumns = engine.database.prepare(
+      `PRAGMA table_info("scheduler_observation_replay")`,
+    ).all() as Array<{ name: string }>;
+    assertEquals(
+      replayColumns.some((column) => column.name === "accepted_payload"),
+      true,
+    );
+    const replay = engine.database.prepare(`
+      SELECT local_seq, status, reason, observed_at_seq, accepted_payload
+      FROM scheduler_observation_replay
+      WHERE session_id = 'migration-session'
+    `).get() as {
+      local_seq: number;
+      status: string;
+      reason: string;
+      observed_at_seq: number;
+      accepted_payload: string | null;
+    };
+    assertEquals(replay, {
+      local_seq: 7,
+      status: "dropped",
+      reason: "stale-confirmed-read",
+      observed_at_seq: 11,
+      accepted_payload: null,
+    });
+
+    const snapshotColumns = engine.database.prepare(
+      `PRAGMA table_info("scheduler_action_snapshot")`,
+    ).all() as Array<{ name: string }>;
+    assertEquals(
+      snapshotColumns.some((column) => column.name === "accepted_payload"),
+      false,
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
 Deno.test("memory v2 migrates legacy scheduler write and snapshot metadata", async () => {
   const path = await Deno.makeTempFile({ suffix: ".sqlite" });
   const legacyDb = new Database(path, { create: true });

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -376,6 +376,21 @@ export interface ExecutionClaim extends ActionClaimKey {
   expiresAt: number;
 }
 
+/**
+ * Host-authored metadata for one accepted server action transaction.
+ * `onBehalfOf` is execution authority, not semantic authorship. The host
+ * derives it from the authenticated sponsor session and derives the basis from
+ * the validated commit reads; Worker/client values are never authoritative.
+ */
+export interface ActionExecutionProvenance {
+  claim: ActionClaimKey;
+  onBehalfOf: string;
+  leaseGeneration: number;
+  claimGeneration: number;
+  causedBy: number[];
+  inputBasisSeq: number;
+}
+
 export interface ExecutionClaimSetEvent {
   type: "session.execution.claim.set";
   claim: ExecutionClaim;

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -376,6 +376,18 @@ export interface ExecutionClaim extends ActionClaimKey {
   expiresAt: number;
 }
 
+/**
+ * Transient executor assertion naming the exact live claim incarnation under
+ * which one action attempt started. It is accepted only from a host-bound
+ * executor session, checked against live control state, and stripped before
+ * scheduler observations are persisted. It is not provenance by itself.
+ */
+export interface ExecutionClaimAssertion {
+  contextKey: SchedulerExecutionContextKey;
+  leaseGeneration: number;
+  claimGeneration: number;
+}
+
 declare const inputBasisSeqBrand: unique symbol;
 declare const acceptedCommitSeqBrand: unique symbol;
 

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -376,6 +376,33 @@ export interface ExecutionClaim extends ActionClaimKey {
   expiresAt: number;
 }
 
+declare const inputBasisSeqBrand: unique symbol;
+declare const acceptedCommitSeqBrand: unique symbol;
+
+/** Maximum accepted input revision consumed by one action attempt. */
+export type InputBasisSeq = number & {
+  readonly [inputBasisSeqBrand]: "InputBasisSeq";
+};
+
+/** Semantic commit sequence assigned after canonical acceptance. */
+export type AcceptedCommitSeq = number & {
+  readonly [acceptedCommitSeqBrand]: "AcceptedCommitSeq";
+};
+
+export const toInputBasisSeq = (value: number): InputBasisSeq => {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError("input basis sequence must be a non-negative integer");
+  }
+  return value as InputBasisSeq;
+};
+
+export const toAcceptedCommitSeq = (value: number): AcceptedCommitSeq => {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError("accepted commit sequence must be a positive integer");
+  }
+  return value as AcceptedCommitSeq;
+};
+
 /**
  * Host-authored metadata for one accepted server action transaction.
  * `onBehalfOf` is execution authority, not semantic authorship. The host
@@ -388,7 +415,7 @@ export interface ActionExecutionProvenance {
   leaseGeneration: number;
   claimGeneration: number;
   causedBy: number[];
-  inputBasisSeq: number;
+  inputBasisSeq: InputBasisSeq;
 }
 
 export interface ExecutionClaimSetEvent {
@@ -408,15 +435,15 @@ export type ActionSettlement =
   | {
     branch: BranchName;
     claim: ExecutionClaim;
-    inputBasisSeq: number;
+    inputBasisSeq: InputBasisSeq;
     outcome: "committed";
-    acceptedCommitSeq: number;
+    acceptedCommitSeq: AcceptedCommitSeq;
     diagnosticCode?: never;
   }
   | {
     branch: BranchName;
     claim: ExecutionClaim;
-    inputBasisSeq: number;
+    inputBasisSeq: InputBasisSeq;
     outcome: "no-op" | "failed" | "unserved";
     acceptedCommitSeq?: never;
     diagnosticCode?: string;

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -614,6 +614,20 @@ export class SpaceSession {
     };
   }
 
+  /**
+   * Called by the replica after it has applied an accepted local commit. The
+   * transact response alone is not sufficient: resolving it precedes
+   * SpaceReplica.confirmPending(), while settlement must never clear an
+   * overlay before that data application barrier.
+   */
+  noteAppliedCommit(seq: number): void {
+    if (!Number.isSafeInteger(seq) || seq < 0) {
+      throw new TypeError("applied commit sequence must be non-negative");
+    }
+    this.#executionDataSeq = Math.max(this.#executionDataSeq, seq);
+    this.#flushPendingSettlements();
+  }
+
   initializeSync(sync: SessionSync): void {
     this.noteResult(sync.toSeq);
     this.#executionDataSeq = Math.max(this.#executionDataSeq, sync.toSeq);

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -916,6 +916,8 @@ export interface SchedulerActionObservation {
   runtimeFingerprint: string;
   completeActionScopeSummary?: CompleteActionScopeSummary;
   observedAtSeq: number;
+  /** Host-derived maximum accepted revision sequence in the commit read set. */
+  inputBasisSeq?: number;
   observedAtLocalSeq?: number;
   transactionKind: SchedulerObservationTransactionKind;
   reads: SchedulerObservationAddress[];
@@ -995,6 +997,9 @@ export const schedulerObservationFromValue = (
         ))) ||
     !Number.isSafeInteger(value.observedAtSeq) ||
     Number(value.observedAtSeq) < 0 ||
+    (value.inputBasisSeq !== undefined &&
+      (!Number.isSafeInteger(value.inputBasisSeq) ||
+        Number(value.inputBasisSeq) < 0)) ||
     (value.observedAtLocalSeq !== undefined &&
       (!Number.isSafeInteger(value.observedAtLocalSeq) ||
         Number(value.observedAtLocalSeq) < 0)) ||
@@ -5293,6 +5298,10 @@ const applyCommitTransaction = (
     branch,
     commit,
   );
+  const inputBasisSeq = acceptedInputBasisSeq(
+    commit.reads.confirmed,
+    resolvedPendingReads,
+  );
 
   const seq = (engine.statements.selectNextSeq.get() as { seq: number }).seq;
   const invocationRef = engine.legacyCommitMetadataRefsRequired
@@ -5379,7 +5388,12 @@ const applyCommitTransaction = (
       scopeContext: { principal: principal!, sessionId },
       writerSessionId: sessionKey,
       localSeq: commit.localSeq,
-      observation: schedulerObservation,
+      // The host derives the basis from the same confirmed/pending reads that
+      // just passed canonical validation. Never persist a caller assertion.
+      observation: {
+        ...schedulerObservation,
+        inputBasisSeq,
+      },
     })
     : undefined;
 
@@ -5738,6 +5752,41 @@ const resolvePendingReads = (
   return [...resolutions.values()].sort((a, b) => a.localSeq - b.localSeq);
 };
 
+/**
+ * Compute the scalar basis from reads whose revision identities are accepted
+ * by the canonical transaction path. Confirmed reads already name their
+ * durable sequence; pending reads use the server-assigned sequence of the
+ * source commit. The accepting head/commit sequence is deliberately absent.
+ */
+const acceptedInputBasisSeq = (
+  confirmed: ClientCommit["reads"]["confirmed"],
+  resolvedPending: readonly { seq: number }[],
+): number => {
+  let basis = 0;
+  for (const read of confirmed) basis = Math.max(basis, read.seq);
+  for (const read of resolvedPending) basis = Math.max(basis, read.seq);
+  return basis;
+};
+
+const resolvedPendingReadsForBasis = (
+  engine: Engine,
+  sessionKey: string,
+  reads: ClientCommit["reads"]["pending"],
+): { seq: number }[] => {
+  const resolutions = new Map<number, { seq: number }>();
+  for (const read of reads) {
+    if (resolutions.has(read.localSeq)) continue;
+    const row = engine.statements.selectPendingResolution.get({
+      session_id: sessionKey,
+      local_seq: read.localSeq,
+    }) as { seq: number } | undefined;
+    // A missing dependency is handled by the existing observation validation
+    // and the observation is dropped. It contributes no accepted basis.
+    if (row !== undefined) resolutions.set(read.localSeq, row);
+  }
+  return [...resolutions.values()];
+};
+
 const findConflictSeq = (
   engine: Engine,
   branch: BranchName,
@@ -5929,11 +5978,18 @@ const applySchedulerObservationOnlyCommit = (
   },
 ): AppliedCommit => {
   const observedAtSeq = headSeq(engine, branch);
+  const acceptedObservation: SchedulerActionObservation = {
+    ...schedulerObservation,
+    inputBasisSeq: acceptedInputBasisSeq(
+      reads.confirmed,
+      resolvedPendingReadsForBasis(engine, sessionKey, reads.pending),
+    ),
+  };
   const replayPayload = schedulerObservationReplayPayload({
     branch,
     observedAtSeq,
-    ownerSpace: space ?? schedulerObservation.ownerSpace,
-    observation: schedulerObservation,
+    ownerSpace: space ?? acceptedObservation.ownerSpace,
+    observation: acceptedObservation,
   });
   const existingReplay = getSchedulerObservationReplay(engine, {
     branch,
@@ -5992,7 +6048,7 @@ const applySchedulerObservationOnlyCommit = (
 
   const observationResult = upsertSchedulerObservationTransaction(engine, {
     branch,
-    ownerSpace: space ?? schedulerObservation.ownerSpace,
+    ownerSpace: space ?? acceptedObservation.ownerSpace,
     // An observation-only commit advances no semantic sequence, so reserve the
     // next GLOBAL server sequence as its delivery slot. `observedAtSeq` is the
     // selected branch's head and can lag the space-wide sync watermark after a
@@ -6004,7 +6060,7 @@ const applySchedulerObservationOnlyCommit = (
     scopeContext: { principal: principal!, sessionId },
     writerSessionId: sessionKey,
     localSeq,
-    observation: schedulerObservation,
+    observation: acceptedObservation,
   });
   return {
     seq: observedAtSeq,

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -20,6 +20,7 @@ import {
   type EntityDocument,
   type EntityId,
   type ExecutionClaim,
+  type ExecutionClaimAssertion,
   type InputBasisSeq,
   isEntityDocument,
   type Operation,
@@ -950,6 +951,8 @@ export interface SchedulerActionObservation {
   observedAtSeq: number;
   /** Host-derived maximum accepted revision sequence in the commit read set. */
   inputBasisSeq?: InputBasisSeq;
+  /** Transient exact-claim assertion; validated by the bound executor host. */
+  executionClaimAssertion?: ExecutionClaimAssertion;
   executionProvenance?: ActionExecutionProvenance;
   observedAtLocalSeq?: number;
   transactionKind: SchedulerObservationTransactionKind;
@@ -973,6 +976,23 @@ const isSchedulerRecord = (
   value: unknown,
 ): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
+
+const isSchedulerExecutionContextKey = (
+  value: unknown,
+): value is SchedulerExecutionContextKey =>
+  value === "space" ||
+  (typeof value === "string" &&
+    (/^user:[^:]+$/.test(value) || /^session:[^:]+:[^:]+$/.test(value)));
+
+const isExecutionClaimAssertion = (
+  value: unknown,
+): value is ExecutionClaimAssertion =>
+  isSchedulerRecord(value) &&
+  isSchedulerExecutionContextKey(value.contextKey) &&
+  Number.isSafeInteger(value.leaseGeneration) &&
+  Number(value.leaseGeneration) > 0 &&
+  Number.isSafeInteger(value.claimGeneration) &&
+  Number(value.claimGeneration) > 0;
 
 const isSchedulerObservationAddress = (value: unknown): boolean =>
   isSchedulerRecord(value) &&
@@ -1033,6 +1053,8 @@ export const schedulerObservationFromValue = (
     (value.inputBasisSeq !== undefined &&
       (!Number.isSafeInteger(value.inputBasisSeq) ||
         Number(value.inputBasisSeq) < 0)) ||
+    (value.executionClaimAssertion !== undefined &&
+      !isExecutionClaimAssertion(value.executionClaimAssertion)) ||
     (value.observedAtLocalSeq !== undefined &&
       (!Number.isSafeInteger(value.observedAtLocalSeq) ||
         Number(value.observedAtLocalSeq) < 0)) ||
@@ -1538,7 +1560,6 @@ CREATE TABLE scheduler_action_snapshot (
   commit_seq          INTEGER,
   observed_at_seq     INTEGER NOT NULL,
   payload             JSON    NOT NULL,
-  accepted_payload    JSON,
   PRIMARY KEY (
     branch,
     owner_space,
@@ -2326,9 +2347,9 @@ export const open = async (
     migrateSchedulerActionSnapshotOwnerSpaceKey(database);
     migrateSchedulerActionStateOwnerSpaceKey(database);
     migrateSchedulerObservationReplayStatus(database);
-    migrateSchedulerObservationReplayAcceptedPayload(database);
   }
   migrateSchedulerExecutionContextSchema(database);
+  migrateSchedulerObservationReplayAcceptedPayload(database);
   migrateSchedulerWriteLookupIndex(database);
   migrateSchedulerActionIndexes(database);
   return {
@@ -4571,6 +4592,7 @@ function getSchedulerObservationReplay(
   execution_context_key: SchedulerExecutionContextKey | null;
   observed_at_seq: number;
   payload: string;
+  accepted_payload: string | null;
 } | undefined {
   return engine.database.prepare(`
     SELECT
@@ -4578,6 +4600,7 @@ function getSchedulerObservationReplay(
       replay.reason,
       replay.observation_id,
       active_snapshot.execution_context_key,
+      active_snapshot.payload AS accepted_payload,
       replay.observed_at_seq,
       replay.payload
     FROM scheduler_observation_replay replay
@@ -4605,6 +4628,7 @@ function getSchedulerObservationReplay(
     execution_context_key: SchedulerExecutionContextKey | null;
     observed_at_seq: number;
     payload: string;
+    accepted_payload: string | null;
   } | undefined;
 }
 
@@ -5470,6 +5494,15 @@ const applyCommitTransaction = (
       observation: acceptedObservation.observation,
     })
     : undefined;
+  if (
+    acceptedObservation?.provenance !== undefined &&
+    schedulerObservationResult?.executionContextKey !==
+      acceptedObservation.provenance.claim.contextKey
+  ) {
+    throw new ProtocolError(
+      "execution claim context does not match the effective scheduler context",
+    );
+  }
 
   return {
     seq,
@@ -5903,15 +5936,22 @@ const acceptedSchedulerObservation = (
   observation: SchedulerActionObservation;
   provenance?: ActionExecutionProvenance;
 } => {
+  const assertedClaim = observation.executionClaimAssertion;
   // Reserved fields are host outputs. Strip any wire/Worker assertion before
   // constructing the canonical accepted observation.
   const {
     inputBasisSeq: _assertedBasis,
+    executionClaimAssertion: _assertedClaim,
     executionProvenance: _assertedProvenance,
     ...untrustedObservation
   } = observation;
   const claim = options.executionClaim;
   if (claim === undefined) {
+    if (assertedClaim !== undefined) {
+      throw new ProtocolError(
+        "execution claim incarnation is not live for this action attempt",
+      );
+    }
     return {
       observation: {
         ...untrustedObservation,
@@ -5920,6 +5960,10 @@ const acceptedSchedulerObservation = (
     };
   }
   if (
+    assertedClaim === undefined ||
+    assertedClaim.contextKey !== claim.contextKey ||
+    assertedClaim.leaseGeneration !== claim.leaseGeneration ||
+    assertedClaim.claimGeneration !== claim.claimGeneration ||
     options.principal === undefined || options.space === undefined ||
     claim.branch !== options.branch || claim.space !== options.space ||
     // Initial server execution is deliberately space-scoped. W1.3 owns the
@@ -5930,10 +5974,11 @@ const acceptedSchedulerObservation = (
     claim.actionKind !== observation.actionKind ||
     claim.implementationFingerprint !== observation.implementationFingerprint ||
     claim.runtimeFingerprint !== observation.runtimeFingerprint ||
-    observation.actionKind === "event-handler"
+    observation.actionKind === "event-handler" ||
+    observation.transactionKind !== "action-run"
   ) {
     throw new ProtocolError(
-      "execution claim does not match the accepted scheduler action",
+      "execution claim incarnation does not match the accepted scheduler action",
     );
   }
   const provenance: ActionExecutionProvenance = {
@@ -6083,6 +6128,7 @@ const replayedSchedulerObservationResult = (
     reason: AppliedSchedulerObservationResult["reason"] | null;
     observation_id: number | null;
     execution_context_key: SchedulerExecutionContextKey | null;
+    accepted_payload: string | null;
   },
 ): AppliedSchedulerObservationResult => {
   if (replay.status === "dropped") {
@@ -6097,12 +6143,21 @@ const replayedSchedulerObservationResult = (
       `kept scheduler observation replay missing observation identity for localSeq ${localSeq}`,
     );
   }
+  const accepted = replay.accepted_payload === null
+    ? undefined
+    : decodeSchedulerObservation(replay.accepted_payload);
   return {
     localSeq,
     status: "kept",
     schedulerObservationId: replay.observation_id,
     ...(replay.execution_context_key !== null
       ? { executionContextKey: replay.execution_context_key }
+      : {}),
+    ...(accepted?.inputBasisSeq !== undefined
+      ? { inputBasisSeq: accepted.inputBasisSeq }
+      : {}),
+    ...(accepted?.executionProvenance !== undefined
+      ? { executionProvenance: accepted.executionProvenance }
       : {}),
   };
 };
@@ -6157,22 +6212,14 @@ const applySchedulerObservationOnlyCommit = (
   },
 ): AppliedCommit => {
   const observedAtSeq = headSeq(engine, branch);
-  const inputBasisSeq = acceptedInputBasisSeq(
-    reads.confirmed,
-    resolvedPendingReadsForBasis(engine, sessionKey, reads.pending),
-  );
-  const accepted = acceptedSchedulerObservation(schedulerObservation, {
-    branch,
-    space,
-    principal,
-    inputBasisSeq,
-    executionClaim,
-  });
+  // Request replay identity retains the transient exact-claim assertion while
+  // excluding only host-authored acceptance fields. Check it before the live
+  // claim fence so a lost-response replay remains idempotent after revoke.
   const replayPayload = schedulerObservationReplayPayload({
     branch,
     observedAtSeq,
-    ownerSpace: space ?? accepted.observation.ownerSpace,
-    observation: accepted.observation,
+    ownerSpace: space ?? schedulerObservation.ownerSpace,
+    observation: schedulerObservation,
   });
   const existingReplay = getSchedulerObservationReplay(engine, {
     branch,
@@ -6199,6 +6246,18 @@ const applySchedulerObservationOnlyCommit = (
       schedulerObservationResults: [replayed],
     });
   }
+
+  const inputBasisSeq = acceptedInputBasisSeq(
+    reads.confirmed,
+    resolvedPendingReadsForBasis(engine, sessionKey, reads.pending),
+  );
+  const accepted = acceptedSchedulerObservation(schedulerObservation, {
+    branch,
+    space,
+    principal,
+    inputBasisSeq,
+    executionClaim,
+  });
 
   const dropReason = schedulerObservationReadDropReason(engine, {
     sessionKey,
@@ -6246,6 +6305,15 @@ const applySchedulerObservationOnlyCommit = (
     replayPayload,
     observation: accepted.observation,
   });
+  if (
+    accepted.provenance !== undefined &&
+    observationResult.executionContextKey !==
+      accepted.provenance.claim.contextKey
+  ) {
+    throw new ProtocolError(
+      "execution claim context does not match the effective scheduler context",
+    );
+  }
   return {
     seq: observedAtSeq,
     branch,

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -9,6 +9,7 @@ import {
 } from "./patch.ts";
 import { isPrefixPath, parentPath, pathsOverlap } from "./path.ts";
 import {
+  type AcceptedCommitSeq,
   type ActionExecutionProvenance,
   type BranchName,
   type CellScope,
@@ -19,6 +20,7 @@ import {
   type EntityDocument,
   type EntityId,
   type ExecutionClaim,
+  type InputBasisSeq,
   isEntityDocument,
   type Operation,
   type PatchOp,
@@ -28,6 +30,8 @@ import {
   type SessionId,
   type SqliteOperation,
   tableDeclaresRowLabel,
+  toAcceptedCommitSeq,
+  toInputBasisSeq,
 } from "../v2.ts";
 
 export type { SchedulerExecutionContextKey } from "../v2.ts";
@@ -846,7 +850,7 @@ export interface AppliedSchedulerObservationResult {
   /** Effective owner-derived context; emitted metadata, never client input. */
   executionContextKey?: SchedulerExecutionContextKey;
   /** Canonical accepted basis/provenance, emitted only for kept rows. */
-  inputBasisSeq?: number;
+  inputBasisSeq?: InputBasisSeq;
   executionProvenance?: ActionExecutionProvenance;
   reason?:
     | "stale-confirmed-read"
@@ -860,7 +864,7 @@ export type AppliedActionAttempt =
     claim: ExecutionClaim;
     provenance: ActionExecutionProvenance;
     outcome: "committed";
-    acceptedCommitSeq: number;
+    acceptedCommitSeq: AcceptedCommitSeq;
   }
   | {
     localSeq: number;
@@ -944,7 +948,7 @@ export interface SchedulerActionObservation {
   completeActionScopeSummary?: CompleteActionScopeSummary;
   observedAtSeq: number;
   /** Host-derived maximum accepted revision sequence in the commit read set. */
-  inputBasisSeq?: number;
+  inputBasisSeq?: InputBasisSeq;
   executionProvenance?: ActionExecutionProvenance;
   observedAtLocalSeq?: number;
   transactionKind: SchedulerObservationTransactionKind;
@@ -5467,7 +5471,7 @@ const applyCommitTransaction = (
           claim: executionClaims.get(commit.localSeq)!,
           provenance: acceptedObservation.provenance,
           outcome: "committed" as const,
-          acceptedCommitSeq: seq,
+          acceptedCommitSeq: toAcceptedCommitSeq(seq),
         }],
       }
       : {}),
@@ -5820,11 +5824,11 @@ const resolvePendingReads = (
 const acceptedInputBasisSeq = (
   confirmed: ClientCommit["reads"]["confirmed"],
   resolvedPending: readonly { seq: number }[],
-): number => {
+): InputBasisSeq => {
   let basis = 0;
   for (const read of confirmed) basis = Math.max(basis, read.seq);
   for (const read of resolvedPending) basis = Math.max(basis, read.seq);
-  return basis;
+  return toInputBasisSeq(basis);
 };
 
 const resolvedPendingReadsForBasis = (
@@ -5865,7 +5869,7 @@ const acceptedSchedulerObservation = (
     branch: BranchName;
     space?: string;
     principal?: string;
-    inputBasisSeq: number;
+    inputBasisSeq: InputBasisSeq;
     executionClaim?: ExecutionClaim;
   },
 ): {

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -9,6 +9,7 @@ import {
 } from "./patch.ts";
 import { isPrefixPath, parentPath, pathsOverlap } from "./path.ts";
 import {
+  type ActionExecutionProvenance,
   type BranchName,
   type CellScope,
   type ClientCommit,
@@ -17,6 +18,7 @@ import {
   encodeMemoryBoundary,
   type EntityDocument,
   type EntityId,
+  type ExecutionClaim,
   isEntityDocument,
   type Operation,
   type PatchOp,
@@ -811,6 +813,12 @@ export interface ApplyCommitOptions {
   invocationPayload?: FabricValue;
   authorization?: AuthorizationRecord;
   commit: ClientCommit;
+  /**
+   * Host-only exact live claims for scheduler observations in this commit,
+   * keyed by the observation localSeq. This never appears in ClientCommit or
+   * crosses the memory protocol boundary.
+   */
+  executionClaims?: ReadonlyMap<number, ExecutionClaim>;
   /** Map of cell-db id -> attach alias for `sqlite` ops in this commit. The
    *  server attaches these BEFORE applyCommit (ATTACH can't run in a txn); the
    *  apply loop executes the SQL inside the commit's transaction against the
@@ -837,11 +845,29 @@ export interface AppliedSchedulerObservationResult {
   schedulerObservationId?: number;
   /** Effective owner-derived context; emitted metadata, never client input. */
   executionContextKey?: SchedulerExecutionContextKey;
+  /** Canonical accepted basis/provenance, emitted only for kept rows. */
+  inputBasisSeq?: number;
+  executionProvenance?: ActionExecutionProvenance;
   reason?:
     | "stale-confirmed-read"
     | "stale-pending-read"
     | "pending-read-missing";
 }
+
+export type AppliedActionAttempt =
+  | {
+    localSeq: number;
+    claim: ExecutionClaim;
+    provenance: ActionExecutionProvenance;
+    outcome: "committed";
+    acceptedCommitSeq: number;
+  }
+  | {
+    localSeq: number;
+    claim: ExecutionClaim;
+    provenance: ActionExecutionProvenance;
+    outcome: "no-op" | "failed";
+  };
 
 export interface AppliedCommit {
   seq: number;
@@ -849,6 +875,7 @@ export interface AppliedCommit {
   revisions: AppliedRevision[];
   schedulerObservationId?: number;
   schedulerObservationResults?: AppliedSchedulerObservationResult[];
+  actionAttempts?: AppliedActionAttempt[];
   schedulerDirtiedReaders?: SchedulerReaderIndexEntry[];
 }
 
@@ -918,6 +945,7 @@ export interface SchedulerActionObservation {
   observedAtSeq: number;
   /** Host-derived maximum accepted revision sequence in the commit read set. */
   inputBasisSeq?: number;
+  executionProvenance?: ActionExecutionProvenance;
   observedAtLocalSeq?: number;
   transactionKind: SchedulerObservationTransactionKind;
   reads: SchedulerObservationAddress[];
@@ -5180,6 +5208,7 @@ const applyCommitTransaction = (
     space,
     principal,
     commit,
+    executionClaims,
     sqliteAttachments,
   }: ApplyCommitOptions,
 ): AppliedCommit => {
@@ -5273,6 +5302,7 @@ const applyCommitTransaction = (
       principal,
       branch,
       batch: schedulerObservationBatch,
+      executionClaims,
     });
   }
 
@@ -5286,6 +5316,7 @@ const applyCommitTransaction = (
       localSeq: commit.localSeq,
       reads: commit.reads,
       schedulerObservation,
+      executionClaim: executionClaims?.get(commit.localSeq),
     });
   }
 
@@ -5302,6 +5333,23 @@ const applyCommitTransaction = (
     commit.reads.confirmed,
     resolvedPendingReads,
   );
+  const acceptedObservation = schedulerObservation
+    ? acceptedSchedulerObservation(schedulerObservation, {
+      branch,
+      space,
+      principal,
+      inputBasisSeq,
+      executionClaim: executionClaims?.get(commit.localSeq),
+    })
+    : undefined;
+  if (
+    acceptedObservation?.provenance !== undefined &&
+    schedulerObservation?.status === "failed"
+  ) {
+    throw new ProtocolError(
+      "failed claimed actions must not include semantic operations",
+    );
+  }
 
   const seq = (engine.statements.selectNextSeq.get() as { seq: number }).seq;
   const invocationRef = engine.legacyCommitMetadataRefsRequired
@@ -5379,21 +5427,16 @@ const applyCommitTransaction = (
     });
   }
 
-  const schedulerObservationResult = schedulerObservation
+  const schedulerObservationResult = acceptedObservation
     ? upsertSchedulerObservationTransaction(engine, {
       branch,
-      ownerSpace: space ?? schedulerObservation.ownerSpace,
+      ownerSpace: space ?? acceptedObservation.observation.ownerSpace,
       commitSeq: seq,
       observedAtSeq: seq,
       scopeContext: { principal: principal!, sessionId },
       writerSessionId: sessionKey,
       localSeq: commit.localSeq,
-      // The host derives the basis from the same confirmed/pending reads that
-      // just passed canonical validation. Never persist a caller assertion.
-      observation: {
-        ...schedulerObservation,
-        inputBasisSeq,
-      },
+      observation: acceptedObservation.observation,
     })
     : undefined;
 
@@ -5409,6 +5452,22 @@ const applyCommitTransaction = (
           status: "kept" as const,
           schedulerObservationId: schedulerObservationResult.observationId,
           executionContextKey: schedulerObservationResult.executionContextKey,
+          inputBasisSeq,
+          ...(acceptedObservation?.provenance !== undefined
+            ? { executionProvenance: acceptedObservation.provenance }
+            : {}),
+        }],
+      }
+      : {}),
+    ...(acceptedObservation?.provenance !== undefined &&
+        executionClaims?.get(commit.localSeq) !== undefined
+      ? {
+        actionAttempts: [{
+          localSeq: commit.localSeq,
+          claim: executionClaims.get(commit.localSeq)!,
+          provenance: acceptedObservation.provenance,
+          outcome: "committed" as const,
+          acceptedCommitSeq: seq,
         }],
       }
       : {}),
@@ -5787,6 +5846,85 @@ const resolvedPendingReadsForBasis = (
   return [...resolutions.values()];
 };
 
+const claimKeyFromExecutionClaim = (
+  claim: ExecutionClaim,
+): ActionExecutionProvenance["claim"] => ({
+  branch: claim.branch,
+  space: claim.space,
+  contextKey: claim.contextKey,
+  pieceId: claim.pieceId,
+  actionId: claim.actionId,
+  actionKind: claim.actionKind,
+  implementationFingerprint: claim.implementationFingerprint,
+  runtimeFingerprint: claim.runtimeFingerprint,
+});
+
+const acceptedSchedulerObservation = (
+  observation: SchedulerActionObservation,
+  options: {
+    branch: BranchName;
+    space?: string;
+    principal?: string;
+    inputBasisSeq: number;
+    executionClaim?: ExecutionClaim;
+  },
+): {
+  observation: SchedulerActionObservation;
+  provenance?: ActionExecutionProvenance;
+} => {
+  // Reserved fields are host outputs. Strip any wire/Worker assertion before
+  // constructing the canonical accepted observation.
+  const {
+    inputBasisSeq: _assertedBasis,
+    executionProvenance: _assertedProvenance,
+    ...untrustedObservation
+  } = observation;
+  const claim = options.executionClaim;
+  if (claim === undefined) {
+    return {
+      observation: {
+        ...untrustedObservation,
+        inputBasisSeq: options.inputBasisSeq,
+      },
+    };
+  }
+  if (
+    options.principal === undefined || options.space === undefined ||
+    claim.branch !== options.branch || claim.space !== options.space ||
+    // Initial server execution is deliberately space-scoped. W1.3 owns the
+    // full firewall; a host cannot smuggle a narrower claim through W0.4.
+    claim.contextKey !== "space" ||
+    claim.pieceId !== observation.pieceId ||
+    claim.actionId !== observation.actionId ||
+    claim.actionKind !== observation.actionKind ||
+    claim.implementationFingerprint !== observation.implementationFingerprint ||
+    claim.runtimeFingerprint !== observation.runtimeFingerprint ||
+    observation.actionKind === "event-handler"
+  ) {
+    throw new ProtocolError(
+      "execution claim does not match the accepted scheduler action",
+    );
+  }
+  const provenance: ActionExecutionProvenance = {
+    claim: claimKeyFromExecutionClaim(claim),
+    onBehalfOf: options.principal,
+    leaseGeneration: claim.leaseGeneration,
+    claimGeneration: claim.claimGeneration,
+    // Invalidations currently retain addresses, not authoritative source
+    // sequences. Unknown is represented honestly as an empty sorted set.
+    causedBy: [],
+    inputBasisSeq: options.inputBasisSeq,
+  };
+  return {
+    provenance,
+    observation: {
+      ...untrustedObservation,
+      inputBasisSeq: options.inputBasisSeq,
+      executionProvenance: provenance,
+    },
+  };
+};
+
 const findConflictSeq = (
   engine: Engine,
   branch: BranchName,
@@ -5945,15 +6083,23 @@ const schedulerObservationReplayPayload = (
     ownerSpace?: string;
     observation: SchedulerActionObservation;
   },
-): string =>
-  encodeSchedulerDependencySnapshot(
+): string => {
+  // Replay identity is the client/Worker request, not host-derived acceptance
+  // metadata. A reconnect may reconstruct the same authority separately.
+  const {
+    inputBasisSeq: _acceptedBasis,
+    executionProvenance: _acceptedProvenance,
+    ...requestedObservation
+  } = options.observation;
+  return encodeSchedulerDependencySnapshot(
     normalizeSchedulerObservation(
-      options.observation,
+      requestedObservation as SchedulerActionObservation,
       options.branch,
       options.observedAtSeq,
       options.ownerSpace,
     ),
   );
+};
 
 const applySchedulerObservationOnlyCommit = (
   engine: Engine,
@@ -5966,6 +6112,7 @@ const applySchedulerObservationOnlyCommit = (
     localSeq,
     reads,
     schedulerObservation,
+    executionClaim,
   }: {
     sessionId: SessionId;
     sessionKey: string;
@@ -5975,21 +6122,26 @@ const applySchedulerObservationOnlyCommit = (
     localSeq: number;
     reads: ClientCommit["reads"];
     schedulerObservation: SchedulerActionObservation;
+    executionClaim?: ExecutionClaim;
   },
 ): AppliedCommit => {
   const observedAtSeq = headSeq(engine, branch);
-  const acceptedObservation: SchedulerActionObservation = {
-    ...schedulerObservation,
-    inputBasisSeq: acceptedInputBasisSeq(
-      reads.confirmed,
-      resolvedPendingReadsForBasis(engine, sessionKey, reads.pending),
-    ),
-  };
+  const inputBasisSeq = acceptedInputBasisSeq(
+    reads.confirmed,
+    resolvedPendingReadsForBasis(engine, sessionKey, reads.pending),
+  );
+  const accepted = acceptedSchedulerObservation(schedulerObservation, {
+    branch,
+    space,
+    principal,
+    inputBasisSeq,
+    executionClaim,
+  });
   const replayPayload = schedulerObservationReplayPayload({
     branch,
     observedAtSeq,
-    ownerSpace: space ?? acceptedObservation.ownerSpace,
-    observation: acceptedObservation,
+    ownerSpace: space ?? accepted.observation.ownerSpace,
+    observation: accepted.observation,
   });
   const existingReplay = getSchedulerObservationReplay(engine, {
     branch,
@@ -6048,7 +6200,7 @@ const applySchedulerObservationOnlyCommit = (
 
   const observationResult = upsertSchedulerObservationTransaction(engine, {
     branch,
-    ownerSpace: space ?? acceptedObservation.ownerSpace,
+    ownerSpace: space ?? accepted.observation.ownerSpace,
     // An observation-only commit advances no semantic sequence, so reserve the
     // next GLOBAL server sequence as its delivery slot. `observedAtSeq` is the
     // selected branch's head and can lag the space-wide sync watermark after a
@@ -6060,7 +6212,7 @@ const applySchedulerObservationOnlyCommit = (
     scopeContext: { principal: principal!, sessionId },
     writerSessionId: sessionKey,
     localSeq,
-    observation: acceptedObservation,
+    observation: accepted.observation,
   });
   return {
     seq: observedAtSeq,
@@ -6072,7 +6224,23 @@ const applySchedulerObservationOnlyCommit = (
       status: "kept",
       schedulerObservationId: observationResult.observationId,
       executionContextKey: observationResult.executionContextKey,
+      inputBasisSeq,
+      ...(accepted.provenance !== undefined
+        ? { executionProvenance: accepted.provenance }
+        : {}),
     }],
+    ...(accepted.provenance !== undefined && executionClaim !== undefined
+      ? {
+        actionAttempts: [{
+          localSeq,
+          claim: executionClaim,
+          provenance: accepted.provenance,
+          outcome: schedulerObservation.status === "failed"
+            ? "failed" as const
+            : "no-op" as const,
+        }],
+      }
+      : {}),
   };
 };
 
@@ -6085,6 +6253,7 @@ const applySchedulerObservationBatchCommit = (
     principal,
     branch,
     batch,
+    executionClaims,
   }: {
     sessionId: SessionId;
     sessionKey: string;
@@ -6092,9 +6261,11 @@ const applySchedulerObservationBatchCommit = (
     principal?: string;
     branch: BranchName;
     batch: NonNullable<ClientCommit["schedulerObservationBatch"]>;
+    executionClaims?: ReadonlyMap<number, ExecutionClaim>;
   },
 ): AppliedCommit => {
   const results: AppliedSchedulerObservationResult[] = [];
+  const actionAttempts: AppliedActionAttempt[] = [];
   let hasNewObservation = false;
   for (const item of batch) {
     const result = applySchedulerObservationOnlyCommit(engine, {
@@ -6107,9 +6278,11 @@ const applySchedulerObservationBatchCommit = (
       reads: item.reads,
       schedulerObservation: item
         .schedulerObservation as SchedulerActionObservation,
+      executionClaim: executionClaims?.get(item.localSeq),
     });
     hasNewObservation ||= !isAppliedCommitReplay(result);
     results.push(result.schedulerObservationResults![0]);
+    actionAttempts.push(...(result.actionAttempts ?? []));
   }
 
   const commit: AppliedCommit = {
@@ -6117,6 +6290,7 @@ const applySchedulerObservationBatchCommit = (
     branch,
     revisions: [],
     schedulerObservationResults: results,
+    ...(actionAttempts.length > 0 ? { actionAttempts } : {}),
   };
   return hasNewObservation ? commit : markAppliedCommitReplay(commit);
 };

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -199,6 +199,7 @@ CREATE TABLE IF NOT EXISTS scheduler_observation_replay (
   observation_id      INTEGER,
   observed_at_seq     INTEGER NOT NULL,
   payload             JSON    NOT NULL,
+  accepted_payload    JSON,
   created_at          TEXT    NOT NULL DEFAULT (datetime('now')),
   PRIMARY KEY (branch, session_id, local_seq),
   FOREIGN KEY (observation_id)
@@ -1537,6 +1538,7 @@ CREATE TABLE scheduler_action_snapshot (
   commit_seq          INTEGER,
   observed_at_seq     INTEGER NOT NULL,
   payload             JSON    NOT NULL,
+  accepted_payload    JSON,
   PRIMARY KEY (
     branch,
     owner_space,
@@ -1769,6 +1771,18 @@ FROM scheduler_observation_replay_legacy;
 DROP TABLE scheduler_observation_replay_legacy;
 
 COMMIT;
+`);
+};
+
+const migrateSchedulerObservationReplayAcceptedPayload = (
+  database: Database,
+): void => {
+  if (hasColumn(database, "scheduler_observation_replay", "accepted_payload")) {
+    return;
+  }
+  database.exec(`
+ALTER TABLE scheduler_observation_replay
+ADD COLUMN accepted_payload JSON;
 `);
 };
 
@@ -2312,6 +2326,7 @@ export const open = async (
     migrateSchedulerActionSnapshotOwnerSpaceKey(database);
     migrateSchedulerActionStateOwnerSpaceKey(database);
     migrateSchedulerObservationReplayStatus(database);
+    migrateSchedulerObservationReplayAcceptedPayload(database);
   }
   migrateSchedulerExecutionContextSchema(database);
   migrateSchedulerWriteLookupIndex(database);
@@ -2498,6 +2513,9 @@ export interface UpsertSchedulerObservationOptions {
   /** Canonical commit-session key used only for replay/echo provenance. */
   writerSessionId?: string;
   localSeq?: number;
+  /** Client-request replay identity when canonical host fields differ from the
+   * persisted observation payload. */
+  replayPayload?: string;
   observation: SchedulerActionObservation;
 }
 
@@ -2663,7 +2681,10 @@ const upsertSchedulerObservationTransaction = (
       status: "kept",
       observationId,
       observedAtSeq: options.observedAtSeq,
-      payload,
+      payload: options.replayPayload ?? payload,
+      ...(options.replayPayload !== undefined
+        ? { acceptedPayload: payload }
+        : {}),
     });
   }
 
@@ -4487,6 +4508,7 @@ function recordSchedulerObservationReplay(
     observationId?: number;
     observedAtSeq: number;
     payload: string;
+    acceptedPayload?: string;
   },
 ): void {
   runSchedulerObservationStatement("record observation replay", () => {
@@ -4499,7 +4521,8 @@ function recordSchedulerObservationReplay(
         reason,
         observation_id,
         observed_at_seq,
-        payload
+        payload,
+        accepted_payload
       )
       VALUES (
         :branch,
@@ -4509,7 +4532,8 @@ function recordSchedulerObservationReplay(
         :reason,
         :observation_id,
         :observed_at_seq,
-        :payload
+        :payload,
+        :accepted_payload
       )
       ON CONFLICT (branch, session_id, local_seq)
       DO UPDATE SET
@@ -4517,7 +4541,8 @@ function recordSchedulerObservationReplay(
         reason = excluded.reason,
         observation_id = excluded.observation_id,
         observed_at_seq = excluded.observed_at_seq,
-        payload = excluded.payload
+        payload = excluded.payload,
+        accepted_payload = excluded.accepted_payload
     `).run({
       branch: options.branch,
       session_id: options.sessionId,
@@ -4527,6 +4552,7 @@ function recordSchedulerObservationReplay(
       observation_id: options.observationId ?? null,
       observed_at_seq: options.observedAtSeq,
       payload: options.payload,
+      accepted_payload: options.acceptedPayload ?? null,
     });
   });
 }
@@ -4561,7 +4587,8 @@ function getSchedulerObservationReplay(
       ON active_snapshot.observation_id = observation.observation_id
       AND active_snapshot.execution_context_key =
         observation.execution_context_key
-      AND active_snapshot.payload = replay.payload
+      AND active_snapshot.payload =
+        COALESCE(replay.accepted_payload, replay.payload)
       AND active_snapshot.observed_at_seq = replay.observed_at_seq
       AND observation.session_id = replay.session_id
     WHERE replay.branch = :branch
@@ -6216,6 +6243,7 @@ const applySchedulerObservationOnlyCommit = (
     scopeContext: { principal: principal!, sessionId },
     writerSessionId: sessionKey,
     localSeq,
+    replayPayload,
     observation: accepted.observation,
   });
   return {

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -43,6 +43,7 @@ import {
   type SessionOpenResult,
   type SessionRevokedMessage,
   type SessionSync,
+  type SessionToken,
   type SqliteDbRef,
   type SqliteParamsWire,
   type SqliteQueryRequest,
@@ -448,7 +449,9 @@ const executionDemandKey = (
 type ExecutionClaimInput = ActionClaimKey & { leaseGeneration: number };
 
 type BoundExecutionSession = {
-  readonly connectionId: string | null;
+  readonly connectionId: string;
+  readonly sessionToken: SessionToken;
+  readonly principal: string;
   readonly leaseGeneration: number;
 };
 
@@ -1645,15 +1648,18 @@ export class Server {
     const session = this.#sessions.get(space, sessionId);
     if (
       session === null || session.principal === undefined ||
-      session.principal === ANYONE_USER
+      session.principal === ANYONE_USER || session.ownerConnectionId === null ||
+      !this.#connections.has(session.ownerConnectionId)
     ) {
       throw new Error(
-        "execution authority requires an authenticated live session",
+        "execution authority requires an authenticated session with a live connection",
       );
     }
     const key = sessionKey(space, sessionId);
     const binding: BoundExecutionSession = Object.freeze({
       connectionId: session.ownerConnectionId,
+      sessionToken: session.sessionToken,
+      principal: session.principal,
       leaseGeneration: authority.leaseGeneration,
     });
     this.#boundExecutionSessions.set(key, binding);
@@ -1871,16 +1877,42 @@ export class Server {
     ) {
       return undefined;
     }
+    if (
+      session.ownerConnectionId === null ||
+      binding.connectionId !== session.ownerConnectionId ||
+      binding.sessionToken !== session.sessionToken ||
+      binding.principal !== session.principal ||
+      !this.#connections.has(binding.connectionId)
+    ) {
+      this.#boundExecutionSessions.delete(sessionKey(space, session.id));
+      throw new Engine.ProtocolError(
+        "execution authority is not bound to this live session connection",
+      );
+    }
     this.expireExecutionClaims();
     const claims = new Map<number, ExecutionClaim>();
     for (const { localSeq, observation } of observations) {
-      // The first server-primary phase admits only space-scoped actions. The
-      // engine independently verifies this exact claim/action match before it
-      // authors provenance.
+      if (
+        observation.actionKind === "event-handler" ||
+        observation.transactionKind !== "action-run"
+      ) {
+        if (observation.executionClaimAssertion !== undefined) {
+          throw new Engine.ProtocolError(
+            "execution claim assertions are valid only for action attempts",
+          );
+        }
+        continue;
+      }
+      const expected = observation.executionClaimAssertion;
+      if (expected === undefined) {
+        throw new Engine.ProtocolError(
+          "bound executor action is missing an execution claim incarnation",
+        );
+      }
       const key: ActionClaimKey = {
         branch,
         space,
-        contextKey: "space",
+        contextKey: expected.contextKey,
         pieceId: observation.pieceId,
         actionId: observation.actionId,
         actionKind: observation.actionKind,
@@ -1890,7 +1922,9 @@ export class Server {
       const live = this.#executionClaims.get(actionClaimMapKey(key));
       if (
         live !== undefined &&
-        live.leaseGeneration === binding.leaseGeneration
+        live.leaseGeneration === binding.leaseGeneration &&
+        live.leaseGeneration === expected.leaseGeneration &&
+        live.claimGeneration === expected.claimGeneration
       ) {
         claims.set(localSeq, live);
       }
@@ -4547,15 +4581,21 @@ export class Server {
     );
     return observations.map(({ localSeq, observation }) => {
       const result = results.get(localSeq);
-      if (result?.status !== "kept" || result.inputBasisSeq === undefined) {
-        return { localSeq, observation };
-      }
+      const {
+        inputBasisSeq: _assertedBasis,
+        executionClaimAssertion: _assertedClaim,
+        executionProvenance: _assertedProvenance,
+        ...requestedObservation
+      } = observation;
       return {
         localSeq,
         observation: {
-          ...observation,
-          inputBasisSeq: result.inputBasisSeq,
-          ...(result.executionProvenance !== undefined
+          ...requestedObservation,
+          ...(result?.status === "kept" &&
+              result.inputBasisSeq !== undefined
+            ? { inputBasisSeq: result.inputBasisSeq }
+            : {}),
+          ...(result?.executionProvenance !== undefined
             ? { executionProvenance: result.executionProvenance }
             : {}),
         },

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -447,6 +447,11 @@ const executionDemandKey = (
 
 type ExecutionClaimInput = ActionClaimKey & { leaseGeneration: number };
 
+type BoundExecutionSession = {
+  readonly connectionId: string | null;
+  readonly leaseGeneration: number;
+};
+
 const actionClaimKey = (claim: ActionClaimKey): ActionClaimKey => ({
   branch: claim.branch,
   space: claim.space,
@@ -1078,6 +1083,7 @@ export class Server {
   #executionDemandOrder = 0;
   #executionClaims = new Map<string, ExecutionClaim>();
   #executionClaimGeneration = new Map<string, number>();
+  #boundExecutionSessions = new Map<string, BoundExecutionSession>();
   #executionPolicyEnabledSpaces = new Set<string>();
   #executionClaimExpiryTimer: ReturnType<typeof setTimeout> | null = null;
   #store?: URL;
@@ -1594,6 +1600,11 @@ export class Server {
   disconnect(connection: Connection): void {
     this.#connections.delete(connection.id);
     this.#removeExecutionDemands({ connectionId: connection.id });
+    for (const [key, binding] of this.#boundExecutionSessions) {
+      if (binding.connectionId === connection.id) {
+        this.#boundExecutionSessions.delete(key);
+      }
+    }
     if (this.#connections.size === 0) {
       this.cancelScheduledRefresh();
     }
@@ -1605,6 +1616,7 @@ export class Server {
     ownerConnectionId: string,
   ): void {
     this.#sessions.detach(space, sessionId, ownerConnectionId);
+    this.#boundExecutionSessions.delete(sessionKey(space, sessionId));
   }
 
   removeExecutionDemandsForSession(
@@ -1613,6 +1625,46 @@ export class Server {
     sessionId: string,
   ): void {
     this.#removeExecutionDemands({ connectionId, space, sessionId });
+    this.#boundExecutionSessions.delete(sessionKey(space, sessionId));
+  }
+
+  /**
+   * Bind one authenticated session to host-owned executor authority. This is a
+   * process API, never a protocol message; the Worker receives no sponsor key
+   * and cannot select `onBehalfOf`. W1.1 replaces the generation-only seam
+   * with the durable lease/fence record.
+   */
+  bindExecutionSession(
+    space: string,
+    sessionId: string,
+    authority: { leaseGeneration: number },
+  ): () => void {
+    if (!isPositiveSafeInteger(authority.leaseGeneration)) {
+      throw new TypeError("execution lease generation must be positive");
+    }
+    const session = this.#sessions.get(space, sessionId);
+    if (
+      session === null || session.principal === undefined ||
+      session.principal === ANYONE_USER
+    ) {
+      throw new Error(
+        "execution authority requires an authenticated live session",
+      );
+    }
+    const key = sessionKey(space, sessionId);
+    const binding: BoundExecutionSession = Object.freeze({
+      connectionId: session.ownerConnectionId,
+      leaseGeneration: authority.leaseGeneration,
+    });
+    this.#boundExecutionSessions.set(key, binding);
+    let bound = true;
+    return () => {
+      if (!bound) return;
+      bound = false;
+      if (this.#boundExecutionSessions.get(key) === binding) {
+        this.#boundExecutionSessions.delete(key);
+      }
+    };
   }
 
   listExecutionDemands(
@@ -1802,6 +1854,48 @@ export class Server {
         left.branch.localeCompare(right.branch) ||
         actionClaimMapKey(left).localeCompare(actionClaimMapKey(right))
       );
+  }
+
+  #executionClaimsForCommit(
+    space: string,
+    branch: BranchName,
+    session: SessionState,
+    observations: readonly CommitSchedulerObservation[],
+  ): ReadonlyMap<number, ExecutionClaim> | undefined {
+    const binding = this.#boundExecutionSessions.get(
+      sessionKey(space, session.id),
+    );
+    if (
+      binding === undefined || session.principal === undefined ||
+      session.principal === ANYONE_USER
+    ) {
+      return undefined;
+    }
+    this.expireExecutionClaims();
+    const claims = new Map<number, ExecutionClaim>();
+    for (const { localSeq, observation } of observations) {
+      // The first server-primary phase admits only space-scoped actions. The
+      // engine independently verifies this exact claim/action match before it
+      // authors provenance.
+      const key: ActionClaimKey = {
+        branch,
+        space,
+        contextKey: "space",
+        pieceId: observation.pieceId,
+        actionId: observation.actionId,
+        actionKind: observation.actionKind,
+        implementationFingerprint: observation.implementationFingerprint,
+        runtimeFingerprint: observation.runtimeFingerprint,
+      };
+      const live = this.#executionClaims.get(actionClaimMapKey(key));
+      if (
+        live !== undefined &&
+        live.leaseGeneration === binding.leaseGeneration
+      ) {
+        claims.set(localSeq, live);
+      }
+    }
+    return claims.size > 0 ? claims : undefined;
   }
 
   #executionControlSync(
@@ -2096,6 +2190,7 @@ export class Server {
     this.#executionDemandListeners.clear();
     this.#executionClaims.clear();
     this.#executionClaimGeneration.clear();
+    this.#boundExecutionSessions.clear();
     this.#executionPolicyEnabledSpaces.clear();
     this.#readPool.close();
   }
@@ -3021,6 +3116,12 @@ export class Server {
           const schedulerObservations = schedulerStateEnabled
             ? schedulerObservationsFromCommit(commitPayload)
             : [];
+          const executionClaims = this.#executionClaimsForCommit(
+            message.space,
+            message.commit.branch ?? "",
+            session,
+            schedulerObservations,
+          );
           const previousReadSpaces = new Map<number, Set<string>>();
           for (const { localSeq, observation } of schedulerObservations) {
             const previousSnapshots = Engine.listSchedulerActionSnapshots(
@@ -3068,6 +3169,7 @@ export class Server {
                     space: message.space,
                     principal: session.principal,
                     commit: commitPayload,
+                    executionClaims,
                     sqliteAttachments,
                   });
                 } finally {
@@ -3112,10 +3214,15 @@ export class Server {
               this.#revokeExecutionClaimsForSpace(message.space);
             }
           }
+          const acceptedSchedulerObservations = this
+            .#acceptedSchedulerObservations(
+              schedulerObservations,
+              commit,
+            );
           await this.runPostCommitSchedulerSideEffects(
             message.space,
             commit,
-            schedulerObservations,
+            acceptedSchedulerObservations,
             previousReadSpaces,
             session,
           );
@@ -3126,6 +3233,7 @@ export class Server {
               deliverySeq: acceptedDeliverySeq,
               commit,
             });
+            this.#publishAcceptedActionAttempts(commit);
           }
           this.markSpaceDirty(
             message.space,
@@ -4424,6 +4532,57 @@ export class Server {
         "Post-commit scheduler state update failed after semantic commit:",
         error,
       );
+    }
+  }
+
+  #acceptedSchedulerObservations(
+    observations: readonly CommitSchedulerObservation[],
+    commit: Engine.AppliedCommit,
+  ): CommitSchedulerObservation[] {
+    const results = new Map(
+      (commit.schedulerObservationResults ?? []).map((result) => [
+        result.localSeq,
+        result,
+      ]),
+    );
+    return observations.map(({ localSeq, observation }) => {
+      const result = results.get(localSeq);
+      if (result?.status !== "kept" || result.inputBasisSeq === undefined) {
+        return { localSeq, observation };
+      }
+      return {
+        localSeq,
+        observation: {
+          ...observation,
+          inputBasisSeq: result.inputBasisSeq,
+          ...(result.executionProvenance !== undefined
+            ? { executionProvenance: result.executionProvenance }
+            : {}),
+        },
+      };
+    });
+  }
+
+  #publishAcceptedActionAttempts(commit: Engine.AppliedCommit): void {
+    for (const attempt of commit.actionAttempts ?? []) {
+      const settlement: ActionSettlement = attempt.outcome === "committed"
+        ? {
+          branch: attempt.claim.branch,
+          claim: attempt.claim,
+          inputBasisSeq: attempt.provenance.inputBasisSeq,
+          outcome: "committed",
+          acceptedCommitSeq: attempt.acceptedCommitSeq,
+        }
+        : {
+          branch: attempt.claim.branch,
+          claim: attempt.claim,
+          inputBasisSeq: attempt.provenance.inputBasisSeq,
+          outcome: attempt.outcome,
+        };
+      // The attempt was accepted synchronously under this exact live claim.
+      // A false return now means expiry/revocation won during async post-commit
+      // side effects; never resurrect that stale authority.
+      this.publishActionSettlement(settlement);
     }
   }
 

--- a/packages/runner/src/scheduler/persistent-observation.ts
+++ b/packages/runner/src/scheduler/persistent-observation.ts
@@ -2,7 +2,10 @@ import type {
   IMemorySpaceAddress,
   TransactionReactivityLog,
 } from "../storage/interface.ts";
-import type { SchedulerExecutionContextKey } from "@commonfabric/memory/v2";
+import type {
+  ActionExecutionProvenance,
+  SchedulerExecutionContextKey,
+} from "@commonfabric/memory/v2";
 import { isCellScope } from "../scope.ts";
 
 export type SchedulerActionKind =
@@ -62,6 +65,8 @@ export interface SchedulerActionObservation {
    * commit read set; a runner/client value is never authoritative.
    */
   inputBasisSeq?: number;
+  /** Present only after an authenticated executor commit is accepted. */
+  executionProvenance?: ActionExecutionProvenance;
   observedAtLocalSeq?: number;
   transactionKind: SchedulerObservationTransactionKind;
   reads: IMemorySpaceAddress[];

--- a/packages/runner/src/scheduler/persistent-observation.ts
+++ b/packages/runner/src/scheduler/persistent-observation.ts
@@ -4,6 +4,7 @@ import type {
 } from "../storage/interface.ts";
 import type {
   ActionExecutionProvenance,
+  ExecutionClaimAssertion,
   InputBasisSeq,
   SchedulerExecutionContextKey,
 } from "@commonfabric/memory/v2";
@@ -66,6 +67,8 @@ export interface SchedulerActionObservation {
    * commit read set; a runner/client value is never authoritative.
    */
   inputBasisSeq?: InputBasisSeq;
+  /** Transient selector for the exact host claim used by this attempt. */
+  executionClaimAssertion?: ExecutionClaimAssertion;
   /** Present only after an authenticated executor commit is accepted. */
   executionProvenance?: ActionExecutionProvenance;
   observedAtLocalSeq?: number;

--- a/packages/runner/src/scheduler/persistent-observation.ts
+++ b/packages/runner/src/scheduler/persistent-observation.ts
@@ -56,6 +56,12 @@ export interface SchedulerActionObservation {
   implementationFingerprint: string;
   runtimeFingerprint: string;
   observedAtSeq: number;
+  /**
+   * Maximum durable same-space revision sequence actually consumed by this
+   * action. The memory host overwrites this at acceptance from the validated
+   * commit read set; a runner/client value is never authoritative.
+   */
+  inputBasisSeq?: number;
   observedAtLocalSeq?: number;
   transactionKind: SchedulerObservationTransactionKind;
   reads: IMemorySpaceAddress[];
@@ -186,6 +192,8 @@ export function isSchedulerActionObservation(
     typeof candidate.implementationFingerprint === "string" &&
     typeof candidate.runtimeFingerprint === "string" &&
     isNonNegativeInteger(candidate.observedAtSeq) &&
+    (candidate.inputBasisSeq === undefined ||
+      isNonNegativeInteger(candidate.inputBasisSeq)) &&
     (candidate.observedAtLocalSeq === undefined ||
       isNonNegativeInteger(candidate.observedAtLocalSeq)) &&
     isSchedulerObservationTransactionKind(candidate.transactionKind) &&

--- a/packages/runner/src/scheduler/persistent-observation.ts
+++ b/packages/runner/src/scheduler/persistent-observation.ts
@@ -4,6 +4,7 @@ import type {
 } from "../storage/interface.ts";
 import type {
   ActionExecutionProvenance,
+  InputBasisSeq,
   SchedulerExecutionContextKey,
 } from "@commonfabric/memory/v2";
 import { isCellScope } from "../scope.ts";
@@ -64,7 +65,7 @@ export interface SchedulerActionObservation {
    * action. The memory host overwrites this at acceptance from the validated
    * commit read set; a runner/client value is never authoritative.
    */
-  inputBasisSeq?: number;
+  inputBasisSeq?: InputBasisSeq;
   /** Present only after an authenticated executor commit is accepted. */
   executionProvenance?: ActionExecutionProvenance;
   observedAtLocalSeq?: number;

--- a/packages/runner/src/storage/v2-host-provider.ts
+++ b/packages/runner/src/storage/v2-host-provider.ts
@@ -511,6 +511,10 @@ class HostReplicaSession implements ReplicaSession {
     }
   }
 
+  noteAppliedCommit(seq: number): void {
+    this.session.noteAppliedCommit(seq);
+  }
+
   queryGraph(query: GraphQuery): Promise<GraphQueryResult> {
     return this.session.queryGraph({ ...query, branch: this.branch });
   }

--- a/packages/runner/src/storage/v2-host-provider.ts
+++ b/packages/runner/src/storage/v2-host-provider.ts
@@ -20,6 +20,7 @@ import {
   type SqliteRegisterDiskSourceResult,
   type V2Error,
   type WatchSpec,
+  type WireMemoryProtocolFlags,
 } from "@commonfabric/memory/v2";
 import * as MemoryClient from "@commonfabric/memory/v2/client";
 import {
@@ -59,6 +60,9 @@ export interface HostProviderChannelOptions {
   /** Host-owned grant creation. This callback and its credentials never cross
    *  the MessagePort into the Worker. */
   authorizeSessionOpen: MemoryClient.SessionOpenAuthFactory;
+  /** Host-only lease generation for canonical action provenance. W1.1 binds
+   * this to the durable fenced ExecutionLease before creating the channel. */
+  executionLeaseGeneration?: number;
 }
 
 export interface HostProviderChannel {
@@ -167,6 +171,7 @@ export function createHostProviderChannel(
   let disposed = false;
   let receiving = Promise.resolve();
   let unsubscribeAcceptedCommits = () => {};
+  let unbindExecutionSession = () => {};
 
   const connection = options.server.connect((message) => {
     if (disposed) return;
@@ -175,6 +180,20 @@ export function createHostProviderChannel(
       if (hello.sessionOpen !== undefined) {
         authContext = hello.sessionOpen;
       }
+    }
+    if (
+      options.executionLeaseGeneration !== undefined &&
+      message.type === "response" && "ok" in message &&
+      typeof message.ok === "object" && message.ok !== null &&
+      "sessionId" in message.ok &&
+      typeof message.ok.sessionId === "string"
+    ) {
+      unbindExecutionSession();
+      unbindExecutionSession = options.server.bindExecutionSession(
+        options.space,
+        message.ok.sessionId,
+        { leaseGeneration: options.executionLeaseGeneration },
+      );
     }
     hostPort.postMessage(
       {
@@ -188,6 +207,8 @@ export function createHostProviderChannel(
     if (disposed) return;
     disposed = true;
     unsubscribeAcceptedCommits();
+    unbindExecutionSession();
+    unbindExecutionSession = () => {};
     connection.close();
     try {
       hostPort.postMessage(
@@ -763,6 +784,7 @@ class HostSessionFactory implements SessionFactory {
     private readonly port: MessagePort,
     private readonly space: MemorySpace,
     private readonly branch: BranchName,
+    private readonly protocolFlags?: Partial<WireMemoryProtocolFlags>,
   ) {}
 
   async create(
@@ -774,7 +796,10 @@ class HostSessionFactory implements SessionFactory {
       throw new Error(`executor provider is bound to ${this.space}`);
     }
     const transport = new MessagePortTransport(this.port);
-    const client = await MemoryClient.connect({ transport });
+    const client = await MemoryClient.connect({
+      transport,
+      ...(this.protocolFlags ? { protocolFlags: this.protocolFlags } : {}),
+    });
     // This transferred channel is a lease-bound one-shot transport, not a
     // reconnectable network endpoint. A host close is terminal: close the
     // client so pending requests reject without starting the generic memory
@@ -811,6 +836,7 @@ export interface HostStorageManagerOptions {
   branch?: BranchName;
   id?: string;
   settings?: Options["settings"];
+  protocolFlags?: Partial<WireMemoryProtocolFlags>;
 }
 
 /** StorageManager construction available inside the executor Worker. */
@@ -829,6 +855,7 @@ export class HostStorageManager extends StorageManager {
         options.port,
         options.space,
         options.branch ?? "",
+        options.protocolFlags,
       ),
     );
   }

--- a/packages/runner/src/storage/v2-replica-session.ts
+++ b/packages/runner/src/storage/v2-replica-session.ts
@@ -34,6 +34,9 @@ export interface ReplicaSession {
   readonly sessionToken: string | undefined;
   readonly serverSeq: number;
   transact(commit: ClientCommit): Promise<AppliedCommit>;
+  /** Advance execution settlement gating only after the local replica has
+   * applied/confirmed the accepted commit data. */
+  noteAppliedCommit?(seq: number): void;
   queryGraph(query: GraphQuery): Promise<GraphQueryResult>;
   watchAddSync(watches: WatchSpec[]): Promise<{
     view: ReplicaWatchView;

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2578,6 +2578,7 @@ class SpaceReplica implements ISpaceReplica {
       const { session } = await this.sessionHandle();
       const applied = await session.transact(commit);
       this.confirmPending(localSeq, operations, applied);
+      session.noteAppliedCommit?.(applied.seq);
       return { ok: {} };
     } catch (error) {
       const rejection = toRejectedError(error, commit, this.#space);

--- a/packages/runner/test/executor-provider-parity.test.ts
+++ b/packages/runner/test/executor-provider-parity.test.ts
@@ -9,6 +9,7 @@ import type {
 } from "@commonfabric/memory/interface";
 import * as MemoryClient from "@commonfabric/memory/v2/client";
 import * as MemoryEngine from "@commonfabric/memory/v2/engine";
+import type { ActionSettlement } from "@commonfabric/memory/v2";
 import { resolveSpaceStoreUrl } from "@commonfabric/memory/v2/storage-path";
 import {
   type AcceptedCommitEvent,
@@ -260,6 +261,190 @@ Deno.test("executor host provider commits through authenticated memory without a
   } finally {
     await storage.close();
     await channel.dispose();
+    await server.close();
+  }
+});
+
+Deno.test("executor host provider binds accepted action provenance to its authenticated user", async () => {
+  const principal = await Identity.fromPassphrase(
+    `executor provenance provider ${crypto.randomUUID()}`,
+  );
+  const space = principal.did();
+  const flags = {
+    serverPrimaryExecutionV1: true,
+    serverPrimaryExecutionClaimRoutingV1: true,
+    serverPrimaryExecutionBuiltinPassivityV1: true,
+  } as const;
+  const server = new Server({
+    authorizeSessionOpen(message) {
+      const value = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof value === "string" ? value : undefined;
+    },
+    sessionOpenAuth: {
+      audience: "did:key:z6Mk-executor-provenance-test",
+    },
+    protocolFlags: flags,
+    acl: { mode: "off", serviceDids: [principal.did()] },
+  });
+  const authorizeSessionOpen: MemoryClient.SessionOpenAuthFactory = (
+    _space,
+    _session,
+    context,
+  ) => ({
+    invocation: {
+      aud: context.audience,
+      challenge: context.challenge.value,
+    },
+    authorization: { principal: principal.did() },
+  });
+  const observerClient = await MemoryClient.connect({
+    transport: MemoryClient.loopback(server),
+    protocolFlags: flags,
+  });
+  const observer = await observerClient.mount(
+    space,
+    {},
+    authorizeSessionOpen,
+  );
+  await observer.transact({
+    localSeq: 1,
+    reads: { confirmed: [], pending: [] },
+    operations: [{
+      op: "set",
+      id: `of:${space}:execution-policy`,
+      value: { value: { version: 1, serverPrimaryExecution: true } },
+    }],
+  });
+  await observer.watchSet([{
+    id: "executor-provenance-output",
+    kind: "graph",
+    query: {
+      roots: [{
+        id: "of:executor-provider:provenance-output",
+        selector: { path: [], schema: true },
+      }],
+    },
+  }]);
+
+  const actionId = "action:executor-provenance";
+  const baseObservation = schedulerObservationFor(space, actionId);
+  const claim = server.setExecutionClaim({
+    branch: "",
+    space,
+    contextKey: "space",
+    pieceId: baseObservation.pieceId,
+    actionId,
+    actionKind: "computation",
+    implementationFingerprint: baseObservation.implementationFingerprint,
+    runtimeFingerprint: baseObservation.runtimeFingerprint,
+    leaseGeneration: 23,
+  });
+  const channel = createHostProviderChannel({
+    server,
+    space,
+    authorizeSessionOpen,
+    executionLeaseGeneration: claim.leaseGeneration,
+  });
+  const storage = HostStorageManager.connect({
+    port: channel.port,
+    principal: principal.did(),
+    space,
+    protocolFlags: flags,
+  });
+  const settlement = Promise.withResolvers<ActionSettlement>();
+  const unsubscribe = observer.subscribeExecutionControl((event) => {
+    if (event.type === "session.execution.settlement") {
+      settlement.resolve(event.settlement);
+    }
+  });
+
+  try {
+    const replica = storage.open(space).replica;
+    assert(replica.commitNative);
+    const result = await replica.commitNative({
+      operations: [{
+        op: "set",
+        id: "of:executor-provider:provenance-output",
+        type: "application/json",
+        value: { value: { answer: 42 } },
+      }],
+      schedulerObservation: {
+        ...baseObservation,
+        inputBasisSeq: 999_999,
+        executionProvenance: {
+          claim,
+          onBehalfOf: "did:key:forged",
+          leaseGeneration: 999,
+          claimGeneration: 999,
+          causedBy: [999_999],
+          inputBasisSeq: 999_999,
+        },
+      },
+    });
+    assertEquals(result.error, undefined);
+
+    const snapshots = await observer.listSchedulerActionSnapshots({
+      actionId,
+      pieceId: baseObservation.pieceId,
+      processGeneration: baseObservation.processGeneration,
+    });
+    const stored = snapshots.snapshots[0]?.observation as {
+      inputBasisSeq?: number;
+      executionProvenance?: {
+        claim: {
+          branch: string;
+          space: string;
+          contextKey: string;
+          pieceId: string;
+          actionId: string;
+          actionKind: string;
+          implementationFingerprint: string;
+          runtimeFingerprint: string;
+        };
+        onBehalfOf: string;
+        leaseGeneration: number;
+        claimGeneration: number;
+        causedBy: number[];
+        inputBasisSeq: number;
+      };
+    };
+    assertEquals(stored.inputBasisSeq, 0);
+    assertEquals(stored.executionProvenance, {
+      claim: {
+        branch: "",
+        space,
+        contextKey: "space",
+        pieceId: claim.pieceId,
+        actionId,
+        actionKind: "computation",
+        implementationFingerprint: claim.implementationFingerprint,
+        runtimeFingerprint: claim.runtimeFingerprint,
+      },
+      onBehalfOf: principal.did(),
+      leaseGeneration: claim.leaseGeneration,
+      claimGeneration: claim.claimGeneration,
+      causedBy: [],
+      inputBasisSeq: 0,
+    });
+
+    await server.flushSessions();
+    const accepted = await Promise.race([
+      settlement.promise,
+      new Promise<never>((_resolve, reject) =>
+        setTimeout(
+          () => reject(new Error("executor settlement was not delivered")),
+          1_000,
+        )
+      ),
+    ]);
+    assertEquals(accepted.outcome, "committed");
+    assertEquals(accepted.inputBasisSeq, 0);
+  } finally {
+    unsubscribe();
+    await storage.close();
+    await channel.dispose();
+    await observerClient.close();
     await server.close();
   }
 });

--- a/packages/runner/test/executor-provider-parity.test.ts
+++ b/packages/runner/test/executor-provider-parity.test.ts
@@ -958,9 +958,11 @@ Deno.test("executor host provider carries authenticated scheduler observations o
       updatedNotification.observations[0]?.observation as {
         status?: string;
         errorFingerprint?: string;
+        inputBasisSeq?: number;
       },
       {
         ...externalObservation,
+        inputBasisSeq: 0,
         status: "failed",
         errorFingerprint: "error:second-observation",
       },

--- a/packages/runner/test/executor-provider-parity.test.ts
+++ b/packages/runner/test/executor-provider-parity.test.ts
@@ -371,6 +371,11 @@ Deno.test("executor host provider binds accepted action provenance to its authen
       }],
       schedulerObservation: {
         ...baseObservation,
+        executionClaimAssertion: {
+          contextKey: claim.contextKey,
+          leaseGeneration: claim.leaseGeneration,
+          claimGeneration: claim.claimGeneration,
+        },
         inputBasisSeq: 999_999,
         executionProvenance: {
           claim,

--- a/packages/runner/test/scheduler-events.test.ts
+++ b/packages/runner/test/scheduler-events.test.ts
@@ -103,6 +103,61 @@ describe("event handling", () => {
     expect(eventResultCell.get()).toBe(2);
   });
 
+  it("keeps handler runs out of persistent action observations", async () => {
+    const eventCell = runtime.getCell<number>(
+      space,
+      "handler observation exclusion event",
+      undefined,
+      tx,
+    );
+    const resultCell = runtime.getCell<number>(
+      space,
+      "handler observation exclusion result",
+      undefined,
+      tx,
+    );
+    eventCell.set(0);
+    resultCell.set(0);
+    await tx.commit();
+
+    let schedulerObservationWrites = 0;
+    const originalEdit = runtime.edit.bind(runtime);
+    runtime.edit = ((...args: Parameters<typeof originalEdit>) => {
+      const handlerTx = originalEdit(...args);
+      const originalSet = handlerTx.setSchedulerObservation?.bind(handlerTx);
+      handlerTx.setSchedulerObservation = (observation: unknown) => {
+        schedulerObservationWrites++;
+        originalSet?.(observation);
+      };
+      return handlerTx;
+    }) as typeof runtime.edit;
+
+    const handler = Object.assign(
+      ((handlerTx: IExtendedStorageTransaction, event: unknown) => {
+        resultCell.withTx(handlerTx).send(event as number);
+      }) as EventHandler,
+      {
+        implementationHash: "cf:module/test-handler:observation-exclusion",
+        schedulerObservationIdentity: {
+          ownerSpace: space,
+          branch: "",
+          pieceId: "space:handler-observation-exclusion",
+          processGeneration: 1,
+        },
+      },
+    );
+    runtime.scheduler.addEventHandler(
+      handler,
+      eventCell.getAsNormalizedFullLink(),
+    );
+
+    runtime.scheduler.queueEvent(eventCell.getAsNormalizedFullLink(), 7);
+    await resultCell.pull();
+
+    expect(resultCell.get()).toBe(7);
+    expect(schedulerObservationWrites).toBe(0);
+  });
+
   it("awaits presyncInputs before running the handler body", async () => {
     const eventCell = runtime.getCell<number>(
       space,


### PR DESCRIPTION
## Summary

- derive `inputBasisSeq` from the confirmed and resolved-pending reads actually accepted by memory, including no-op, failed, batched, and zero-read attempts
- author canonical `ActionExecutionProvenance` from the authenticated executor session and an exact per-attempt claim assertion; stale generations, detached session incarnations, and effective-context mismatch fail atomically
- emit committed, no-op, and failed settlements only after canonical acceptance and gate committed delivery on local application of `acceptedCommitSeq`
- preserve canonical basis and provenance through replay and cross-space mirror repair while excluding handlers from persistent action observations

## Stack

Depends on #4689. W1.1 replaces the interim generation-only session binding with a durable fenced lease. W1.3 adds the whole-action scope firewall and unserved outcomes; W1.4 completes external effect lifecycle settlement.

## Validation

- `deno fmt --check`
- `deno lint`
- `deno task check`
- `deno task check-docs` (510 blocks)
- package memory suite: 444 passed, 140 steps
- provider parity: 12 passed
- scheduler events: 22 steps
- `EXPERIMENTAL_SERVER_PRIMARY_EXECUTION=true deno task test` (all workspace packages)
- `EXPERIMENTAL_SERVER_PRIMARY_EXECUTION=true deno task integration` (7/7 groups; all 89 pattern tests)
- independent cf-review re-review: no blockers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record exact action execution provenance for server-side actions: derive the canonical input basis from accepted reads, fence attempts to the exact live claim, and gate committed settlements on applied data. Provenance is preserved across replay/mirroring and handler runs are excluded from persistent observations.

- **New Features**
  - Compute `inputBasisSeq` from confirmed and resolved-pending reads (covers no-op, failed, batched, and zero-read attempts). Introduce branded `InputBasisSeq` and `AcceptedCommitSeq` with helpers `toInputBasisSeq` and `toAcceptedCommitSeq`.
  - Author canonical `ActionExecutionProvenance` from the authenticated executor session. Each attempt includes a transient `ExecutionClaimAssertion` (`contextKey`, `leaseGeneration`, `claimGeneration`) that must match an exact live claim; it’s stripped from persisted observations but retained for replay identity.
  - Emit `committed`, `no-op`, `failed`, and `unserved` settlements only after canonical acceptance. Gate committed delivery on local application of `acceptedCommitSeq` via `SpaceSession.noteAppliedCommit`.
  - Preserve canonical basis and provenance through replay and cross-space mirror repair; exclude handler runs from persistent action observations.

- **Migration**
  - Tests that publish settlements should convert sequences with `toInputBasisSeq` and `toAcceptedCommitSeq`.
  - Hosts using `@commonfabric/memory/v2` can pass `executionLeaseGeneration` and bind the execution session to ensure provenance is tied to the authenticated user.

<sup>Written for commit 3484453b6376c7c2c6ac78944e92ab8f7736b1ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

