### PR TITLE
test(cli): make the throwaway Git repositories hermetic

### DIFF
--- a/packages/cli/test/install-cf.test.ts
+++ b/packages/cli/test/install-cf.test.ts
@@ -49,6 +49,9 @@ async function makeCheckout(
   await git("init", "-q");
   await git("config", "user.email", "test@example.com");
   await git("config", "user.name", "Test");
+  // Signing would wait on the agent holding a contributor's key, and this
+  // stand-in checkout commits.
+  await git("config", "commit.gpgsign", "false");
 }
 
 async function runInstaller(

--- a/packages/cli/test/view-commitmsg.test.ts
+++ b/packages/cli/test/view-commitmsg.test.ts
@@ -267,6 +267,25 @@ async function git(
   return new TextDecoder().decode(o.stdout);
 }
 
+/**
+ * Pins the configuration a commit object is built from, so the configuration a
+ * contributor happens to have cannot reach into a throwaway repository. Signing
+ * matters beyond the identity: a signature records its own creation time, so a
+ * signed commit hashes differently every second, and producing one waits on the
+ * agent holding the key.
+ */
+async function configureRepo(root: string) {
+  await git(root, ["config", "user.email", "t@t.test"]);
+  await git(root, ["config", "user.name", "Test"]);
+  await git(root, ["config", "commit.gpgsign", "false"]);
+}
+
+/** Creates a throwaway repository with that configuration already in place. */
+async function initRepo(root: string) {
+  await git(root, ["init", "-q"]);
+  await configureRepo(root);
+}
+
 async function installHook(root: string, name: string, script: string) {
   const path = `${root}/.git/hooks/${name}`;
   await Deno.writeTextFile(path, `#!/bin/sh\n${script}\n`);
@@ -322,9 +341,7 @@ exec ${shellQuote(realGitPath)} "$@"
 Deno.test("realGit: reads HEAD and amends the message, keeping the tree", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     await Deno.writeTextFile(`${root}/f.txt`, "a\nb\n");
     await git(root, ["add", "f.txt"]);
     await git(root, ["commit", "-q", "-m", "original"]);
@@ -361,9 +378,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
       const journal = `${root}/hook-journal`;
       await installHook(
@@ -394,9 +409,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
       const helperMarker = `${root}/helper-ran`;
       const helper = `${root}/.git/check`;
@@ -436,9 +449,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
       const hooksName = " custom-hooks ";
       await git(root, ["config", "core.hooksPath", hooksName]);
@@ -470,9 +481,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
       const hooksName = "custom hooks";
       await git(root, ["config", "core.hooksPath", hooksName]);
@@ -507,9 +516,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
       const marker = `${root}/post-commit-ran`;
       await installHook(
@@ -546,9 +553,7 @@ Deno.test({
     const other = await Deno.makeTempDir();
     try {
       for (const repository of [root, other]) {
-        await git(repository, ["init", "-q"]);
-        await git(repository, ["config", "user.email", "t@t.test"]);
-        await git(repository, ["config", "user.name", "Test"]);
+        await initRepo(repository);
         await git(repository, [
           "commit",
           "-q",
@@ -591,9 +596,7 @@ Deno.test({
     const other = await Deno.makeTempDir();
     try {
       for (const repository of [root, other]) {
-        await git(repository, ["init", "-q"]);
-        await git(repository, ["config", "user.email", "t@t.test"]);
-        await git(repository, ["config", "user.name", "Test"]);
+        await initRepo(repository);
         await git(repository, [
           "commit",
           "-q",
@@ -644,9 +647,7 @@ Deno.test({
     const linked = `${parent}/linked`;
     try {
       await Deno.mkdir(root);
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
       await git(root, ["worktree", "add", "-q", "-b", "linked", linked]);
       await git(root, ["config", "extensions.worktreeConfig", "true"]);
@@ -715,13 +716,9 @@ Deno.test("realGit: accepts an amend that reproduces the same commit object", as
     const fixedDate = "2001-01-01T00:00:00+00:00";
     Deno.env.set("GIT_AUTHOR_DATE", fixedDate);
     Deno.env.set("GIT_COMMITTER_DATE", fixedDate);
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
-    // A signature records its own creation time, so a signed commit hashes
-    // differently every second. Pin the switch an inherited configuration may
-    // have turned on, leaving the object id a function of the content alone.
-    await git(root, ["config", "commit.gpgsign", "false"]);
+    // Fixing the dates here, on top of the identity and signing that initRepo
+    // pins, leaves the object id a function of the content alone.
+    await initRepo(root);
     await Deno.writeTextFile(`${root}/f.txt`, "same\n");
     await git(root, ["add", "f.txt"]);
     await git(root, ["commit", "-q", "-m", "same"]);
@@ -746,9 +743,7 @@ Deno.test("realGit: accepts an amend that reproduces the same commit object", as
 Deno.test("realGit: preserves non-UTF-8 commit message bytes", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     await git(root, ["config", "i18n.commitEncoding", "ISO-8859-1"]);
     const file = `${root}/f.txt`;
     await Deno.writeTextFile(file, "before\n");
@@ -799,9 +794,7 @@ Deno.test("realGit: preserves non-UTF-8 commit message bytes", async () => {
 Deno.test("realGit: labels edited commit messages as UTF-8", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     await git(root, ["config", "i18n.commitEncoding", "ISO-8859-1"]);
     await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
     const runner = realGit(root);
@@ -830,9 +823,7 @@ Deno.test("realGit: labels edited commit messages as UTF-8", async () => {
 Deno.test("realGit: amends a valid empty commit", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
     const runner = realGit(root);
     const head = runner.headSha();
@@ -856,8 +847,7 @@ Deno.test("realGit: amends reftable commits and preserves staged state", async (
   try {
     if (!await initReftable(root)) return;
 
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await configureRepo(root);
     await Deno.writeTextFile(`${root}/selected.txt`, "original selected\n");
     await Deno.writeTextFile(`${root}/unrelated.txt`, "original unrelated\n");
     await git(root, ["add", "selected.txt", "unrelated.txt"]);
@@ -905,8 +895,7 @@ Deno.test("realGit: amends a detached reftable HEAD", async () => {
   const root = await Deno.makeTempDir();
   try {
     if (!await initReftable(root)) return;
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await configureRepo(root);
     await Deno.writeTextFile(`${root}/f.txt`, "original\n");
     await git(root, ["add", "f.txt"]);
     await git(root, ["commit", "-q", "-m", "original"]);
@@ -939,8 +928,7 @@ Deno.test("realGit: amends reftable commits in a linked worktree", async () => {
   try {
     await Deno.mkdir(root);
     if (!await initReftable(root)) return;
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await configureRepo(root);
     await Deno.writeTextFile(`${root}/f.txt`, "original\n");
     await git(root, ["add", "f.txt"]);
     await git(root, ["commit", "-q", "-m", "original"]);
@@ -973,8 +961,7 @@ Deno.test({
     const root = await Deno.makeTempDir();
     try {
       if (!await initReftable(root)) return;
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await configureRepo(root);
       await Deno.writeTextFile(`${root}/f.txt`, "original\n");
       await git(root, ["add", "f.txt"]);
       await git(root, ["commit", "-q", "-m", "original"]);
@@ -1011,8 +998,7 @@ Deno.test({
     const root = await Deno.makeTempDir();
     try {
       if (!await initReftable(root)) return;
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await configureRepo(root);
       await Deno.writeTextFile(`${root}/f.txt`, "original\n");
       await git(root, ["add", "f.txt"]);
       await git(root, ["commit", "-q", "-m", "original"]);
@@ -1058,8 +1044,7 @@ Deno.test({
         } else {
           await git(root, ["init", "-q"]);
         }
-        await git(root, ["config", "user.email", "t@t.test"]);
-        await git(root, ["config", "user.name", "Test"]);
+        await configureRepo(root);
         await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
         await installHook(
           root,
@@ -1097,8 +1082,7 @@ Deno.test({
         } else {
           await git(root, ["init", "-q"]);
         }
-        await git(root, ["config", "user.email", "t@t.test"]);
-        await git(root, ["config", "user.name", "Test"]);
+        await configureRepo(root);
         const path = `${root}/f.txt`;
         await Deno.writeTextFile(path, "original\n");
         await git(root, ["add", "f.txt"]);
@@ -1148,8 +1132,7 @@ Deno.test({
         } else {
           await git(root, ["init", "-q"]);
         }
-        await git(root, ["config", "user.email", "t@t.test"]);
-        await git(root, ["config", "user.name", "Test"]);
+        await configureRepo(root);
         await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
         const marker = `${root}/.git/nested-expiry-hook-ran`;
         await installHook(
@@ -1197,8 +1180,7 @@ Deno.test({
         } else {
           await git(root, ["init", "-q"]);
         }
-        await git(root, ["config", "user.email", "t@t.test"]);
-        await git(root, ["config", "user.name", "Test"]);
+        await configureRepo(root);
         await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
         const marker = `${root}/.git/reference-hook-ran`;
         await installHook(
@@ -1246,8 +1228,7 @@ Deno.test({
         } else {
           await git(root, ["init", "-q"]);
         }
-        await git(root, ["config", "user.email", "t@t.test"]);
-        await git(root, ["config", "user.name", "Test"]);
+        await configureRepo(root);
         await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
         const runner = realGit(root);
         const original = runner.headSha();
@@ -1278,7 +1259,7 @@ git reflog expire --expire=now --all`,
 Deno.test("realGit: preserves pager insertion order around a workspace insertion", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
+    await initRepo(root);
     const runner = realGit(root);
     assert(runner.applyFileChanges, "the real Git runner applies file changes");
     assertEquals(
@@ -1298,7 +1279,7 @@ Deno.test("realGit: preserves pager insertion order around a workspace insertion
 Deno.test("realGit: rejects an insertion at a hidden deletion boundary", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
+    await initRepo(root);
     const runner = realGit(root);
 
     assertThrows(
@@ -1320,9 +1301,7 @@ Deno.test("realGit: rejects an insertion at a hidden deletion boundary", async (
 Deno.test("realGit: amends selected files and preserves unrelated staged changes", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     await Deno.writeTextFile(`${root}/selected.txt`, "old selected\n");
     await Deno.writeTextFile(`${root}/unrelated.txt`, "old unrelated\n");
     await git(root, ["add", "selected.txt", "unrelated.txt"]);
@@ -1361,9 +1340,7 @@ Deno.test("realGit: amends selected files and preserves unrelated staged changes
 Deno.test("realGit: commits exact pager contents while preserving staged and unstaged edits in the same file", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     const path = `${root}/selected.txt`;
     await Deno.writeTextFile(path, "one\ntwo\nthree\nfour\nfive\n");
     await git(root, ["add", "selected.txt"]);
@@ -1408,9 +1385,7 @@ Deno.test("realGit: commits exact pager contents while preserving staged and uns
 Deno.test("realGit: refuses a pager edit that conflicts with a staged edit", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     const path = `${root}/selected.txt`;
     await Deno.writeTextFile(path, "one\ntwo\nthree\n");
     await git(root, ["add", "selected.txt"]);
@@ -1448,9 +1423,7 @@ Deno.test("realGit: refuses a pager edit that conflicts with a staged edit", asy
 Deno.test("realGit: refuses to merge content into a staged file type change", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     const path = `${root}/selected.txt`;
     await Deno.writeTextFile(path, "target");
     await git(root, ["add", "selected.txt"]);
@@ -1497,9 +1470,7 @@ Deno.test("realGit: refuses to merge content into a staged file type change", as
 Deno.test("realGit: merges content through a staged executable mode change", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     const path = `${root}/selected.txt`;
     await Deno.writeTextFile(path, "original\n");
     await git(root, ["add", "selected.txt"]);
@@ -1533,9 +1504,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       const path = `${root}/back\\slash.txt`;
       await Deno.writeTextFile(path, "old\n");
       await git(root, ["add", "--", "back\\slash.txt"]);
@@ -1561,9 +1530,7 @@ Deno.test({
   fn: async () => {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       const link = `${root}/link.txt`;
       const target = `${root}/target.txt`;
       Deno.writeTextFileSync(link, "link head\n");
@@ -1597,9 +1564,7 @@ Deno.test({
   fn: async () => {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await Deno.mkdir(`${root}/subalias`);
       await Deno.writeTextFile(`${root}/f.txt`, "root head\n");
       await Deno.writeTextFile(`${root}/subalias/f.txt`, "alias head\n");
@@ -1626,9 +1591,7 @@ Deno.test({
 Deno.test("realGit: reads and writes selected files through clean filters", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     await git(root, ["config", "filter.caps.clean", "tr a-z A-Z"]);
     await git(root, ["config", "filter.caps.smudge", "tr A-Z a-z"]);
     await Deno.writeTextFile(`${root}/.gitattributes`, "*.dat filter=caps\n");
@@ -1653,9 +1616,7 @@ Deno.test("realGit: reads and writes selected files through clean filters", asyn
 Deno.test("realGit: handles an index path beginning with a stage prefix", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     const path = `${root}/1:f.txt`;
     await Deno.writeTextFile(path, "original\n");
     await git(root, ["add", "--", "1:f.txt"]);
@@ -1674,9 +1635,7 @@ Deno.test("realGit: handles an index path beginning with a stage prefix", async 
 Deno.test("realGit: preserves assume-unchanged and skip-worktree index flags", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     await Deno.writeTextFile(`${root}/assume.txt`, "old assume\n");
     await Deno.writeTextFile(`${root}/skip.txt`, "old skip\n");
     await git(root, ["add", "assume.txt", "skip.txt"]);
@@ -1710,9 +1669,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       const path = `${root}/f.txt`;
       await Deno.writeTextFile(path, "original\n");
       await git(root, ["add", "f.txt"]);
@@ -1748,9 +1705,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       const path = `${root}/f.txt`;
       await Deno.writeTextFile(path, "original\n");
       await git(root, ["add", "f.txt"]);
@@ -1789,9 +1744,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       const path = `${root}/f.txt`;
       await Deno.writeTextFile(path, "original\n");
       await git(root, ["add", "f.txt"]);
@@ -1836,9 +1789,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       const path = `${root}/f.txt`;
       await Deno.writeTextFile(path, "original\n");
       await git(root, ["add", "f.txt"]);
@@ -1878,9 +1829,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await Deno.writeTextFile(`${root}/f.txt`, "original\n");
       await git(root, ["add", "f.txt"]);
       await git(root, ["commit", "-q", "-m", "original"]);
@@ -1905,9 +1854,7 @@ Deno.test({
 Deno.test("realGit: refuses a different branch at the same commit", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     await Deno.writeTextFile(`${root}/f.txt`, "original\n");
     await git(root, ["add", "f.txt"]);
     await git(root, ["commit", "-q", "-m", "original"]);
@@ -1938,9 +1885,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await Deno.writeTextFile(`${root}/f.txt`, "original\n");
       await git(root, ["add", "f.txt"]);
       await git(root, ["commit", "-q", "-m", "original"]);
@@ -1976,9 +1921,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await Deno.writeTextFile(`${root}/f.txt`, "original\n");
       await git(root, ["add", "f.txt"]);
       await git(root, ["commit", "-q", "-m", "original"]);
@@ -2020,9 +1963,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await Deno.writeTextFile(`${root}/f.txt`, "original\n");
       await git(root, ["add", "f.txt"]);
       await git(root, ["commit", "-q", "-m", "original"]);
@@ -2069,9 +2010,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await Deno.writeTextFile(`${root}/f.txt`, "base\n");
       await git(root, ["add", "f.txt"]);
       await git(root, ["commit", "-q", "-m", "base"]);
@@ -2147,9 +2086,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await Deno.writeTextFile(`${root}/f.txt`, "original\n");
       await git(root, ["add", "f.txt"]);
       await git(root, ["commit", "-q", "-m", "original"]);
@@ -2179,9 +2116,7 @@ Deno.test({
 Deno.test("realGit: Git refuses amend while resolving a conflicted merge", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     await Deno.writeTextFile(`${root}/f.txt`, "base\n");
     await git(root, ["add", "f.txt"]);
     await git(root, ["commit", "-q", "-m", "base"]);
@@ -2242,9 +2177,7 @@ Deno.test("realGit: validates selected paths before reading commit contents", as
   const root = await Deno.makeTempDir();
   const outside = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     await Deno.writeTextFile(`${root}/tracked.txt`, "tracked\n");
     await git(root, ["add", "tracked.txt"]);
     await git(root, ["commit", "-q", "-m", "original"]);
@@ -2303,9 +2236,7 @@ Deno.test("realGit: reports unavailable optional Git queries", () => {
 Deno.test("realGit: rejects a stale expected HEAD", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
     const runner = realGit(root);
     const head = runner.headSha();
@@ -2325,9 +2256,7 @@ Deno.test("realGit: rejects a stale expected HEAD", async () => {
 Deno.test("realGit: preserves a selected path staged for deletion", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     const path = `${root}/selected.txt`;
     await Deno.writeTextFile(path, "original\n");
     await git(root, ["add", "selected.txt"]);
@@ -2361,9 +2290,7 @@ Deno.test("realGit: preserves a selected path staged for deletion", async () => 
 Deno.test("realGit: rejects both multi-stage and lone unmerged index entries", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     const path = `${root}/selected.txt`;
     await Deno.writeTextFile(path, "original\n");
     await git(root, ["add", "selected.txt"]);
@@ -2415,9 +2342,7 @@ Deno.test("realGit: rejects both multi-stage and lone unmerged index entries", a
 Deno.test("realGit: rejects a selected path that HEAD does not contain", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
     const path = `${root}/new.txt`;
     await Deno.writeTextFile(path, "workspace\n");
@@ -2444,7 +2369,7 @@ Deno.test("realGit: rejects a selected path that HEAD does not contain", async (
 Deno.test("realGit: a no-op pager change keeps the committed contents", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
+    await initRepo(root);
     const runner = realGit(root);
 
     assertEquals(
@@ -2464,7 +2389,7 @@ Deno.test("realGit: a no-op pager change keeps the committed contents", async ()
 Deno.test("realGit: fallback merge handles insertions around added and empty content", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
+    await initRepo(root);
     const runner = realGit(root);
     const path = `${root}/selected.txt`;
 
@@ -2493,7 +2418,7 @@ Deno.test("realGit: fallback merge handles insertions around added and empty con
 Deno.test("realGit: fallback merge rejects a deletion inside a pager replacement", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
+    await initRepo(root);
 
     assertThrows(
       () =>
@@ -2514,9 +2439,7 @@ Deno.test("realGit: fallback merge rejects a deletion inside a pager replacement
 Deno.test("realGit: preserves a staged version that already matches the pager", async () => {
   const root = await Deno.makeTempDir();
   try {
-    await git(root, ["init", "-q"]);
-    await git(root, ["config", "user.email", "t@t.test"]);
-    await git(root, ["config", "user.name", "Test"]);
+    await initRepo(root);
     const path = `${root}/selected.txt`;
     await Deno.writeTextFile(path, "original\n");
     await git(root, ["add", "selected.txt"]);
@@ -2552,8 +2475,7 @@ Deno.test({
         } else {
           await git(root, ["init", "-q"]);
         }
-        await git(root, ["config", "user.email", "t@t.test"]);
-        await git(root, ["config", "user.name", "Test"]);
+        await configureRepo(root);
         await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
         const marker = `${root}/fallback-hook-ran`;
         await installHook(
@@ -2591,9 +2513,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
       await installHook(
         root,
@@ -2625,9 +2545,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
       await installHook(
         root,
@@ -2665,9 +2583,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
       const runner = realGit(root);
       const branch = runner.headRef!();
@@ -2705,9 +2621,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
       const runner = realGit(root);
       const branch = runner.headRef!();
@@ -2747,9 +2661,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
       const journalMarker = `${root}/journal-removed`;
       const reflogMarker = `${root}/reflogs-removed`;
@@ -2798,9 +2710,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       const path = `${root}/selected.txt`;
       await Deno.writeTextFile(path, "original\n");
       await git(root, ["add", "selected.txt"]);
@@ -2842,9 +2752,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       await git(root, ["commit", "-q", "--allow-empty", "-m", "original"]);
       const runner = realGit(root);
       const branch = runner.headRef!();
@@ -2878,9 +2786,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       const path = `${root}/selected.txt`;
       await Deno.writeTextFile(path, "original\n");
       await git(root, ["add", "selected.txt"]);
@@ -2918,9 +2824,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       const path = `${root}/tracked.txt`;
       await Deno.writeTextFile(path, "tracked\n");
       await git(root, ["add", "tracked.txt"]);
@@ -2990,7 +2894,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
+      await initRepo(root);
       const path = `${root}/selected.txt`;
       await withGitShim(
         `if test "$1" = merge-file; then
@@ -3070,9 +2974,7 @@ Deno.test({
   async fn() {
     const root = await Deno.makeTempDir();
     try {
-      await git(root, ["init", "-q"]);
-      await git(root, ["config", "user.email", "t@t.test"]);
-      await git(root, ["config", "user.name", "Test"]);
+      await initRepo(root);
       const path = `${root}/selected.txt`;
       await Deno.writeTextFile(path, "original\n");
       await git(root, ["add", "selected.txt"]);

--- a/packages/cli/test/view-commitmsg.test.ts
+++ b/packages/cli/test/view-commitmsg.test.ts
@@ -718,6 +718,10 @@ Deno.test("realGit: accepts an amend that reproduces the same commit object", as
     await git(root, ["init", "-q"]);
     await git(root, ["config", "user.email", "t@t.test"]);
     await git(root, ["config", "user.name", "Test"]);
+    // A signature records its own creation time, so a signed commit hashes
+    // differently every second. Pin the switch an inherited configuration may
+    // have turned on, leaving the object id a function of the content alone.
+    await git(root, ["config", "commit.gpgsign", "false"]);
     await Deno.writeTextFile(`${root}/f.txt`, "same\n");
     await git(root, ["add", "f.txt"]);
     await git(root, ["commit", "-q", "-m", "same"]);

--- a/packages/cli/test/view-diffedit.test.ts
+++ b/packages/cli/test/view-diffedit.test.ts
@@ -199,6 +199,19 @@ function runGit(root: string, args: string[]): string {
   return new TextDecoder().decode(output.stdout);
 }
 
+/**
+ * Creates a throwaway repository, pinning the configuration its commits are
+ * built from so the configuration a contributor happens to have cannot reach
+ * in. Signing matters beyond the identity: producing a signature waits on the
+ * agent holding the key, and it records its own creation time.
+ */
+function initRepo(root: string): void {
+  runGit(root, ["init", "-q"]);
+  runGit(root, ["config", "user.email", "t@t.test"]);
+  runGit(root, ["config", "user.name", "Test"]);
+  runGit(root, ["config", "commit.gpgsign", "false"]);
+}
+
 Deno.test("diffedit: edits an added line in place and saves it to the file", () => {
   const { root, ws, done } = tempWorkspace();
   try {
@@ -3482,9 +3495,7 @@ Deno.test("diffedit: editing only a hunk prompts and amends the file into the co
 Deno.test("diffedit: saving edited git show output amends the real HEAD tree", () => {
   const root = Deno.makeTempDirSync();
   try {
-    runGit(root, ["init", "-q"]);
-    runGit(root, ["config", "user.email", "t@t.test"]);
-    runGit(root, ["config", "user.name", "Test"]);
+    initRepo(root);
     const path = join(root, "m.ts");
     Deno.writeTextFileSync(
       path,
@@ -3557,9 +3568,7 @@ Deno.test("diffedit: saving edited git show output amends the real HEAD tree", (
 Deno.test("diffedit: a hunk-only amend preserves the raw commit message", () => {
   const root = Deno.makeTempDirSync();
   try {
-    runGit(root, ["init", "-q"]);
-    runGit(root, ["config", "user.email", "t@t.test"]);
-    runGit(root, ["config", "user.name", "Test"]);
+    initRepo(root);
     const path = join(root, "f.txt");
     Deno.writeTextFileSync(path, "before\n");
     runGit(root, ["add", "f.txt"]);
@@ -3606,9 +3615,7 @@ Deno.test("diffedit: a hunk-only amend preserves the raw commit message", () => 
 Deno.test("diffedit: abbreviated, compact, and email formats amend hunk edits", () => {
   const root = Deno.makeTempDirSync();
   try {
-    runGit(root, ["init", "-q"]);
-    runGit(root, ["config", "user.email", "t@t.test"]);
-    runGit(root, ["config", "user.name", "Test"]);
+    initRepo(root);
     const path = join(root, "f.txt");
     Deno.writeTextFileSync(path, "before\n");
     runGit(root, ["add", "f.txt"]);
@@ -3710,9 +3717,7 @@ Deno.test("diffedit: standard and compact views skip email ownership checks", ()
 Deno.test("diffedit: consecutive compact commits keep historical hunk ownership", () => {
   const root = Deno.makeTempDirSync();
   try {
-    runGit(root, ["init", "-q"]);
-    runGit(root, ["config", "user.email", "t@t.test"]);
-    runGit(root, ["config", "user.name", "Test"]);
+    initRepo(root);
     const path = join(root, "f.txt");
     Deno.writeTextFileSync(path, "before\n");
     runGit(root, ["add", "f.txt"]);
@@ -3748,9 +3753,7 @@ Deno.test("diffedit: consecutive compact commits keep historical hunk ownership"
 Deno.test("diffedit: consecutive email commits keep historical hunk ownership", () => {
   const root = Deno.makeTempDirSync();
   try {
-    runGit(root, ["init", "-q"]);
-    runGit(root, ["config", "user.email", "t@t.test"]);
-    runGit(root, ["config", "user.name", "Test"]);
+    initRepo(root);
     const path = join(root, "f.txt");
     Deno.writeTextFileSync(path, "before\n");
     runGit(root, ["add", "f.txt"]);
@@ -3786,9 +3789,7 @@ Deno.test("diffedit: consecutive email commits keep historical hunk ownership", 
 Deno.test("diffedit: a CRLF commit preamble keeps an LF-normalized message", () => {
   const root = Deno.makeTempDirSync();
   try {
-    runGit(root, ["init", "-q"]);
-    runGit(root, ["config", "user.email", "t@t.test"]);
-    runGit(root, ["config", "user.name", "Test"]);
+    initRepo(root);
     const path = join(root, "f.txt");
     Deno.writeTextFileSync(path, "before\n");
     runGit(root, ["add", "f.txt"]);
@@ -3833,9 +3834,7 @@ Deno.test({
   fn() {
     const root = Deno.makeTempDirSync();
     try {
-      runGit(root, ["init", "-q"]);
-      runGit(root, ["config", "user.email", "t@t.test"]);
-      runGit(root, ["config", "user.name", "Test"]);
+      initRepo(root);
       runGit(root, [
         "config",
         "filter.caps.clean",
@@ -3903,9 +3902,7 @@ Deno.test({
 Deno.test("diffedit: an empty-message commit amends when its hunk changes", () => {
   const root = Deno.makeTempDirSync();
   try {
-    runGit(root, ["init", "-q"]);
-    runGit(root, ["config", "user.email", "t@t.test"]);
-    runGit(root, ["config", "user.name", "Test"]);
+    initRepo(root);
     const path = join(root, "m.ts");
     Deno.writeTextFileSync(path, "before\n");
     runGit(root, ["add", "m.ts"]);
@@ -3946,9 +3943,7 @@ Deno.test("diffedit: an empty-message commit amends when its hunk changes", () =
 Deno.test("diffedit: later hunk saves retain earlier amendments in the same file", () => {
   const root = Deno.makeTempDirSync();
   try {
-    runGit(root, ["init", "-q"]);
-    runGit(root, ["config", "user.email", "t@t.test"]);
-    runGit(root, ["config", "user.name", "Test"]);
+    initRepo(root);
     const path = join(root, "m.ts");
     const parent = Array.from(
       { length: 16 },
@@ -4013,9 +4008,7 @@ Deno.test("diffedit: later hunk saves retain earlier amendments in the same file
 Deno.test("diffedit: editing a HEAD hunk does not amend a matching historical hunk", () => {
   const root = Deno.makeTempDirSync();
   try {
-    runGit(root, ["init", "-q"]);
-    runGit(root, ["config", "user.email", "t@t.test"]);
-    runGit(root, ["config", "user.name", "Test"]);
+    initRepo(root);
     const path = join(root, "m.ts");
     const parent = Array.from(
       { length: 12 },
@@ -4125,9 +4118,7 @@ Deno.test("diffedit: editing a HEAD hunk does not amend a matching historical hu
 Deno.test("diffedit: a historical insertion does not shift a later HEAD amend", () => {
   const root = Deno.makeTempDirSync();
   try {
-    runGit(root, ["init", "-q"]);
-    runGit(root, ["config", "user.email", "t@t.test"]);
-    runGit(root, ["config", "user.name", "Test"]);
+    initRepo(root);
     const path = join(root, "m.ts");
     const base = Array.from({ length: 14 }, (_, index) => `line ${index + 1}`);
     Deno.writeTextFileSync(path, `${base.join("\n")}\n`);
@@ -4203,9 +4194,7 @@ Deno.test("diffedit: a historical insertion does not shift a later HEAD amend", 
 Deno.test("diffedit: expanded workspace context stays outside the amended commit", () => {
   const root = Deno.makeTempDirSync();
   try {
-    runGit(root, ["init", "-q"]);
-    runGit(root, ["config", "user.email", "t@t.test"]);
-    runGit(root, ["config", "user.name", "Test"]);
+    initRepo(root);
     const path = join(root, "m.ts");
     const base = Array.from({ length: 12 }, (_, index) => `line ${index + 1}`);
     Deno.writeTextFileSync(path, `${base.join("\n")}\n`);
@@ -4281,9 +4270,7 @@ Deno.test("diffedit: expanded workspace context stays outside the amended commit
 Deno.test("diffedit: an amend excludes unrelated same-file edits and preserves their staged state", () => {
   const root = Deno.makeTempDirSync();
   try {
-    runGit(root, ["init", "-q"]);
-    runGit(root, ["config", "user.email", "t@t.test"]);
-    runGit(root, ["config", "user.name", "Test"]);
+    initRepo(root);
     const path = join(root, "m.ts");
     const parentLines = Array.from({ length: 12 }, (_, i) => `line ${i + 1}`);
     const commitLines = [...parentLines];


### PR DESCRIPTION
## The failure

`realGit: accepts an amend that reproduces the same commit object` fails on a pristine checkout of `main`, taking the whole `packages/cli` suite red (122 passed, 1 failed) and masking real regressions there. It is not caused by any recent change.

The test asserts that amending with identical content reproduces the identical commit object. Dumping both objects on the real `amendCommit` path shows `tree`, `author`, `committer`, and the message bytes are byte-identical — the only differing header is `gpgsig`, and it differs at the signature's own creation timestamp:

```
-  iQHPBAABCAA5FiEEkr0fe78jfmLway5y6eF5kxXog6EFAmprn7cbFIAAAAAABAAO
+  iQHPBAABCAA5FiEEkr0fe78jfmLway5y6eF5kxXog6EFAmprn7gbFIAAAAAABAAO
```

The repository is created with `git init` and inherits the checkout's configuration. Where that turns `commit.gpgsign` on, both the original commit and the amend get signed; GPG's signatures are deterministic for a fixed payload *and* fixed signing time, so two signings a second apart produce different bytes and a different object id. The test already pinned everything else — identity via local config, both dates via `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE`. Signing was the one unpinned input. CI has no signing key, which is why it is green there.

## The change

Pin signing along with the identity, and put the whole setup behind one helper.

The identity was configured by hand at each of the ~70 places that make a throwaway repository, and none of them pinned signing. So the hazard was never limited to the one assertion: every one of those repositories signed its commits, each waiting on the agent holding the key, and would block outright if that key ever needed a pinentry prompt.

`initRepo` now creates them all, so the invariant is "a throwaway repository comes from `initRepo`" rather than a rule about which of them commit. The reftable branches, which init their own repository, share the configuration half as `configureRepo`. Repositories that only hash blobs go through it too — uniformity costs three subprocess calls and removes the trap a future commit would spring.

## Verification

The equality still has teeth — it is not weakened to a tautology. Driving the real `amendCommit` with signing pinned off:

| amend message | before | after | ids equal |
| --- | --- | --- | --- |
| `same` (what the test does) | `4d9e1a6c…` | `4d9e1a6c…` | yes, and byte-identical |
| `different` (control) | `4d9e1a6c…` | `250ffad9…` | no |

- `packages/cli`: **123 passed, 0 failed** (was 122 / 1).
- Repo-wide `deno fmt --check` and `deno lint`: clean. `deno check` on the changed files: clean.
- The suite drops from 3m43s to 3m24s with the signatures gone.

Left alone deliberately: `tasks/check-skill-facts.test.ts`, `tasks/check-unused-deps.test.ts`, and `view-diff.test.ts:994` only `init`/`add`/`hash-object` and never commit, so signing cannot reach them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make throwaway test Git repos hermetic by centralizing repo setup and turning off commit signing. Fixes nondeterministic commit IDs and removes gpg-agent dependencies in `packages/cli` tests.

- **Bug Fixes**
  - Set `commit.gpgsign=false` in test repos so identical-amend commits produce the same object.
  - Prevent local failures when user config enables signing and avoid agent/pinentry prompts.

- **Refactors**
  - Add `initRepo` and `configureRepo` helpers to pin identity and signing; use them across tests (including reftable cases).
  - Unify setup for all throwaway repos, including blob-only cases; suite is ~19s faster (3m24s vs 3m43s).

<sup>Written for commit eed7766329c48ee7363154e2b70d9f332c630312. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

