### PR TITLE
feat(execution): default server-primary execution on

### DIFF
--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -273,7 +273,7 @@ Most shell config is **build-time**: esbuild injects defines in
 | `COMMIT_SHA` | `$COMMIT_SHA` | _(unset)_ | Surfaced for debugging. |
 | `EXPERIMENTAL_MODERN_CELL_REP` | `EXPERIMENTAL.modernCellRep` | _(unset)_ | See experimental flags. |
 | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` | `EXPERIMENTAL.persistentSchedulerState` | _(unset = runtime on)_ | See experimental flags. |
-| `EXPERIMENTAL_SERVER_PRIMARY_EXECUTION` | `EXPERIMENTAL.serverPrimaryExecution` | _(unset = runtime off)_ | See experimental flags. |
+| `EXPERIMENTAL_SERVER_PRIMARY_EXECUTION` | `EXPERIMENTAL.serverPrimaryExecution` | _(unset = runtime on)_ | Set `false` for rollback; see experimental flags. |
 | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` | `EXPERIMENTAL.eagerSourceAnnotation` | on in dev builds, off in production | See experimental flags. |
 | `SHELL_PORT` | _(server-only)_ | `5173` (from `ports.json`) | Dev server port. |
 
@@ -332,7 +332,7 @@ Passed before the CLI args; rarely needed:
 | `API_URL` | `http://localhost:8000` | Toolshed URL the service calls. |
 | `EXPERIMENTAL_MODERN_CELL_REP` | _(unset)_ | See experimental flags. |
 | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` | _(unset = runtime on)_ | See experimental flags. |
-| `EXPERIMENTAL_SERVER_PRIMARY_EXECUTION` | _(unset = runtime off)_ | See experimental flags. |
+| `EXPERIMENTAL_SERVER_PRIMARY_EXECUTION` | _(unset = runtime on)_ | Set `false` for rollback; see experimental flags. |
 | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` | _(unset)_ | See experimental flags. |
 
 ---

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -29,7 +29,7 @@ was last checked against the code.
 |------|-----------|---------------|---------------------|-------------------|---------------------|
 | [`modernCellRep`](#moderncellrep) | `EXPERIMENTAL_MODERN_CELL_REP` env, or `RuntimeOptions.experimental` | off | Dan Bornstein (#3818) | graduate to always-on, then delete flag | implemented, off by default |
 | [`persistentSchedulerState`](#persistentschedulerstate) | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` env, or `RuntimeOptions.experimental` | on | Bernhard Seefeld (#3646) | graduate to always-on | implemented, on by default, rollback override retained |
-| [`serverPrimaryExecution`](#serverprimaryexecution) | `EXPERIMENTAL_SERVER_PRIMARY_EXECUTION` env, or `RuntimeOptions.experimental` | off | Bernhard Seefeld (server-primary execution W0.6) | graduate after the phased authority rollout, then delete flag | implemented, off by default |
+| [`serverPrimaryExecution`](#serverprimaryexecution) | `EXPERIMENTAL_SERVER_PRIMARY_EXECUTION` env, or `RuntimeOptions.experimental` | on | Bernhard Seefeld (server-primary execution W0.6) | graduate after the phased authority rollout, then delete flag | implemented, on by default, explicit-false rollback retained |
 | [`commitPreconditions`](#commitpreconditions) | `RuntimeOptions.experimental` only (mapped `null` — programmatic rollback override — in the canonical env registry) | on | Bernhard Seefeld (#4090) | fold into base scheduler semantics, then delete flag | implemented, on by default |
 | [`eagerSourceAnnotation`](#eagersourceannotation) | `EXPERIMENTAL_EAGER_SOURCE_ANNOTATION` env, or `RuntimeOptions.experimental` | off in production, on in shell dev builds | gideon (#4458) | permanent debug toggle, not slated for removal | implemented |
 | [`systemPatternAutoUpdate`](#systempatternautoupdate) | `EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE` env / shell build define, or `RuntimeOptions.experimental` | on in the shell (non-home roots); off server-side | Bernhard Seefeld (#4611; shell default-on #4619) | graduate to always-on, then delete both auto-update flags | implemented, on in the shell |
@@ -156,11 +156,11 @@ propagate](#how-flags-propagate).
   the optional `serverPrimaryExecutionV1` capability. When the flag is on, the
   server requires compatible clients and automatically claims every eligible
   action in every active compatible space; there is no per-space opt-in.
-- **Current default and planned end state.** Off by default in every runtime.
-  Both the server process and browser worker must enable it for a negotiated
-  connection. The planned end state is to graduate the protocol after the
-  phased authority rollout, then remove the flag once every supported client
-  obeys server-primary claims.
+- **Current default and planned end state.** On by default in every runtime.
+  An unset value enables the negotiated protocol; explicit `false` remains the
+  fleet-wide rollback override and must be deployed to both the server process
+  and browser worker. The planned end state is to remove the flag once every
+  supported client obeys server-primary claims.
 - **Status on 2026-07-14.** Runtime, environment, browser-worker, background-
   worker, memory handshake, connection-owned client root demand, one shared
   fenced Worker per active branch/space, durable legacy-background exclusion
@@ -177,9 +177,11 @@ propagate](#how-flags-propagate).
   deterministic cold-wake and replacement coverage. The 500-event
   counterbalanced browser/CPU acceptance gate passes; see the
   [accepted Phase 2 rollout report](../history/development/performance/server-primary-rollout-2026-07-13.md).
-  The flag is the only authority rollout control: off remains client-primary
-  behavior with no execution pool, while on is the final server-primary mode
-  for all eligible compatible pieces. The narrower
+  The protocol now defaults on with an explicit-false rollback; the deployed
+  flag-off/flag-on drill remains pending. The flag is the only authority rollout
+  control: off remains client-primary behavior with no execution pool, while on
+  is the final server-primary mode for all eligible compatible pieces. The
+  narrower
   `serverPrimaryExecutionClaimRoutingV1` and
   `serverPrimaryExecutionBuiltinPassivityV1` capabilities now advertise with
   the main flag. A server with the flag on rejects peers missing either

--- a/docs/development/server-primary-execution.md
+++ b/docs/development/server-primary-execution.md
@@ -1,7 +1,7 @@
 # Server-Primary Execution Rollout
 
 Server-primary execution is implemented through the trusted-client authority
-split and remains off by default. It moves claimed derived writes and supported
+split and is on by default. It moves claimed derived writes and supported
 fetch/generate effects to one user-sponsored server Worker while clients keep
 speculatively computing for UI latency. It does not yet reduce browser action
 runs. There is one rollout switch: when it is off, clients remain primary and
@@ -12,8 +12,8 @@ within that final server-primary posture, not another authority mode.
 ## Prerequisites
 
 - Deploy toolshed and shell/client builds from the same revision.
-- Enable persistent scheduler state (the current default) and
-  `EXPERIMENTAL_SERVER_PRIMARY_EXECUTION=true` on the toolshed and clients.
+- Leave persistent scheduler state and server-primary execution at their
+  current defaults, or explicitly set both true on the toolshed and clients.
 - Restart/redeploy both sides so the memory handshake advertises
   `serverPrimaryExecutionV1`, claim routing, and builtin passivity together.
 - Verify first with staging pieces whose active computations are same-space and
@@ -32,12 +32,12 @@ within that final server-primary posture, not another authority mode.
 
 ## Enable server-primary execution
 
-Set `EXPERIMENTAL_SERVER_PRIMARY_EXECUTION=true` in both the toolshed and
-client build, then restart/redeploy both sides. Compatible clients publish
-demand and the shared pool starts one Worker per active eligible branch/space.
-The Worker discovers the graph and claims each servable action automatically.
-Actions that are not yet servable remain client-primary; their server discovery
-attempts may be reported as shadow or unserved diagnostics.
+Leave `EXPERIMENTAL_SERVER_PRIMARY_EXECUTION` unset, or set it to `true`, in
+both the toolshed and client build, then restart/redeploy both sides. Compatible
+clients publish demand and the shared pool starts one Worker per active eligible
+branch/space. The Worker discovers the graph and claims each servable action
+automatically. Actions that are not yet servable remain client-primary; their
+server discovery attempts may be reported as shadow or unserved diagnostics.
 
 Verify:
 
@@ -203,8 +203,9 @@ latency without a shared trace or timestamp.
 
 ## Deployment rollback
 
-1. Disable `EXPERIMENTAL_SERVER_PRIMARY_EXECUTION` on the server and restart it.
-2. Rebuild/restart clients with the flag disabled.
+1. Set `EXPERIMENTAL_SERVER_PRIMARY_EXECUTION=false` on the server and restart
+   it.
+2. Rebuild/restart clients with the same explicit-false override.
 
 Do not disable only the clients. A server-primary host rejects an incompatible
 client because falling back silently would let stale clients duplicate claimed
@@ -212,8 +213,9 @@ writes or effects. No data migration or overlay cleanup command is required.
 
 ## Validation and rollout limits
 
-Run the repository gates in both authority modes. Persistent scheduler state is
-on in both; only the server-primary flag changes:
+Run the repository gates in both supported postures: the explicit-false
+rollback and the default-on server-primary mode. Persistent scheduler state is
+on in both:
 
 ```sh
 EXPERIMENTAL_SERVER_PRIMARY_EXECUTION=false \
@@ -222,11 +224,16 @@ EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=true deno task test
 EXPERIMENTAL_SERVER_PRIMARY_EXECUTION=false \
 EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=true deno task integration
 
-EXPERIMENTAL_SERVER_PRIMARY_EXECUTION=true \
-EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=true deno task test
+deno task test
 
-EXPERIMENTAL_SERVER_PRIMARY_EXECUTION=true \
-EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=true deno task integration
+deno task integration
+```
+
+The focused flag tests also pin the explicit-false rollback:
+
+```sh
+deno test -A packages/memory/test/v2-server-primary-execution-flags-test.ts \
+  packages/runner/test/experimental-options.test.ts
 ```
 
 The three-client executor fixtures cover claimed pure actions and supported

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -31,9 +31,11 @@ rewrite. In particular:
 - the public one-shot read surface is currently `graph.query`
 - watch-set mutations return inline `sync` payloads, and steady-state topology
   shrink does not yet guarantee automatic `removes`
-- server-primary execution is an optional, default-off capability. Compatible
-  sessions carry connection-owned demand and receive claims/settlements inside
-  the existing ordered logical-session sync stream; no parallel control socket
+- server-primary execution is an optional capability that defaults on with an
+  explicit-false deployment rollback. Compatible sessions carry
+  connection-owned demand and receive claims/settlements inside the existing
+  ordered logical-session sync stream; positive authority still requires the
+  owner-managed per-space execution policy, and no parallel control socket
   exists
 
 ## 4.1 Transport
@@ -56,9 +58,9 @@ The client MUST declare its protocol version in the first WebSocket message:
     "modernCellRep": true,
     "persistentSchedulerState": true,
     "schedulerWriterLookup": true,
-    "serverPrimaryExecutionV1": false,
-    "serverPrimaryExecutionClaimRoutingV1": false,
-    "serverPrimaryExecutionBuiltinPassivityV1": false
+    "serverPrimaryExecutionV1": true,
+    "serverPrimaryExecutionClaimRoutingV1": true,
+    "serverPrimaryExecutionBuiltinPassivityV1": true
   }
 }
 ```
@@ -73,9 +75,9 @@ If the server accepts the protocol, it returns:
     "modernCellRep": true,
     "persistentSchedulerState": true,
     "schedulerWriterLookup": true,
-    "serverPrimaryExecutionV1": false,
-    "serverPrimaryExecutionClaimRoutingV1": false,
-    "serverPrimaryExecutionBuiltinPassivityV1": false
+    "serverPrimaryExecutionV1": true,
+    "serverPrimaryExecutionClaimRoutingV1": true,
+    "serverPrimaryExecutionBuiltinPassivityV1": true
   },
   "sessionOpen": {
     "audience": "did:key:z6Mk...",
@@ -160,9 +162,10 @@ requires reconnecting clients (normally by restarting/redeploying the host).
 The two narrower capabilities are positive promises by the client:
 `serverPrimaryExecutionClaimRoutingV1` says it can route computation writes by
 claim, and `serverPrimaryExecutionBuiltinPassivityV1` says it can keep claimed
-async builtins passive. Both are absent-false and remain false in ordinary
-builds until W2.1 and W2.3 respectively. The server only sends a claim class to
-sessions that advertised the matching promise.
+async builtins passive. Both are absent-false for compatibility with older or
+explicitly disabled peers. Current builds advertise both with the main
+default-on capability; the server only sends a claim class to sessions that
+advertised the matching promise.
 
 ### 4.1.2 Logical Sessions and Resume
 

--- a/docs/specs/server-side-execution/README.md
+++ b/docs/specs/server-side-execution/README.md
@@ -1,11 +1,13 @@
 # Server-Primary Execution
 
-Status: Phases 0–2 are implemented behind the default-off flag. W2.4's product
-and deterministic failure gates are locally validated, including the accepted
-500-event counterbalanced browser/CPU gate. A deployed flag-off/flag-on drill
-remains pending. Phases 3+ remain design. Terminal crash quarantine and
-hard pool resource caps are later operational hardening tracked as G18, not
-part of the Phase 0–2 acceptance contract.
+Status: Phases 0–2 are implemented and the protocol now defaults on with an
+explicit-false deployment rollback. Every compatible eligible piece
+automatically participates when the flag is on. W2.4's product and deterministic
+failure gates are locally validated, including the accepted 500-event
+counterbalanced browser/CPU gate. A deployed flag-off/flag-on drill remains
+pending. Phases 3+ remain design. Terminal crash quarantine and hard pool
+resource caps are later operational hardening tracked as G18, not part of the
+Phase 0–2 acceptance contract.
 Author: design session
 2026-07-06; revised 2026-07-07 (doc-centric demand, SQLite-primary state,
 transient executor passes, reactive interpreter de-scoped); revised
@@ -15,7 +17,8 @@ producer lookup, scope-safe fallback, causal settlement acknowledgements,
 and server egress parity); revised 2026-07-12 after Phase 2 implementation and
 local rollout validation; revised 2026-07-13 after the parked-worker wake,
 causal-actor, permanent-builtin-failure, bounded-observability, and accepted
-500-event browser/CPU follow-ups.
+500-event browser/CPU follow-ups); revised 2026-07-14 for the default-on
+protocol graduation with explicit-false rollback.
 Completed work-order status is
 recorded inline; unimplemented phases remain design requirements rather than
 descriptions of current behavior. Operator procedure lives in the
@@ -1346,7 +1349,8 @@ checklists: [implementation-plan.md](./implementation-plan.md).
   consolidation is deferred, but legacy-owned spaces are excluded immediately
   so a second server Worker cannot start.
 - **Phase 2 — positive B claims (implemented and locally validated,
-  default-off).** Add client overlay routing, ephemeral
+  default-on with explicit-false rollback).** Add client overlay routing,
+  ephemeral
   `ExecutionClaim`, `ActionSettlement.inputBasisSeq`, whole-action scope
   firewall, passive claimed builtins, and egress parity (G5/G10/G11). Measure
   conflict rate, multi-client action volume, divergence, revocations, and

--- a/docs/specs/server-side-execution/implementation-plan.md
+++ b/docs/specs/server-side-execution/implementation-plan.md
@@ -3,13 +3,14 @@
 Companion to [README.md](./README.md). Read the design first; this plan turns
 it into reviewable, red-green work orders.
 
-Status: Phases 0–2 are implemented behind the default-off flag. W2.4's product
-and deterministic failure gates are locally validated, including the accepted
-500-event counterbalanced browser/CPU gate. A deployed flag-off/flag-on drill
-remains pending. Later background, feed, scoped, and handler work is
-outlined only. The design's terminal crash quarantine and hard pool resource
-caps are later operational hardening (G18), not additional Phase 0–2 work
-orders.
+Status: Phases 0–2 are implemented and the protocol now defaults on with an
+explicit-false deployment rollback. Every compatible eligible piece
+automatically participates when the flag is on. W2.4's product and deterministic
+failure gates are locally validated, including the accepted 500-event
+counterbalanced browser/CPU gate. A deployed flag-off/flag-on drill remains
+pending. Later background, feed, scoped, and handler work is outlined only. The
+design's terminal crash quarantine and hard pool resource caps are later
+operational hardening (G18), not additional Phase 0–2 work orders.
 
 Baseline assumption: scheduler-v2 from PR #4288 has landed. Build directly on
 its facade, commit-gated starts, cancellation semantics, bounded settle,
@@ -43,9 +44,11 @@ where server and clients knowingly duplicate authoritative work.
 - **The named seams are mandatory reading.** If symbols move, follow the
   current code and describe the delta; do not create parallel scheduler,
   identity, transaction, or serialization machinery.
-- **Flags default off.** Every experimental option is registered in
-  docs/development/EXPERIMENTAL_OPTIONS.md in the same change. Flag-off
-  behavior is proven by test.
+- **Flags start dark and graduate deliberately.** Every experimental option is
+  registered in docs/development/EXPERIMENTAL_OPTIONS.md in the same change.
+  The Phase 0–2 implementation work defaulted off; the follow-up graduation
+  defaults the completed protocol on while retaining tested explicit-false
+  rollback behavior.
 - **Preserve transaction boundaries.** Servability is decided for a whole
   action transaction. Never commit its space-scoped subset on the server and
   send scoped or foreign-space operations back to a client.
@@ -94,7 +97,8 @@ where server and clients knowingly duplicate authoritative work.
   including committed, no-op, failed, and unserved outcomes.
 - **ActionExecutionProvenance:** transaction metadata containing action
   identity, onBehalfOf, lease/claim generations, causedBy, and inputBasisSeq.
-- Runtime experimental option: serverPrimaryExecution, default false.
+- Runtime experimental option: serverPrimaryExecution, default true; explicitly
+  setting it false remains the deployment rollback path.
 - Existing scheduler option: persistentSchedulerState, default true; explicitly
   setting it false remains its independent scheduler-state rollback path.
 - Protocol capability: server-primary-execution-v1.
@@ -573,12 +577,13 @@ capability and both graduated sub-capabilities.
    server memory or duplicate retained-success delivery.
 6. Authorize demand using the session's existing READ access. Sponsor
    eligibility is a separate WRITE check in W1.1.
-7. Use `serverPrimaryExecution`, default off, as the only rollout authority
-   switch. With it off, start no execution pool and preserve client-primary
-   behavior. With it on, automatically claim every eligible action in every
-   active compatible space. Do not add a per-space authority document or CLI;
-   claims, actor identity, heartbeat, exception lists, and epochs remain
-   server control-plane state rather than mutable user data.
+7. Use `serverPrimaryExecution`, default on with an explicit-false rollback, as
+   the only rollout authority switch. With it off, start no execution pool and
+   preserve client-primary behavior. With it on, automatically claim every
+   eligible action in every active compatible space. Do not add a per-space
+   authority document or CLI; claims, actor identity, heartbeat, exception
+   lists, and epochs remain server control-plane state rather than mutable user
+   data.
 8. Gate all messages behind serverPrimaryExecution. Negotiate
    absent-false `serverPrimaryExecutionClaimRoutingV1` and
    `serverPrimaryExecutionBuiltinPassivityV1` sub-capabilities. Implemented

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -588,6 +588,11 @@ Deno.test("memory v2 client watch views expose incremental sync effects", async 
         },
       }],
       removes: [],
+      execution: {
+        fromFeedSeq: 2,
+        toFeedSeq: 3,
+        events: [],
+      },
     });
   } finally {
     await writerClient.close();

--- a/packages/memory/test/v2-server-primary-execution-flags-test.ts
+++ b/packages/memory/test/v2-server-primary-execution-flags-test.ts
@@ -10,11 +10,33 @@ type ServerPrimaryExecutionFlagApi = {
 
 const api = MemoryV2 as unknown as ServerPrimaryExecutionFlagApi;
 
-Deno.test("server-primary execution is an optional protocol capability that defaults off", () => {
+Deno.test("server-primary execution defaults on with an explicit rollback override", () => {
   api.resetServerPrimaryExecutionConfig();
   try {
     assertEquals(
       api.getMemoryProtocolFlags().serverPrimaryExecutionV1,
+      true,
+    );
+    assertEquals(
+      api.getMemoryProtocolFlags().serverPrimaryExecutionClaimRoutingV1,
+      true,
+    );
+    assertEquals(
+      api.getMemoryProtocolFlags().serverPrimaryExecutionBuiltinPassivityV1,
+      true,
+    );
+
+    api.setServerPrimaryExecutionConfig(false);
+    assertEquals(
+      api.getMemoryProtocolFlags().serverPrimaryExecutionV1,
+      false,
+    );
+    assertEquals(
+      api.getMemoryProtocolFlags().serverPrimaryExecutionClaimRoutingV1,
+      false,
+    );
+    assertEquals(
+      api.getMemoryProtocolFlags().serverPrimaryExecutionBuiltinPassivityV1,
       false,
     );
 

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -2792,6 +2792,11 @@ Deno.test("memory v2 server empty caught-up sync preserves previous fromSeq", as
       upserts: [],
       removes: [],
       caughtUpLocalSeq: 2,
+      execution: {
+        fromFeedSeq: 1,
+        toFeedSeq: 2,
+        events: [],
+      },
     });
     assertEquals(messages.length, 0);
   } finally {

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -569,6 +569,11 @@ Deno.test("memory server negotiates schema-table v2 sync frames per connection",
       modernCellRep: flags.modernCellRep,
       persistentSchedulerState: flags.persistentSchedulerState,
       commitPreconditions: flags.commitPreconditions,
+      serverPrimaryExecutionV1: flags.serverPrimaryExecutionV1,
+      serverPrimaryExecutionClaimRoutingV1:
+        flags.serverPrimaryExecutionClaimRoutingV1,
+      serverPrimaryExecutionBuiltinPassivityV1:
+        flags.serverPrimaryExecutionBuiltinPassivityV1,
       ...(mode === "legacy" ? { syncSchemaTable: true } : {}),
     };
 

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -18,9 +18,11 @@ import {
   parseMemoryProtocolFlags,
   resetCommitPreconditionsConfig,
   resetPersistentSchedulerStateConfig,
+  resetServerPrimaryExecutionConfig,
   resetSyncSchemaTableConfig,
   setCommitPreconditionsConfig,
   setPersistentSchedulerStateConfig,
+  setServerPrimaryExecutionConfig,
   setSyncSchemaTableConfig,
   toDocumentPath,
   toDocumentSelector,
@@ -129,10 +131,12 @@ describe("memory v2 flags", () => {
     resetModernCellRepConfig();
     resetPersistentSchedulerStateConfig();
     resetCommitPreconditionsConfig();
+    resetServerPrimaryExecutionConfig();
     resetSyncSchemaTableConfig();
     setModernCellRepConfig(false);
     setPersistentSchedulerStateConfig(false);
     setCommitPreconditionsConfig(false);
+    setServerPrimaryExecutionConfig(false);
     setSyncSchemaTableConfig(false);
 
     assertEquals(getMemoryProtocolFlags(), {
@@ -152,14 +156,15 @@ describe("memory v2 flags", () => {
     setModernCellRepConfig(true);
     setPersistentSchedulerStateConfig(true);
     setCommitPreconditionsConfig(true);
+    setServerPrimaryExecutionConfig(true);
     setSyncSchemaTableConfig(true);
 
     assertEquals(getMemoryProtocolFlags(), {
       modernCellRep: true,
       persistentSchedulerState: true,
-      serverPrimaryExecutionV1: false,
-      serverPrimaryExecutionClaimRoutingV1: false,
-      serverPrimaryExecutionBuiltinPassivityV1: false,
+      serverPrimaryExecutionV1: true,
+      serverPrimaryExecutionClaimRoutingV1: true,
+      serverPrimaryExecutionBuiltinPassivityV1: true,
       schedulerWriterLookup: true,
       commitPreconditions: true,
       syncSchemaTable: false,
@@ -170,6 +175,7 @@ describe("memory v2 flags", () => {
     resetModernCellRepConfig();
     resetPersistentSchedulerStateConfig();
     resetCommitPreconditionsConfig();
+    resetServerPrimaryExecutionConfig();
     resetSyncSchemaTableConfig();
   });
 

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1066,7 +1066,7 @@ const memoryReconstructionContext = new EmptyReconstructionContext(
 let persistentSchedulerStateEnabled = true;
 let commitPreconditionsEnabled = true;
 let syncSchemaTableEnabled = true;
-let serverPrimaryExecutionEnabled = false;
+let serverPrimaryExecutionEnabled = true;
 
 /**
  * Ambient runtime flag for persistent scheduler observations and rehydration.
@@ -1087,11 +1087,11 @@ export function resetPersistentSchedulerStateConfig(): void {
 
 /**
  * Ambient runtime flag for the server-primary execution protocol. The
- * capability is optional and defaults off; when enabled, compatible peers
- * use server-primary authority for every eligible claimed action.
+ * capability defaults on with an explicit false rollback override; compatible
+ * peers use server-primary authority for every eligible claimed action.
  */
 export function setServerPrimaryExecutionConfig(enabled?: boolean): void {
-  serverPrimaryExecutionEnabled = enabled ?? false;
+  serverPrimaryExecutionEnabled = enabled ?? true;
 }
 
 export function getServerPrimaryExecutionConfig(): boolean {
@@ -1099,7 +1099,7 @@ export function getServerPrimaryExecutionConfig(): boolean {
 }
 
 export function resetServerPrimaryExecutionConfig(): void {
-  serverPrimaryExecutionEnabled = false;
+  serverPrimaryExecutionEnabled = true;
 }
 
 /**

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -233,7 +233,7 @@ export interface ExperimentalOptions {
   persistentSchedulerState?: boolean | undefined;
   /** Enforce scheduler-v2 lineage and event-receipt commit preconditions (default on). */
   commitPreconditions?: boolean | undefined;
-  /** Enable the trusted-client server-primary execution protocol (default off). */
+  /** Enable the trusted-client server-primary execution protocol (default on). */
   serverPrimaryExecution?: boolean | undefined;
   /**
    * Eagerly resolve the per-primitive debug source annotation (`fn.src`) at

--- a/packages/runner/test/client-execution-overlay.test.ts
+++ b/packages/runner/test/client-execution-overlay.test.ts
@@ -629,7 +629,7 @@ Deno.test("unserved settlement dirties the claimed producer before exact revoke"
 });
 
 Deno.test("flag off keeps an otherwise matching claimed computation upstream", async () => {
-  resetServerPrimaryExecutionConfig();
+  setServerPrimaryExecutionConfig(false);
   const factory = new OverlaySessionFactory();
   const storage = OverlayStorageManager.connect(factory);
   try {

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -90,7 +90,7 @@ describe("ExperimentalOptions", () => {
         modernCellRep: false,
         persistentSchedulerState: true,
         commitPreconditions: true,
-        serverPrimaryExecution: false,
+        serverPrimaryExecution: true,
         // Read back from the ambient flag (a test seam that deliberately does
         // NOT reset on dispose — see ExperimentalOptions.eagerSourceAnnotation).
         eagerSourceAnnotation: false,
@@ -229,7 +229,7 @@ describe("ExperimentalOptions", () => {
       expect(getModernCellRepConfig()).toBe(initial);
       expect(getPersistentSchedulerStateConfig()).toBe(true);
       expect(getCommitPreconditionsConfig()).toBe(true);
-      expect(getServerPrimaryExecutionConfig()).toBe(false);
+      expect(getServerPrimaryExecutionConfig()).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Stack

Stacked on #4692. Review this PR as the five commits after `dec968074`.

## Summary

- Default the server-primary protocol and runtime option on.
- Retain `EXPERIMENTAL_SERVER_PRIMARY_EXECUTION=false` as the fleet-wide rollback.
- Keep positive write/effect authority opt-in through the owner-managed per-space execution policy; the runtime default alone enables negotiation, demand, and shadow observation.
- Align protocol fixtures, explicit flag-off coverage, operator documentation, and the live specs with the graduated default.

## Red-green TDD

Red first:

```
deno test -A packages/memory/test/v2-server-primary-execution-flags-test.ts
```

The new default-on expectation failed with `actual: false`, `expected: true`.

Focused green:

```
deno test -A packages/memory/test/v2-server-primary-execution-flags-test.ts packages/memory/test/v2-test.ts packages/runner/test/experimental-options.test.ts
```

Passed: 8 tests / 30 steps. Follow-up regression fixtures also cover the default-on execution envelope and explicit-false client overlay behavior.

## Validation

- `deno task check`
- `deno task check-docs` — all 513 checked code blocks passed
- `TEST_CONCURRENCY=1 deno task test` — all workspace package suites passed (476.7s)
- `deno task integration` — 7/7 integration suites passed, including all 91 pattern tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaulted server‑primary execution to on across runtime and protocol, with an explicit‑false rollback via `EXPERIMENTAL_SERVER_PRIMARY_EXECUTION`. Handshakes now default‑advertise `serverPrimaryExecutionV1`, `serverPrimaryExecutionClaimRoutingV1`, and `serverPrimaryExecutionBuiltinPassivityV1`; v2 sync frames include an `execution` envelope, and schema negotiation carries these flags. Defaults are updated in `packages/memory` and `packages/runner`, and docs now reflect unset=runtime on.

- **Migration**
  - No action needed; negotiation, demand, and shadow observation run by default. Positive authority still requires the per‑space policy.
  - To disable, set `EXPERIMENTAL_SERVER_PRIMARY_EXECUTION=false` on server and clients and restart/rebuild; focused tests pin this rollback.
  - Older or explicitly disabled peers remain compatible via absent‑false capability negotiation.

<sup>Written for commit 465d8401bb9a29fe08d2661be09e1c8cfb130d56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

