### PR TITLE
feat(memory): connection-scoped schema tables (`syncSchemaCasV1`)

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -44,6 +44,7 @@ was last checked against the code.
 | [`cfcLabelMetadataProtection`](#cfclabelmetadataprotection) | `RuntimeOptions.cfcLabelMetadataProtection` | `off` | Bernhard Seefeld (#4638) | `observe` (divergence counting) first, then `enforce` | implemented, staged rollout |
 | [`conflictAdmissionMode`](#conflictadmissionmode) | `CF_CONFLICT_ADMISSION` env, or `setConflictAdmissionMode()` | `off` | William Kelly (#4237); `hold` removed CT-1925 (#5110) | keep `preempt` as a tuning dial or remove after re-measurement | implemented, off by default, measured net-negative |
 | [`syncSchemaTableV2`](#syncschematablev2) | `setSyncSchemaTableConfig()` (negotiated per connection) | on | Ben Follington (#4292) | retire the negotiation once every peer speaks v2 | implemented, on by default |
+| [`syncSchemaCasV1`](#syncschemacasv1) | `setSyncSchemaCasConfig()` (negotiated per connection) | off | Bernhard Seefeld | measure distinct schemas per connection, then default on and retire `syncSchemaTableV2` | implemented, off by default |
 | [`experimentalConcurrentWatchRefresh`](#experimentalconcurrentwatchrefresh) | `IRemoteStorageProviderSettings`; in the shell, the `commonfabric.concurrentWatchRefresh()` console command (localStorage, per browser profile) | off | Ben Follington (#4937; shell toggle #4974) | graduate to always-on after live measurement, or remove if superseded | implemented behind the flag, off by default, not yet measured over real latency |
 | [`cfcRenderCeiling`](#cfcrenderceiling) | `commonfabric.cfcRenderCeiling()` in the browser (localStorage) | off | Bernhard Seefeld (#4550) | graduate once exchange resolution lands | implemented, off by default, dogfood only |
 | [`fuseNfsCacheTuning`](#fusenfscachetuning) | `cf fuse mount --attrcache-timeout <whole seconds; 0 = untuned>` or `--noattrcache` | cf adds `attrcache-timeout=1` (one second) to FUSE-T mounts | Ian Hickson | keep the default; shrink the exec.ts listing-recheck delay once the default has field-soaked | implemented, on by default for FUSE-T, soak-validated |
@@ -658,6 +659,33 @@ the per-epic implementation notes).
 - **Path to removal.** Confirm no peer still needs the expanded payload, then
   delete the negotiation and the expanded-form encoder and always send the
   compact form.
+
+### `syncSchemaCasV1`
+
+- **Toggle via.** `setSyncSchemaCasConfig()` in
+  [`packages/memory/v2.ts`](../../packages/memory/v2.ts). Advertised as a
+  capability in the memory `hello` handshake and negotiated per connection, so a
+  peer only receives the connection-scoped form if it advertises support.
+- **Added by.** Bernhard Seefeld.
+- **Purpose.** A wire-size optimization: it scopes the hash-keyed schema table
+  to the CONNECTION rather than to each frame, so a schema body travels on the
+  first frame that names it and later frames carry the `schema-cas@1:` reference
+  alone. `syncSchemaTableV2` re-sends every body on every frame that references
+  it; this removes that repetition for long-lived connections. It changes only
+  when a body travels, never what a peer ends up holding.
+- **Interaction with `syncSchemaTableV2`.** The two encodings are exclusive per
+  connection, and this one wins when both are negotiated. A peer must know from
+  the handshake alone whether a frame is self-describing, so a connection never
+  mixes them.
+- **Current default and planned end state.** Off by default while the
+  distinct-schema count per connection is measured — the delivered set grows
+  monotonically for a connection's lifetime, and that measurement decides
+  whether it needs a cap with an inline fallback. The end state is on by
+  default, then retiring `syncSchemaTableV2` and its negotiation.
+- **Status on 2026-08-05.** Implemented, off by default, unmeasured in the
+  field.
+- **Path to removal.** Default it on, confirm no peer still needs the
+  frame-local form, then delete both negotiations and the frame-local encoder.
 
 > Two neighbours in the same handshake are related but are not runtime-toggleable
 > experimental flags:

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -44,7 +44,7 @@ was last checked against the code.
 | [`cfcLabelMetadataProtection`](#cfclabelmetadataprotection) | `RuntimeOptions.cfcLabelMetadataProtection` | `off` | Bernhard Seefeld (#4638) | `observe` (divergence counting) first, then `enforce` | implemented, staged rollout |
 | [`conflictAdmissionMode`](#conflictadmissionmode) | `CF_CONFLICT_ADMISSION` env, or `setConflictAdmissionMode()` | `off` | William Kelly (#4237); `hold` removed CT-1925 (#5110) | keep `preempt` as a tuning dial or remove after re-measurement | implemented, off by default, measured net-negative |
 | [`syncSchemaTableV2`](#syncschematablev2) | `setSyncSchemaTableConfig()` (negotiated per connection) | on | Ben Follington (#4292) | retire the negotiation once every peer speaks v2 | implemented, on by default |
-| [`syncSchemaCasV1`](#syncschemacasv1) | `setSyncSchemaCasConfig()` (negotiated per connection) | off | Bernhard Seefeld | measure distinct schemas per connection, then default on and retire `syncSchemaTableV2` | implemented, off by default |
+| [`syncSchemaCasV1`](#syncschemacasv1) | `RuntimeOptions.experimental.syncSchemaCasV1` (`EXPERIMENTAL_SYNC_SCHEMA_CAS`); negotiated per connection | off | Bernhard Seefeld | measure distinct schemas per connection, then default on and retire `syncSchemaTableV2` | implemented, off by default |
 | [`experimentalConcurrentWatchRefresh`](#experimentalconcurrentwatchrefresh) | `IRemoteStorageProviderSettings`; in the shell, the `commonfabric.concurrentWatchRefresh()` console command (localStorage, per browser profile) | off | Ben Follington (#4937; shell toggle #4974) | graduate to always-on after live measurement, or remove if superseded | implemented behind the flag, off by default, not yet measured over real latency |
 | [`cfcRenderCeiling`](#cfcrenderceiling) | `commonfabric.cfcRenderCeiling()` in the browser (localStorage) | off | Bernhard Seefeld (#4550) | graduate once exchange resolution lands | implemented, off by default, dogfood only |
 | [`fuseNfsCacheTuning`](#fusenfscachetuning) | `cf fuse mount --attrcache-timeout <whole seconds; 0 = untuned>` or `--noattrcache` | cf adds `attrcache-timeout=1` (one second) to FUSE-T mounts | Ian Hickson | keep the default; shrink the exec.ts listing-recheck delay once the default has field-soaked | implemented, on by default for FUSE-T, soak-validated |
@@ -662,10 +662,17 @@ the per-epic implementation notes).
 
 ### `syncSchemaCasV1`
 
-- **Toggle via.** `setSyncSchemaCasConfig()` in
-  [`packages/memory/v2.ts`](../../packages/memory/v2.ts). Advertised as a
-  capability in the memory `hello` handshake and negotiated per connection, so a
-  peer only receives the connection-scoped form if it advertises support.
+- **Toggle via.** `RuntimeOptions.experimental.syncSchemaCasV1`, or
+  `EXPERIMENTAL_SYNC_SCHEMA_CAS=true` through the canonical env mapping in
+  [`runtime-presets.ts`](../../packages/runner/src/runtime-presets.ts). The
+  Runtime propagates it to `setSyncSchemaCasConfig()` in
+  [`packages/memory/v2.ts`](../../packages/memory/v2.ts), which is also the
+  direct seam tests use. It is advertised as a capability in the memory `hello`
+  handshake and negotiated per connection, so a peer only receives the
+  connection-scoped form if it advertises support. Because the server reads the
+  same ambient flag when it builds its own handshake, setting it on a process
+  arms both ends that process hosts — a toolshed's memory server as well as its
+  runtime's client.
 - **Added by.** Bernhard Seefeld.
 - **Purpose.** A wire-size optimization: it scopes the hash-keyed schema table
   to the CONNECTION rather than to each frame, so a schema body travels on the

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -677,11 +677,22 @@ the per-epic implementation notes).
   connection, and this one wins when both are negotiated. A peer must know from
   the handshake alone whether a frame is self-describing, so a connection never
   mixes them.
+- **Recovering from a lost frame.** Frames under this encoding are not
+  self-describing, so a frame a peer receives but fails to process is not
+  survivable in place: the bodies it carried are counted as delivered, later
+  frames reference them bare, and no protocol request fetches a schema by hash.
+  The client therefore discards the connection when a frame fails to decode or
+  expand, and the fresh connection starts the server's delivered set empty.
 - **Current default and planned end state.** Off by default while the
-  distinct-schema count per connection is measured — the delivered set grows
-  monotonically for a connection's lifetime, and that measurement decides
-  whether it needs a cap with an inline fallback. The end state is on by
-  default, then retiring `syncSchemaTableV2` and its negotiation.
+  per-connection cost is measured. Both sides grow monotonically: the server
+  keeps a set of tagged hashes per connection, and the client keeps whole
+  schema bodies for the life of the `Client` — which in a browser tab is the
+  life of the tab, since a reconnect reuses it — including schemas of documents
+  since unwatched or deleted. Neither side caps or evicts. That measurement
+  decides whether either needs a cap with an inline fallback; inlining is
+  always decodable, so exceeding a cap degrades to the frame-local behavior
+  rather than breaking. The end state is on by default, then retiring
+  `syncSchemaTableV2` and its negotiation.
 - **Status on 2026-08-05.** Implemented, off by default, unmeasured in the
   field.
 - **Path to removal.** Default it on, confirm no peer still needs the

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -683,6 +683,11 @@ the per-epic implementation notes).
   frames reference them bare, and no protocol request fetches a schema by hash.
   The client therefore discards the connection when a frame fails to decode or
   expand, and the fresh connection starts the server's delivered set empty.
+  What that restores is the connection, not the frame. A lost frame's own
+  documents are gone to that client under **both** encodings — their upserts
+  advanced the server's session cache when the frame was built, and
+  resume-time catch-up diffs against that advanced cache. Only a send that
+  throws is repaired, by `rollbackUndeliveredSync`.
 - **Current default and planned end state.** Off by default while the
   per-connection cost is measured. Both sides grow monotonically: the server
   keeps a set of tagged hashes per connection, and the client keeps whole

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -501,9 +501,15 @@ their upserts advanced the session's server-side cache when the frame was
 built, and resume-time catch-up diffs against that advanced cache. A send that
 fails observably is the one case repaired, by rolling that advance back.
 
-Because the delivered set is per connection, a reconnect resets the server's
-side while a client may retain bodies from the previous connection. That
-direction is safe: the server re-sends a body the client already holds.
+The delivered set is scoped to the connection, not to the logical session that
+tracks which documents a client already holds. The two answer the same
+question for different things and are deliberately not aligned: a session
+outlives the connection, and it may be resumed by a different client, whose
+store of schema bodies is empty. Inheriting a delivered set across such a
+resume would send that client references it can never resolve. Scoping to the
+connection also means a reconnect resets the server's side while a client may
+retain bodies from the previous one — the safe direction, where the server
+re-sends a body the client already holds.
 
 Earlier revisions of this encoding also interned the `schema` field of
 `$alias` records. Those records are Pattern-binding vocabulary, not links —

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -475,15 +475,29 @@ connection, and MUST reject the frame when neither satisfies it. Bodies are
 verified on arrival under the same hash rule as the frame-local encoding, so a
 body resolved from an earlier frame has already been checked.
 
-A server MUST NOT record a body as delivered until the frame carrying it has
-reached the transport. A frame that fails to send is recomputed from durable
+A server MUST NOT record a body as delivered until the transport has accepted
+the frame carrying it. A frame that fails to send is recomputed from durable
 state, and the recomputed frame carries the body again; recording it earlier
 would emit later references that the peer has no way to resolve and no way to
-request. Because the delivered set is per connection, a reconnect resets the
-server's side while a client may retain bodies from the previous connection.
-That direction is safe — the server re-sends a body the client already holds —
-and it is the only direction that can occur, since a client that forgets has by
-construction established a new connection.
+request.
+
+Acceptance by a transport is weaker than arrival at the peer, so both sides
+carry an obligation for the gap:
+
+- A transport that discards a frame without reporting failure does so because
+  its connection is already ending. It MUST NOT go on to carry a later frame
+  for that connection, so the stranded reference is never sent and the
+  delivered set dies with the connection.
+- A client that receives a frame but fails to decode or expand it MUST discard
+  the connection rather than continue on it. The frame may have carried bodies
+  the server has recorded, and this encoding gives the client no way to
+  recover them in place — unlike the frame-local encoding, where the next
+  frame describes itself and the connection heals. Establishing a new
+  connection resets the server's delivered set.
+
+Because the delivered set is per connection, a reconnect resets the server's
+side while a client may retain bodies from the previous connection. That
+direction is safe: the server re-sends a body the client already holds.
 
 Earlier revisions of this encoding also interned the `schema` field of
 `$alias` records. Those records are Pattern-binding vocabulary, not links —

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -53,6 +53,7 @@ The client MUST declare its protocol version in the first WebSocket message:
     "modernCellRep": true,
     "persistentSchedulerState": true,
     "syncSchemaTableV2": true,
+    "syncSchemaCasV1": false,
     "verdictCatchUpMarkers": true,
     "entityIdListing": true,
     "entityIdPagination": true,
@@ -71,6 +72,7 @@ If the server accepts the protocol, it returns:
     "modernCellRep": true,
     "persistentSchedulerState": true,
     "syncSchemaTableV2": true,
+    "syncSchemaCasV1": false,
     "verdictCatchUpMarkers": true,
     "entityIdListing": true,
     "entityIdPagination": true,
@@ -144,6 +146,13 @@ in [Session Sync Payload](#423-session-sync-payload). It defaults to `false`
 when absent. The server sends compact sync payloads only when both peers
 advertise the capability; otherwise it sends the historical fully expanded
 shape.
+
+`syncSchemaCasV1` advertises support for the connection-scoped schema table
+described in [Session Sync Payload](#423-session-sync-payload). It defaults to
+`false` when absent. When both peers advertise it, it supersedes
+`syncSchemaTableV2` for that connection: the two encodings are exclusive,
+because a peer must know from the handshake alone whether a frame is
+self-describing.
 
 `entityIdListing` advertises support for `entity-id.list`. It defaults to
 `false` when absent. A client must not send the request unless the server
@@ -283,6 +292,7 @@ interface HelloMessage {
     modernCellRep: boolean;
     persistentSchedulerState?: boolean;
     syncSchemaTableV2?: boolean;
+    syncSchemaCasV1?: boolean;
     entityIdListing?: boolean;
     entityIdPagination?: boolean;
     entityIdLookup?: boolean;
@@ -437,15 +447,43 @@ For example, the compact wire form can contain:
 }
 ```
 
-The table is scoped to one sync payload, not to a connection or logical
-session. A client MUST resolve every `schema-ref@2:` before exposing the sync to
-the session cache. It MUST reject a reference when the table is missing the key
-or when hashing the referenced table value does not reproduce the key. It MUST
-also reject a sync whose documents still carry a reserved reference at a
-recognized schema position after expansion — a reference the client does not
-interpret must fail the frame rather than reach the session cache as data.
-After expansion, downstream consumers observe the historical `SessionSync`
-shape with inline schemas and no `schemaTable` field.
+This table is scoped to one sync payload, not to a connection or logical
+session. A client MUST resolve every `schema-ref@2:` against the table of the
+frame that carried it, and MUST NOT satisfy one from a body delivered on any
+other frame: the encoding's guarantee is that each frame describes itself, so a
+missing key is a sender defect and must be reported as one. A client MUST
+reject a reference when the table is missing the key or when hashing the
+referenced table value does not reproduce the key. It MUST also reject a sync
+whose documents still carry a reserved reference at a recognized schema
+position after expansion — a reference the client does not interpret must fail
+the frame rather than reach the session cache as data. After expansion,
+downstream consumers observe the historical `SessionSync` shape with inline
+schemas and no `schemaTable` field.
+
+#### Connection-scoped schema-table encoding
+
+When both peers advertise `syncSchemaCasV1`, the schema table is scoped to the
+connection instead of the frame, and that encoding replaces the frame-local one
+for the connection's lifetime. References are minted under the `schema-cas@1:`
+prefix, and a schema body is written to `schemaTable` only on the first frame
+of the connection that names its hash. A frame naming only bodies the peer
+already holds carries no `schemaTable` field at all.
+
+A client MUST resolve a `schema-cas@1:` reference against the frame's table
+first, then against the bodies delivered on earlier frames of the same
+connection, and MUST reject the frame when neither satisfies it. Bodies are
+verified on arrival under the same hash rule as the frame-local encoding, so a
+body resolved from an earlier frame has already been checked.
+
+A server MUST NOT record a body as delivered until the frame carrying it has
+reached the transport. A frame that fails to send is recomputed from durable
+state, and the recomputed frame carries the body again; recording it earlier
+would emit later references that the peer has no way to resolve and no way to
+request. Because the delivered set is per connection, a reconnect resets the
+server's side while a client may retain bodies from the previous connection.
+That direction is safe — the server re-sends a body the client already holds —
+and it is the only direction that can occur, since a client that forgets has by
+construction established a new connection.
 
 Earlier revisions of this encoding also interned the `schema` field of
 `$alias` records. Those records are Pattern-binding vocabulary, not links —
@@ -454,14 +492,15 @@ carry them, so current servers leave alias schemas inline. Clients deployed
 against the earlier revision continue to expand references at alias schema
 positions, so those positions remain covered by the reservation rule below.
 
-The `schema-ref@2:` prefix is reserved in the `schema` field of `link@1` and
-legacy `$alias` payloads. Link recognition follows the canonical cell-rep
-form — in the legacy representation, the single-key `{ "/": { "link@1": … } }`
-envelope — so an envelope carrying sibling keys is not a link and its contents
-are ordinary data. Memory servers MUST reject set or patch operations
-whose resulting stored document uses that prefix as an opaque schema string in
-a recognized schema position; ordinary strings in other document positions are
-unaffected.
+The `schema-ref@2:` and `schema-cas@1:` prefixes are reserved in the `schema`
+field of `link@1` and legacy `$alias` payloads. Link recognition follows the
+canonical cell-rep form — in the legacy representation, the single-key
+`{ "/": { "link@1": … } }` envelope — so an envelope carrying sibling keys is
+not a link and its contents are ordinary data. Memory servers MUST reject set
+or patch operations whose resulting stored document uses either prefix as an
+opaque schema string in a recognized schema position; ordinary strings in other
+document positions are unaffected. A reference can therefore only be minted by
+a server compressing a frame, never replayed out of stored data.
 
 ### 4.2.4 Batching
 

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -495,6 +495,12 @@ carry an obligation for the gap:
   frame describes itself and the connection heals. Establishing a new
   connection resets the server's delivered set.
 
+Discarding restores the connection, not the frame. Under either encoding, the
+documents carried by a frame that never reached its peer are not redelivered:
+their upserts advanced the session's server-side cache when the frame was
+built, and resume-time catch-up diffs against that advanced cache. A send that
+fails observably is the one case repaired, by rolling that advance back.
+
 Because the delivered set is per connection, a reconnect resets the server's
 side while a client may retain bodies from the previous connection. That
 direction is safe: the server re-sends a body the client already holds.

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -25,12 +25,15 @@ import {
   getMemoryProtocolFlags,
   type HelloOkMessage,
   MEMORY_PROTOCOL,
+  type MemoryProtocolFlags,
+  resetSyncSchemaCasConfig,
   type ResponseMessage,
   type ServerMessage,
   type SessionEffectMessage,
   type SessionOpenAuthMetadata,
   type SessionOpenResult,
   type SessionSync,
+  setSyncSchemaCasConfig,
   type WatchAddResult,
 } from "../v2.ts";
 import { Server } from "../v2/server.ts";
@@ -183,7 +186,7 @@ Deno.test("sync schema table experiment captures repeated schema savings", () =>
   const bytes = encodedBytes(message);
   const schemaMarkerCount =
     encodeMemoryBoundary(message).split("$defs").length - 1;
-  const compressed = compressServerMessageSchemas(message);
+  const { message: compressed } = compressServerMessageSchemas(message);
   const compressedBytes = encodedBytes(compressed);
   const compressedSchemaMarkerCount = encodeMemoryBoundary(compressed)
     .split("$defs").length - 1;
@@ -204,14 +207,15 @@ Deno.test("sync schema table experiment captures repeated schema savings", () =>
   );
 });
 
-Deno.test("sync schema table reports each repeated schema once", () => {
-  const observed: JSONSchema[] = [];
+Deno.test("sync schema table carries each repeated schema once", () => {
+  const compressed = compressSessionSyncSchemas(
+    repeatedSchemaSync(2),
+  ) as SchemaTableSessionSync;
+  const hash = internSchema(largeSchema(), true).taggedHashString;
 
-  compressSessionSyncSchemas(repeatedSchemaSync(2), (schema) => {
-    observed.push(schema);
-  });
-
-  assertEquals(observed, [internSchema(largeSchema(), true).schema]);
+  assertExists(compressed.schemaTable);
+  assertEquals(Object.keys(compressed.schemaTable), [hash]);
+  assertEquals(compressed.schemaTable[hash], largeSchema());
 });
 
 Deno.test("sync schema table preserves own __proto__ fields", () => {
@@ -337,16 +341,7 @@ Deno.test("sync schema table leaves legacy alias schemas inline", () => {
     `schema-ref@2:${nestedHash}`,
   );
 
-  const expandedSchemas: JSONSchema[] = [];
-  assertEquals(
-    expandSessionSyncSchemas(compressed, (expanded) => {
-      expandedSchemas.push(expanded);
-    }),
-    sync,
-  );
-  assertEquals(expandedSchemas, [
-    internSchema(nestedLinkSchema, true).schema,
-  ]);
+  assertEquals(expandSessionSyncSchemas(compressed), sync);
 });
 
 Deno.test("sync schema table survives malformed link envelope payloads", () => {
@@ -772,19 +767,18 @@ Deno.test("server schema table helpers ignore non-sync messages", () => {
     ok: { sync: { type: "not-sync" } },
   } satisfies ServerMessage;
 
-  assertStrictEquals(compressServerMessageSchemas(hello), hello);
-  assertStrictEquals(
-    compressServerMessageSchemas(responseWithoutOk),
-    responseWithoutOk,
-  );
-  assertStrictEquals(
-    compressServerMessageSchemas(responseWithPrimitiveOk),
-    responseWithPrimitiveOk,
-  );
-  assertStrictEquals(
-    compressServerMessageSchemas(responseWithNonSyncOk),
-    responseWithNonSyncOk,
-  );
+  for (
+    const untouched of [
+      hello,
+      responseWithoutOk,
+      responseWithPrimitiveOk,
+      responseWithNonSyncOk,
+    ]
+  ) {
+    const compressed = compressServerMessageSchemas(untouched);
+    assertStrictEquals(compressed.message, untouched);
+    assertEquals(compressed.staged.size, 0);
+  }
 
   assertStrictEquals(
     expandServerMessageSchemas("not-an-object"),
@@ -908,6 +902,330 @@ Deno.test("memory server negotiates schema-table v2 sync frames per connection",
   assertExists(await run("v2"));
   assertEquals(await run("legacy"), undefined);
   assertEquals(await run("off"), undefined);
+});
+
+/** Opens a cas-negotiated session and returns the pieces a test drives it
+ *  with. The caller owns closing the connection and the server. */
+const openCasSession = async (
+  server: Server,
+  space: string,
+  clientFlags: MemoryProtocolFlags,
+) => {
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+  await connection.receive(encodeMemoryBoundary({
+    type: "hello",
+    protocol: MEMORY_PROTOCOL,
+    flags: clientFlags,
+  }));
+  const sessionOpen = expectHelloOk(messages);
+  await connection.receive(encodeMemoryBoundary({
+    type: "session.open",
+    requestId: "open",
+    space,
+    session: {},
+    invocation: authInvocation(sessionOpen),
+  }));
+  const opened = nextResponse<SessionOpenResult>(messages);
+  assertExists(opened.ok);
+  return { connection, messages, sessionId: opened.ok.sessionId };
+};
+
+const watchAdd = async (
+  connection: { receive(payload: string): Promise<void> },
+  space: string,
+  sessionId: string,
+  requestId: string,
+  id: string,
+) =>
+  await connection.receive(encodeMemoryBoundary({
+    type: "session.watch.add",
+    requestId,
+    space,
+    sessionId,
+    watches: [{
+      id: requestId,
+      kind: "graph",
+      query: { roots: [{ id, selector: { path: [], schema: false } }] },
+    }],
+  }));
+
+Deno.test("connection-scoped schema bodies span a connection, not a frame", async () => {
+  setSyncSchemaCasConfig(true);
+  const space = "did:key:z6Mk-sync-schema-cas-connection";
+  const server = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL("memory://sync-schema-cas-connection"),
+  });
+  const schema = largeSchema();
+  const hash = internSchema(schema, true).taggedHashString;
+  const docValue = (target: string) => ({
+    ref: linkRefFrom({ id: target, path: [], schema }),
+  });
+
+  try {
+    await server.writeDocument(space, "of:cas-a", docValue("of:target-a"));
+    await server.writeDocument(space, "of:cas-b", docValue("of:target-b"));
+
+    const first = await openCasSession(server, space, getMemoryProtocolFlags());
+    try {
+      await watchAdd(first.connection, space, first.sessionId, "a", "of:cas-a");
+      const watchedA = nextResponse<WatchAddResult>(first.messages);
+      const syncA = watchedA.ok?.sync as SchemaTableSessionSync;
+      assertExists(syncA.schemaTable);
+      assertEquals(Object.keys(syncA.schemaTable), [hash]);
+
+      // Same schema, same connection, different document: the body has
+      // already been delivered, so only the reference travels.
+      await watchAdd(first.connection, space, first.sessionId, "b", "of:cas-b");
+      const watchedB = nextResponse<WatchAddResult>(first.messages);
+      const syncB = watchedB.ok?.sync as SchemaTableSessionSync;
+      assertEquals(syncB.schemaTable, undefined);
+      assertEquals(
+        findSyncSchemaRef(syncB.upserts[0].doc),
+        `schema-cas@1:${hash}`,
+      );
+    } finally {
+      first.connection.close();
+    }
+
+    // A FRESH connection has delivered nothing, so it is taught the body
+    // again. This is the direction a reconnect drifts in — the server
+    // forgets while the client remembers — and it costs bytes, not
+    // correctness.
+    const second = await openCasSession(
+      server,
+      space,
+      getMemoryProtocolFlags(),
+    );
+    try {
+      await watchAdd(
+        second.connection,
+        space,
+        second.sessionId,
+        "b",
+        "of:cas-b",
+      );
+      const watched = nextResponse<WatchAddResult>(second.messages);
+      const sync = watched.ok?.sync as SchemaTableSessionSync;
+      assertExists(sync.schemaTable);
+      assertEquals(Object.keys(sync.schemaTable), [hash]);
+    } finally {
+      second.connection.close();
+    }
+  } finally {
+    await server.close();
+    resetSyncSchemaCasConfig();
+  }
+});
+
+Deno.test("both peers must advertise cas before a frame stops describing itself", async () => {
+  const schema = largeSchema();
+  const hash = internSchema(schema, true).taggedHashString;
+
+  const refUnder = async (
+    label: string,
+    serverCas: boolean,
+    clientCas: boolean,
+  ) => {
+    setSyncSchemaCasConfig(serverCas);
+    const space = `did:key:z6Mk-sync-schema-cas-${label}`;
+    const server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL(`memory://sync-schema-cas-negotiation-${label}`),
+    });
+    try {
+      await server.writeDocument(space, "of:cas-negotiated", {
+        ref: linkRefFrom({ id: "of:target", path: [], schema }),
+      });
+      const { connection, messages, sessionId } = await openCasSession(
+        server,
+        space,
+        { ...getMemoryProtocolFlags(), syncSchemaCasV1: clientCas },
+      );
+      try {
+        await watchAdd(connection, space, sessionId, "w", "of:cas-negotiated");
+        const watched = nextResponse<WatchAddResult>(messages);
+        return findSyncSchemaRef(
+          (watched.ok?.sync as SchemaTableSessionSync).upserts[0].doc,
+        );
+      } finally {
+        connection.close();
+      }
+    } finally {
+      await server.close();
+      resetSyncSchemaCasConfig();
+    }
+  };
+
+  assertEquals(await refUnder("both", true, true), `schema-cas@1:${hash}`);
+  // Either peer withholding the capability keeps the connection on
+  // self-describing frames — the encodings are exclusive, so a peer must
+  // never have to guess which one a frame uses.
+  assertEquals(
+    await refUnder("client-only", false, true),
+    `schema-ref@2:${hash}`,
+  );
+  assertEquals(
+    await refUnder("server-only", true, false),
+    `schema-ref@2:${hash}`,
+  );
+});
+
+Deno.test("a schema body is remembered only once its frame reaches the transport", async () => {
+  setSyncSchemaCasConfig(true);
+  const space = "did:key:z6Mk-sync-schema-cas-rollback";
+  const server = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL("memory://sync-schema-cas-rollback"),
+    subscriptionRefreshDelayMs: 60_000,
+  });
+  const schema = largeSchema();
+  const hash = internSchema(schema, true).taggedHashString;
+
+  try {
+    const { connection, messages, sessionId } = await openCasSession(
+      server,
+      space,
+      getMemoryProtocolFlags(),
+    );
+    try {
+      // Watch an absent document: nothing to carry yet, so the body is
+      // still undelivered when the write below makes it due.
+      await watchAdd(connection, space, sessionId, "w", "of:cas-late");
+      assertExists(nextResponse<WatchAddResult>(messages).ok);
+
+      const originalPush = messages.push.bind(messages);
+      let failNextEffect = true;
+      messages.push = ((message: ServerMessage) => {
+        if (failNextEffect && message.type === "session/effect") {
+          failNextEffect = false;
+          throw new Error("synthetic send failure");
+        }
+        return originalPush(message);
+      }) as typeof messages.push;
+
+      await server.writeDocument(space, "of:cas-late", {
+        ref: linkRefFrom({ id: "of:target-late", path: [], schema }),
+      });
+      await server.flushSessions([space]);
+      assertEquals(messages.length, 0, "the effect never reached the wire");
+
+      // The staged body went down with the frame. Recomputation must carry
+      // it again — a connection that recorded it here would emit a bare
+      // reference the peer can never resolve.
+      await server.flushSessions([space]);
+      const effect = shiftMessage(messages) as SessionEffectMessage;
+      assertEquals(effect.type, "session/effect");
+      const sync = effect.effect as SchemaTableSessionSync;
+      assertExists(
+        sync.schemaTable,
+        "the redelivered frame re-carries the undelivered body",
+      );
+      assertEquals(Object.keys(sync.schemaTable), [hash]);
+    } finally {
+      connection.close();
+    }
+  } finally {
+    await server.close();
+    resetSyncSchemaCasConfig();
+  }
+});
+
+Deno.test("connection-scoped compression carries a body once, then references it", () => {
+  const sync = repeatedSchemaSync(2);
+  const hash = internSchema(largeSchema(), true).taggedHashString;
+  const delivered = new Set<string>();
+
+  const first = compressSessionSyncSchemas(
+    sync,
+    delivered,
+  ) as SchemaTableSessionSync;
+  assertExists(first.schemaTable);
+  assertEquals(Object.keys(first.schemaTable), [hash]);
+  assertEquals(
+    (first.upserts[0].doc?.value as Record<string, unknown>).primary,
+    linkRefFrom({
+      id: "of:target-0",
+      path: [],
+      schema: `schema-cas@1:${hash}`,
+    }),
+  );
+
+  for (const staged of Object.keys(first.schemaTable)) delivered.add(staged);
+
+  const second = compressSessionSyncSchemas(
+    sync,
+    delivered,
+  ) as SchemaTableSessionSync;
+  assertEquals(
+    second.schemaTable,
+    undefined,
+    "a steady-state frame carries no table at all",
+  );
+  assertEquals(
+    findSyncSchemaRef(second.upserts[0].doc),
+    `schema-cas@1:${hash}`,
+  );
+
+  // A receiver that took delivery of the first frame resolves the second.
+  const cache = new Map<string, JSONSchema>();
+  assertEquals(expandSessionSyncSchemas(first, cache), sync);
+  assertEquals(cache.size, 1);
+  assertEquals(expandSessionSyncSchemas(second, cache), sync);
+});
+
+Deno.test("connection-scoped references need a table or a delivered body", () => {
+  const hash = internSchema(largeSchema(), true).taggedHashString;
+  const orphaned = compressSessionSyncSchemas(
+    repeatedSchemaSync(1),
+    new Set([hash]),
+  );
+
+  // The body was never delivered to THIS receiver: an empty cache cannot
+  // satisfy the reference, and silently dropping it would hand the session
+  // cache a ref string as data.
+  assertThrows(
+    () => expandSessionSyncSchemas(orphaned, new Map()),
+    Error,
+    "Invalid sync schema table reference",
+  );
+});
+
+Deno.test("a frame-local reference never resolves from the connection cache", () => {
+  // schema-ref@2: promises the body travels on the same frame. A missing
+  // table entry is a sender defect, and must be reported as one rather than
+  // satisfied by an unrelated body the cache happens to hold.
+  const schema: JSONSchema = { type: "string" };
+  const hash = internSchema(schema, true).taggedHashString;
+  const cache = new Map<string, JSONSchema>([[hash, schema]]);
+  const sync: SessionSync = {
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: [{
+      branch: "",
+      id: "of:frame-local-ref",
+      scope: "space",
+      seq: 1,
+      doc: {
+        value: {
+          ref: linkRefFrom({
+            id: "of:target",
+            path: [],
+            schema: `schema-ref@2:${hash}`,
+          }),
+        },
+      },
+    }],
+    removes: [],
+  };
+
+  assertThrows(
+    () => expandSessionSyncSchemas(sync, cache),
+    Error,
+    "Invalid sync schema table reference",
+  );
 });
 
 Deno.test("findSyncSchemaRef ignores inherited object properties", () => {

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -37,6 +37,7 @@ import {
   type WatchAddResult,
 } from "../v2.ts";
 import { Server } from "../v2/server.ts";
+import { connect, type Transport } from "../v2/client.ts";
 import {
   compressServerMessageSchemas,
   compressSessionSyncSchemas,
@@ -49,7 +50,10 @@ import {
   findSyncSchemaRef,
 } from "../v2/sync-schema-ref.ts";
 import { mapLinkSchemas } from "../v2/schema-table-links.ts";
-import { testSessionOpenServerOptions } from "./v2-auth-test-helpers.ts";
+import {
+  testSessionOpenAuthFactory,
+  testSessionOpenServerOptions,
+} from "./v2-auth-test-helpers.ts";
 
 const textEncoder = new TextEncoder();
 
@@ -1017,6 +1021,132 @@ Deno.test("connection-scoped schema bodies span a connection, not a frame", asyn
     await server.close();
     resetSyncSchemaCasConfig();
   }
+});
+
+/**
+ * A loopback that opens a fresh server connection whenever it has none, the
+ * way `WebSocketTransport` opens a fresh socket once the old one is not OPEN.
+ * `loopback()` binds one `Server.connect` for its lifetime, so it cannot carry
+ * a client through a reconnect. `rewrite` sees each outbound frame and may
+ * alter it, standing in for what a transport does to a frame in flight.
+ */
+const reconnectingLoopback = (
+  server: Server,
+  rewrite: (payload: string) => string,
+): Transport => {
+  let receiver = (_payload: string) => {};
+  let closeReceiver = (_error?: Error) => {};
+  let connection: ReturnType<Server["connect"]> | null = null;
+  const open = () => {
+    connection ??= server.connect((message) => {
+      receiver(rewrite(encodeMemoryBoundary(message)));
+    });
+    return connection;
+  };
+  return {
+    async send(payload) {
+      await open().receive(payload);
+    },
+    close() {
+      const current = connection;
+      connection = null;
+      current?.close();
+      closeReceiver();
+      return Promise.resolve();
+    },
+    setReceiver(next) {
+      receiver = next;
+    },
+    setCloseReceiver(next) {
+      closeReceiver = next;
+    },
+  };
+};
+
+/**
+ * Drives a real Client against a real Server, corrupting the first
+ * session/effect so the client's decode fails on it — the frame reaches the
+ * client, which then cannot process it. Returns what the watch view holds for
+ * a document whose schema rode on that lost frame.
+ */
+const documentAfterALostEffect = async (
+  label: string,
+  cas: boolean,
+): Promise<EntityDocument | null | undefined> => {
+  setSyncSchemaCasConfig(cas);
+  const space = `did:key:z6Mk-sync-schema-lost-frame-${label}`;
+  const server = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL(`memory://sync-schema-lost-frame-${label}`),
+    // Only the explicit flushes below deliver, so the corrupted frame is the
+    // one carrying the schema body rather than whichever frame a scheduled
+    // refresh happened to emit first.
+    subscriptionRefreshDelayMs: 60_000,
+  });
+  let corruptNextEffect = false;
+  const transport = reconnectingLoopback(server, (payload) => {
+    if (corruptNextEffect && payload.includes("session/effect")) {
+      corruptNextEffect = false;
+      return `${payload}!corrupt`;
+    }
+    return payload;
+  });
+
+  const client = await connect({ transport });
+  try {
+    const session = await client.mount(space, {}, testSessionOpenAuthFactory);
+    const view = await session.watchAdd([{
+      id: "w",
+      kind: "graph",
+      query: {
+        roots: [
+          { id: "of:lost", selector: { path: [], schema: false } },
+          { id: "of:later", selector: { path: [], schema: false } },
+        ],
+      },
+    }]);
+
+    const updates = view.subscribe();
+    const schema = largeSchema();
+    corruptNextEffect = true;
+    await server.writeDocument(space, "of:lost", {
+      ref: linkRefFrom({ id: "of:target-lost", path: [], schema }),
+    });
+    await server.flushSessions([space]);
+
+    // A later document naming the same schema. A connection that recorded the
+    // lost frame's body as delivered sends a bare reference the client can
+    // never resolve, and this document never arrives.
+    await server.writeDocument(space, "of:later", {
+      ref: linkRefFrom({ id: "of:target-later", path: [], schema }),
+    });
+    await server.flushSessions([space]);
+
+    // Woken by the view, not by a deadline: an update that never arrives
+    // leaves this await pending with nothing else holding the loop, which
+    // Deno reports as a failure rather than a hang.
+    while (true) {
+      const update = await updates.next();
+      if (update.done) return undefined;
+      const later = update.value.entities.find(
+        (entity) => entity.id === "of:later",
+      );
+      if (later?.document != null) return later.document;
+    }
+  } finally {
+    await client.close();
+    await server.close();
+    resetSyncSchemaCasConfig();
+  }
+};
+
+Deno.test("a connection that loses a frame recovers under either encoding", async () => {
+  // The frame-local encoding heals on the next frame: it describes itself.
+  assertExists(await documentAfterALostEffect("frame-local", false));
+  // The connection-scoped encoding cannot heal in place — the body is gone
+  // and no request can fetch it — so the client must discard the connection
+  // and let a fresh one re-teach the bodies.
+  assertExists(await documentAfterALostEffect("cas", true));
 });
 
 Deno.test("both peers must advertise cas before a frame stops describing itself", async () => {

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -1032,6 +1032,248 @@ type LostFrameOutcome = {
   later: EntityDocument | null;
 };
 
+/**
+ * A loopback shaped like `WebSocketTransport` rather than like `loopback()`.
+ *
+ * The two differ in exactly the places a client's connection state machine is
+ * fragile, so exercising only `loopback()` leaves those paths untested:
+ * `WebSocketTransport.close()` detaches its socket first and then AWAITS the
+ * close handshake — arbitrarily long on the half-open socket that mangles a
+ * frame in the first place — and its close listener stays silent for a socket
+ * it has already replaced. A send re-opens.
+ */
+const slowCloseLoopback = (server: Server, rewrite: (p: string) => string) => {
+  let receiver = (_payload: string) => {};
+  let closeReceiver = (_error?: Error) => {};
+  let connection: ReturnType<Server["connect"]> | null = null;
+  let releaseClose: (() => void) | null = null;
+  // While held, a close detaches at once but does not settle, standing in for
+  // the close handshake a real socket waits through.
+  const state = { closes: 0, hellos: 0, holdClose: false };
+  const open = () => {
+    connection ??= server.connect((message) => {
+      receiver(rewrite(encodeMemoryBoundary(message)));
+    });
+    return connection;
+  };
+  const transport: Transport = {
+    async send(payload) {
+      if (payload.includes('"hello"')) state.hellos += 1;
+      await open().receive(payload);
+    },
+    close() {
+      state.closes += 1;
+      const current = connection;
+      connection = null;
+      current?.close();
+      // Deliberately no close callback — the real transport suppresses it for
+      // a socket it has already replaced.
+      if (!state.holdClose) return Promise.resolve();
+      return new Promise<void>((resolve) => {
+        releaseClose = resolve;
+      });
+    },
+    setReceiver(next) {
+      receiver = next;
+    },
+    setCloseReceiver(next) {
+      closeReceiver = next;
+    },
+  };
+  return {
+    transport,
+    state,
+    /** Kills the current connection the way a socket dying does: the peer is
+     *  gone and the client is told, so its reconnect loop takes over. */
+    dropConnection: () => {
+      connection?.close();
+      connection = null;
+      closeReceiver(new Error("socket died"));
+    },
+    /** Lets the pending close finish, as a real socket's close event does,
+     *  and stops holding later ones. */
+    settleClose: () => {
+      state.holdClose = false;
+      releaseClose?.();
+      releaseClose = null;
+    },
+  };
+};
+
+Deno.test("a reconnect completed during a discard's close is not handshaken twice", async () => {
+  // The discard closes the transport and reconnects once the close settles.
+  // A real close is slow, and anything routine — a transact, a request —
+  // reconnects inside that window. The deferred reconnect must then notice
+  // the connection is already up: a server connection refuses a second
+  // `hello` with an error no retry can clear, so handshaking again spins the
+  // reconnect loop forever with every request waiting behind it.
+  setSyncSchemaCasConfig(true);
+  const space = "did:key:z6Mk-sync-schema-double-hello";
+  const server = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL("memory://sync-schema-double-hello"),
+    subscriptionRefreshDelayMs: 60_000,
+  });
+  let corruptNextEffect = false;
+  const { transport, state, settleClose } = slowCloseLoopback(
+    server,
+    (payload) => {
+      if (corruptNextEffect && payload.includes("session/effect")) {
+        corruptNextEffect = false;
+        return `${payload}!corrupt`;
+      }
+      return payload;
+    },
+  );
+
+  const client = await connect({ transport });
+  try {
+    const session = await client.mount(space, {}, testSessionOpenAuthFactory);
+    await session.watchAdd([{
+      id: "w",
+      kind: "graph",
+      query: {
+        roots: [{ id: "of:double", selector: { path: [], schema: false } }],
+      },
+    }]);
+    assertEquals(state.hellos, 1);
+
+    // Fail a frame: the discard detaches the transport and parks on the close.
+    state.holdClose = true;
+    corruptNextEffect = true;
+    await server.writeDocument(space, "of:double", {
+      ref: linkRefFrom({ id: "of:target", path: [], schema: largeSchema() }),
+    });
+    await server.flushSessions([space]);
+
+    // Someone else reconnects while that close is still pending. This is the
+    // ordinary path — `transact` does it whenever the client reads as
+    // disconnected — and it succeeds on a fresh connection.
+    await client.restoreConnection();
+    assertEquals(state.hellos, 2);
+    assertEquals(client.isConnected(), true);
+
+    // Now the close settles and the deferred reconnect runs. It must be a
+    // no-op; a second handshake here is refused and never recovers.
+    settleClose();
+    await client.restoreConnection();
+    assertEquals(
+      state.hellos,
+      2,
+      "the deferred reconnect must not handshake a live connection",
+    );
+    assertEquals(client.isConnected(), true);
+  } finally {
+    settleClose();
+    await client.close();
+    await server.close();
+    resetSyncSchemaCasConfig();
+  }
+});
+
+Deno.test("the client's encoding follows what its handshake advertised", async () => {
+  // The server negotiates from the flags it RECEIVED. A client that re-read
+  // the ambient config when `hello.ok` landed could answer differently, and
+  // the two ends would then disagree about whether frames describe
+  // themselves — the one thing this encoding cannot tolerate. Flipping the
+  // config in flight forces exactly that divergence.
+  setSyncSchemaCasConfig(true);
+  const space = "did:key:z6Mk-sync-schema-advertised";
+  const server = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL("memory://sync-schema-advertised"),
+    subscriptionRefreshDelayMs: 60_000,
+  });
+  let corruptNextEffect = false;
+  const { transport, state } = slowCloseLoopback(server, (payload) => {
+    if (payload.includes("hello.ok")) {
+      // The handshake is committed on both sides; only a later ambient read
+      // can still be misled.
+      setSyncSchemaCasConfig(false);
+    }
+    if (corruptNextEffect && payload.includes("session/effect")) {
+      corruptNextEffect = false;
+      return `${payload}!corrupt`;
+    }
+    return payload;
+  });
+
+  const client = await connect({ transport });
+  try {
+    const session = await client.mount(space, {}, testSessionOpenAuthFactory);
+    await session.watchAdd([{
+      id: "w",
+      kind: "graph",
+      query: {
+        roots: [{ id: "of:advertised", selector: { path: [], schema: false } }],
+      },
+    }]);
+    assertEquals(state.closes, 0);
+
+    corruptNextEffect = true;
+    await server.writeDocument(space, "of:advertised", {
+      ref: linkRefFrom({ id: "of:target", path: [], schema: largeSchema() }),
+    });
+    await server.flushSessions([space]);
+
+    // This connection speaks cas — both ends advertised it — so a frame the
+    // client cannot process must discard it. A client that concluded
+    // otherwise from the flipped config would stay on a connection whose
+    // later references it can no longer resolve.
+    assert(
+      state.closes > 0,
+      "the connection negotiated cas, so a lost frame must discard it",
+    );
+  } finally {
+    await client.close();
+    await server.close();
+    resetSyncSchemaCasConfig();
+  }
+});
+
+Deno.test("a reconnect whose handshake frame is unreadable still recovers", async () => {
+  // The server connection has already answered a `hello` by the time it sends
+  // a frame the client cannot read, so the reconnect loop's next attempt on
+  // that same transport is refused as a repeat — an error nothing marks
+  // permanent, so the loop can never succeed on it. Dropping the transport is
+  // what lets the following attempt reach a fresh connection.
+  const server = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL("memory://sync-schema-handshake-drop"),
+    subscriptionRefreshDelayMs: 60_000,
+  });
+  let corruptNextHelloOk = false;
+  const { transport, state, dropConnection } = slowCloseLoopback(
+    server,
+    (payload) => {
+      if (corruptNextHelloOk && payload.includes("hello.ok")) {
+        corruptNextHelloOk = false;
+        return `${payload}!corrupt`;
+      }
+      return payload;
+    },
+  );
+
+  const client = await connect({ transport });
+  try {
+    assertEquals(state.hellos, 1);
+
+    // The socket dies, and the reconnect's own handshake frame is the one
+    // that arrives unreadable.
+    corruptNextHelloOk = true;
+    dropConnection();
+
+    // Joins the reconnect loop and resolves once it succeeds. Without the
+    // transport drop it never does: every further attempt reuses a connection
+    // that has already handshaken.
+    await client.restoreConnection();
+    assertEquals(client.isConnected(), true);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
 Deno.test("a failed handshake settles rather than stranding its replacement", async () => {
   // Closing the transport on an unreadable handshake frame can drive
   // `onClose` synchronously, so the reconnect it triggers installs its own

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -1025,10 +1025,11 @@ Deno.test("connection-scoped schema bodies span a connection, not a frame", asyn
 
 /** What a watch view holds after a frame the client could not process. */
 type LostFrameOutcome = {
-  /** The document whose schema rode on the lost frame. */
-  lost: EntityDocument | null | undefined;
-  /** A later document naming that same schema. */
-  later: EntityDocument | null | undefined;
+  /** The document whose schema rode on the lost frame, or null if none
+   *  arrived. */
+  lost: EntityDocument | null;
+  /** A later document naming that same schema, or null if none arrived. */
+  later: EntityDocument | null;
 };
 
 /**
@@ -1103,8 +1104,11 @@ const watchAfterALostEffect = async (
     // Woken by the view, not by a deadline: an update that never arrives
     // leaves this await pending with nothing else holding the loop, which
     // Deno reports as a failure rather than a hang.
-    const documentOf = (id: string) =>
-      view.entities.find((entity) => entity.id === id)?.document;
+    // An entity the view never received and one it holds as absent both mean
+    // "no document arrived"; collapse them so a caller asserts the outcome
+    // rather than which of the two spellings produced it.
+    const documentOf = (id: string): EntityDocument | null =>
+      view.entities.find((entity) => entity.id === id)?.document ?? null;
     while (documentOf("of:later") == null) {
       const update = await updates.next();
       if (update.done) break;

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -37,7 +37,7 @@ import {
   type WatchAddResult,
 } from "../v2.ts";
 import { Server } from "../v2/server.ts";
-import { connect, type Transport } from "../v2/client.ts";
+import { connect, loopback, type Transport } from "../v2/client.ts";
 import {
   compressServerMessageSchemas,
   compressSessionSyncSchemas,
@@ -1023,56 +1023,23 @@ Deno.test("connection-scoped schema bodies span a connection, not a frame", asyn
   }
 });
 
-/**
- * A loopback that opens a fresh server connection whenever it has none, the
- * way `WebSocketTransport` opens a fresh socket once the old one is not OPEN.
- * `loopback()` binds one `Server.connect` for its lifetime, so it cannot carry
- * a client through a reconnect. `rewrite` sees each outbound frame and may
- * alter it, standing in for what a transport does to a frame in flight.
- */
-const reconnectingLoopback = (
-  server: Server,
-  rewrite: (payload: string) => string,
-): Transport => {
-  let receiver = (_payload: string) => {};
-  let closeReceiver = (_error?: Error) => {};
-  let connection: ReturnType<Server["connect"]> | null = null;
-  const open = () => {
-    connection ??= server.connect((message) => {
-      receiver(rewrite(encodeMemoryBoundary(message)));
-    });
-    return connection;
-  };
-  return {
-    async send(payload) {
-      await open().receive(payload);
-    },
-    close() {
-      const current = connection;
-      connection = null;
-      current?.close();
-      closeReceiver();
-      return Promise.resolve();
-    },
-    setReceiver(next) {
-      receiver = next;
-    },
-    setCloseReceiver(next) {
-      closeReceiver = next;
-    },
-  };
+/** What a watch view holds after a frame the client could not process. */
+type LostFrameOutcome = {
+  /** The document whose schema rode on the lost frame. */
+  lost: EntityDocument | null | undefined;
+  /** A later document naming that same schema. */
+  later: EntityDocument | null | undefined;
 };
 
 /**
- * Drives a real Client against a real Server, corrupting the first
- * session/effect so the client's decode fails on it — the frame reaches the
- * client, which then cannot process it. Returns what the watch view holds for
- * a document whose schema rode on that lost frame.
+ * Drives a real Client against a real Server over `loopback`, corrupting one
+ * session/effect so the client's own decode path fails on it — the frame
+ * reaches the client, which then cannot process it.
  */
-const documentAfterALostEffect = async (
+const watchAfterALostEffect = async (
   label: string,
   cas: boolean,
-): Promise<EntityDocument | null | undefined> => {
+): Promise<LostFrameOutcome> => {
   setSyncSchemaCasConfig(cas);
   const space = `did:key:z6Mk-sync-schema-lost-frame-${label}`;
   const server = new Server({
@@ -1083,14 +1050,25 @@ const documentAfterALostEffect = async (
     // refresh happened to emit first.
     subscriptionRefreshDelayMs: 60_000,
   });
+  const base = loopback(server);
   let corruptNextEffect = false;
-  const transport = reconnectingLoopback(server, (payload) => {
-    if (corruptNextEffect && payload.includes("session/effect")) {
-      corruptNextEffect = false;
-      return `${payload}!corrupt`;
-    }
-    return payload;
-  });
+  const transport: Transport = {
+    send: (payload) => base.send(payload),
+    close: () => base.close(),
+    setReceiver(next) {
+      base.setReceiver((payload) => {
+        if (corruptNextEffect && payload.includes("session/effect")) {
+          corruptNextEffect = false;
+          next(`${payload}!corrupt`);
+          return;
+        }
+        next(payload);
+      });
+    },
+    setCloseReceiver(next) {
+      base.setCloseReceiver?.(next);
+    },
+  };
 
   const client = await connect({ transport });
   try {
@@ -1125,14 +1103,13 @@ const documentAfterALostEffect = async (
     // Woken by the view, not by a deadline: an update that never arrives
     // leaves this await pending with nothing else holding the loop, which
     // Deno reports as a failure rather than a hang.
-    while (true) {
+    const documentOf = (id: string) =>
+      view.entities.find((entity) => entity.id === id)?.document;
+    while (documentOf("of:later") == null) {
       const update = await updates.next();
-      if (update.done) return undefined;
-      const later = update.value.entities.find(
-        (entity) => entity.id === "of:later",
-      );
-      if (later?.document != null) return later.document;
+      if (update.done) break;
     }
+    return { lost: documentOf("of:lost"), later: documentOf("of:later") };
   } finally {
     await client.close();
     await server.close();
@@ -1140,13 +1117,27 @@ const documentAfterALostEffect = async (
   }
 };
 
-Deno.test("a connection that loses a frame recovers under either encoding", async () => {
-  // The frame-local encoding heals on the next frame: it describes itself.
-  assertExists(await documentAfterALostEffect("frame-local", false));
-  // The connection-scoped encoding cannot heal in place — the body is gone
-  // and no request can fetch it — so the client must discard the connection
-  // and let a fresh one re-teach the bodies.
-  assertExists(await documentAfterALostEffect("cas", true));
+Deno.test("a frame the client cannot process costs that frame, not the connection", async () => {
+  // Under the frame-local encoding the next frame describes itself, so the
+  // connection keeps delivering.
+  const frameLocal = await watchAfterALostEffect("frame-local", false);
+  assertExists(frameLocal.later);
+
+  // The connection-scoped encoding cannot heal in place: the server counts
+  // the lost frame's body as delivered, later frames reference it bare, and
+  // no request fetches a schema by hash. The client must discard the
+  // connection so a fresh one re-teaches the bodies. Without that, `later`
+  // never arrives and this wait fails.
+  const cas = await watchAfterALostEffect("cas", true);
+  assertExists(cas.later);
+
+  // What is NOT recovered, under EITHER encoding: the lost frame's own
+  // content. Its upserts advanced the server's session cache when the frame
+  // was built, and resume-time catch-up diffs against that advanced cache —
+  // see rollbackUndeliveredSync, which repairs only a send that threw. The
+  // discard restores the connection, not the frame.
+  assertEquals(frameLocal.lost, null);
+  assertEquals(cas.lost, null);
 });
 
 Deno.test("both peers must advertise cas before a frame stops describing itself", async () => {

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -1032,6 +1032,50 @@ type LostFrameOutcome = {
   later: EntityDocument | null;
 };
 
+Deno.test("a failed handshake settles rather than stranding its replacement", async () => {
+  // Closing the transport on an unreadable handshake frame can drive
+  // `onClose` synchronously, so the reconnect it triggers installs its own
+  // pending handshake BEFORE the failed one unwinds. A `hello()` that retired
+  // the pending unconditionally would retire the replacement's, leaving that
+  // handshake awaiting an ack nothing resolves — and `close()`, which waits
+  // on the reconnect, never returning.
+  const server = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL("memory://sync-schema-handshake-strand"),
+    subscriptionRefreshDelayMs: 60_000,
+  });
+  const base = loopback(server);
+  let corruptNextHelloOk = true;
+  const transport: Transport = {
+    send: (payload) => base.send(payload),
+    close: () => base.close(),
+    setReceiver(next) {
+      base.setReceiver((payload) => {
+        if (corruptNextHelloOk && payload.includes("hello.ok")) {
+          corruptNextHelloOk = false;
+          next(`${payload}!corrupt`);
+          return;
+        }
+        next(payload);
+      });
+    },
+    setCloseReceiver(next) {
+      base.setCloseReceiver?.(next);
+    },
+  };
+
+  try {
+    // Either outcome is acceptable — the handshake may fail or the retry may
+    // land — but it must SETTLE. Before the identity guard this neither
+    // resolved nor rejected.
+    await connect({ transport })
+      .then((client) => client.close())
+      .catch(() => undefined);
+  } finally {
+    await server.close();
+  }
+});
+
 /**
  * Drives a real Client against a real Server over `loopback`, corrupting one
  * session/effect so the client's own decode path fails on it — the frame

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -1296,6 +1296,35 @@ Deno.test("connection-scoped compression carries a body once, then references it
   assertEquals(expandSessionSyncSchemas(second, cache), sync);
 });
 
+Deno.test("expansion leaves an inline schema alone", () => {
+  // Not every schema position on an expanded frame holds a reference: a
+  // server may compress some and leave others, and a position holding an
+  // ordinary value is data. Expansion must pass those through rather than
+  // treat every schema position as a reference to resolve.
+  const inline: JSONSchema = { type: "string" };
+  const sync: SessionSync = {
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: [{
+      branch: "",
+      id: "of:inline-schema",
+      scope: "space",
+      seq: 1,
+      doc: {
+        value: {
+          ref: linkRefFrom({ id: "of:target", path: [], schema: inline }),
+        },
+      },
+    }],
+    removes: [],
+  };
+
+  const cache = new Map<string, JSONSchema>();
+  assertEquals(expandSessionSyncSchemas(sync, cache), sync);
+  assertEquals(cache.size, 0);
+});
+
 Deno.test("connection-scoped references need a table or a delivered body", () => {
   const hash = internSchema(largeSchema(), true).taggedHashString;
   const orphaned = compressSessionSyncSchemas(

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -310,6 +310,27 @@ describe("parseMemoryProtocolFlags", () => {
     );
   });
 
+  it("accepts the canonical syncSchemaCasV1 key", () => {
+    assertEquals(
+      parseMemoryProtocolFlags({
+        syncSchemaCasV1: true,
+      }),
+      {
+        modernCellRep: false,
+        persistentSchedulerState: false,
+        commitPreconditions: false,
+        syncSchemaTableV2: false,
+        syncSchemaCasV1: true,
+        sqliteCommitRowLabelEval: false,
+        pendingReadStacks: false,
+        verdictCatchUpMarkers: false,
+        entityIdListing: false,
+        entityIdPagination: false,
+        entityIdLookup: false,
+      },
+    );
+  });
+
   it("accepts the sqliteCommitRowLabelEval capability key", () => {
     assertEquals(
       parseMemoryProtocolFlags({
@@ -434,6 +455,7 @@ describe("parseMemoryProtocolFlags", () => {
     assertEquals(parseMemoryProtocolFlags([true]), null);
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: "true" }), null);
     assertEquals(parseMemoryProtocolFlags({ syncSchemaTableV2: "true" }), null);
+    assertEquals(parseMemoryProtocolFlags({ syncSchemaCasV1: "true" }), null);
     assertEquals(
       parseMemoryProtocolFlags({ verdictCatchUpMarkers: "true" }),
       null,

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -18,9 +18,11 @@ import {
   parseMemoryProtocolFlags,
   resetCommitPreconditionsConfig,
   resetPersistentSchedulerStateConfig,
+  resetSyncSchemaCasConfig,
   resetSyncSchemaTableConfig,
   setCommitPreconditionsConfig,
   setPersistentSchedulerStateConfig,
+  setSyncSchemaCasConfig,
   setSyncSchemaTableConfig,
   toDocumentPath,
   toDocumentSelector,
@@ -131,6 +133,7 @@ describe("memory v2 flags", () => {
     resetPersistentSchedulerStateConfig();
     resetCommitPreconditionsConfig();
     resetSyncSchemaTableConfig();
+    resetSyncSchemaCasConfig();
     setModernCellRepConfig(false);
     setPersistentSchedulerStateConfig(false);
     setCommitPreconditionsConfig(false);
@@ -148,12 +151,14 @@ describe("memory v2 flags", () => {
       entityIdPagination: true,
       entityIdLookup: true,
       syncSchemaTableV2: false,
+      syncSchemaCasV1: false,
     });
 
     setModernCellRepConfig(true);
     setPersistentSchedulerStateConfig(true);
     setCommitPreconditionsConfig(true);
     setSyncSchemaTableConfig(true);
+    setSyncSchemaCasConfig(true);
 
     assertEquals(getMemoryProtocolFlags(), {
       modernCellRep: true,
@@ -166,12 +171,14 @@ describe("memory v2 flags", () => {
       entityIdPagination: true,
       entityIdLookup: true,
       syncSchemaTableV2: true,
+      syncSchemaCasV1: true,
     });
 
     resetModernCellRepConfig();
     resetPersistentSchedulerStateConfig();
     resetCommitPreconditionsConfig();
     resetSyncSchemaTableConfig();
+    resetSyncSchemaCasConfig();
   });
 
   it("treats non-wire-shape flags as optional capabilities", () => {
@@ -181,6 +188,7 @@ describe("memory v2 flags", () => {
         persistentSchedulerState: true,
         commitPreconditions: true,
         syncSchemaTableV2: true,
+        syncSchemaCasV1: false,
         sqliteCommitRowLabelEval: true,
         pendingReadStacks: true,
         verdictCatchUpMarkers: false,
@@ -193,6 +201,7 @@ describe("memory v2 flags", () => {
         persistentSchedulerState: false,
         commitPreconditions: false,
         syncSchemaTableV2: false,
+        syncSchemaCasV1: false,
         // A peer without commit-time sqlite row-label evaluation stays
         // compatible — the capability only gates the runner's write-gate
         // relaxation, never the connection.
@@ -214,6 +223,7 @@ describe("parseMemoryProtocolFlags", () => {
       persistentSchedulerState: false,
       commitPreconditions: false,
       syncSchemaTableV2: false,
+      syncSchemaCasV1: false,
       sqliteCommitRowLabelEval: false,
       pendingReadStacks: false,
       verdictCatchUpMarkers: false,
@@ -226,6 +236,7 @@ describe("parseMemoryProtocolFlags", () => {
       persistentSchedulerState: false,
       commitPreconditions: false,
       syncSchemaTableV2: false,
+      syncSchemaCasV1: false,
       sqliteCommitRowLabelEval: false,
       pendingReadStacks: false,
       verdictCatchUpMarkers: false,
@@ -245,6 +256,7 @@ describe("parseMemoryProtocolFlags", () => {
         persistentSchedulerState: true,
         commitPreconditions: false,
         syncSchemaTableV2: false,
+        syncSchemaCasV1: false,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: false,
         verdictCatchUpMarkers: false,
@@ -265,6 +277,7 @@ describe("parseMemoryProtocolFlags", () => {
         persistentSchedulerState: false,
         commitPreconditions: true,
         syncSchemaTableV2: false,
+        syncSchemaCasV1: false,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: false,
         verdictCatchUpMarkers: false,
@@ -279,12 +292,14 @@ describe("parseMemoryProtocolFlags", () => {
     assertEquals(
       parseMemoryProtocolFlags({
         syncSchemaTableV2: true,
+        syncSchemaCasV1: false,
       }),
       {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: false,
         syncSchemaTableV2: true,
+        syncSchemaCasV1: false,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: false,
         verdictCatchUpMarkers: false,
@@ -305,6 +320,7 @@ describe("parseMemoryProtocolFlags", () => {
         persistentSchedulerState: false,
         commitPreconditions: false,
         syncSchemaTableV2: false,
+        syncSchemaCasV1: false,
         sqliteCommitRowLabelEval: true,
         pendingReadStacks: false,
         verdictCatchUpMarkers: false,
@@ -333,6 +349,7 @@ describe("parseMemoryProtocolFlags", () => {
         persistentSchedulerState: false,
         commitPreconditions: false,
         syncSchemaTableV2: false,
+        syncSchemaCasV1: false,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: false,
         verdictCatchUpMarkers: true,
@@ -354,6 +371,7 @@ describe("parseMemoryProtocolFlags", () => {
         persistentSchedulerState: false,
         commitPreconditions: false,
         syncSchemaTableV2: false,
+        syncSchemaCasV1: false,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: true,
         verdictCatchUpMarkers: false,
@@ -372,6 +390,7 @@ describe("parseMemoryProtocolFlags", () => {
         persistentSchedulerState: false,
         commitPreconditions: false,
         syncSchemaTableV2: false,
+        syncSchemaCasV1: false,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: false,
         verdictCatchUpMarkers: false,
@@ -393,6 +412,7 @@ describe("parseMemoryProtocolFlags", () => {
         persistentSchedulerState: false,
         commitPreconditions: false,
         syncSchemaTableV2: false,
+        syncSchemaCasV1: false,
         sqliteCommitRowLabelEval: false,
         pendingReadStacks: false,
         verdictCatchUpMarkers: false,

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -935,7 +935,12 @@ export function resetSyncSchemaTableConfig(): void {
  * body travels, never what a peer ends up holding.
  */
 export function setSyncSchemaCasConfig(enabled?: boolean): void {
-  syncSchemaCasEnabled = enabled ?? true;
+  // Absent means the default, and this capability's default is OFF — the
+  // opposite of `setSyncSchemaTableConfig`, whose feature ships on. The
+  // runtime propagates `experimental.syncSchemaCasV1` unconditionally, so an
+  // `enabled ?? true` here would arm the capability for every runtime that
+  // never asked for it.
+  syncSchemaCasEnabled = enabled ?? false;
 }
 
 export function getSyncSchemaCasConfig(): boolean {

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -277,6 +277,14 @@ export type MemoryProtocolFlags = {
   /** Hash-keyed per-frame schema table. */
   syncSchemaTableV2: boolean;
   /**
+   * Hash-keyed CONNECTION-scoped schema table: a schema body travels on the
+   * first frame of the connection that names it, and later frames carry the
+   * `schema-cas@1:` reference alone. Supersedes `syncSchemaTableV2` when both
+   * peers advertise it. The two are exclusive per connection — a peer must
+   * know from the negotiation whether a frame is self-describing.
+   */
+  syncSchemaCasV1: boolean;
+  /**
    * Server capability (CFC Phase 3.c): commit-folded `sqlite` writes to
    * rule-bearing tables are re-derived through the shared row-label evaluator
    * against the committed rows, rolling back on violation (see
@@ -330,6 +338,7 @@ export type WireMemoryProtocolFlags = {
   persistentSchedulerState?: boolean;
   commitPreconditions?: boolean;
   syncSchemaTableV2?: boolean;
+  syncSchemaCasV1?: boolean;
   sqliteCommitRowLabelEval?: boolean;
   pendingReadStacks?: boolean;
   verdictCatchUpMarkers?: boolean;
@@ -865,6 +874,7 @@ const memoryReconstructionContext = new EmptyReconstructionContext(
 let persistentSchedulerStateEnabled = false;
 let commitPreconditionsEnabled = true;
 let syncSchemaTableEnabled = true;
+let syncSchemaCasEnabled = false;
 
 /**
  * Ambient runtime flag for persistent scheduler observations and rehydration.
@@ -917,6 +927,25 @@ export function resetSyncSchemaTableConfig(): void {
   syncSchemaTableEnabled = true;
 }
 
+/**
+ * Ambient protocol capability for connection-scoped schema tables: a schema
+ * body travels on the first frame of a connection that names it, and later
+ * frames carry the reference alone. Supersedes the frame-local table when both
+ * peers advertise it. Also a wire-size optimization only — it changes when a
+ * body travels, never what a peer ends up holding.
+ */
+export function setSyncSchemaCasConfig(enabled?: boolean): void {
+  syncSchemaCasEnabled = enabled ?? true;
+}
+
+export function getSyncSchemaCasConfig(): boolean {
+  return syncSchemaCasEnabled;
+}
+
+export function resetSyncSchemaCasConfig(): void {
+  syncSchemaCasEnabled = false;
+}
+
 export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
   modernCellRep: getModernCellRepConfig(),
   persistentSchedulerState: getPersistentSchedulerStateConfig(),
@@ -940,6 +969,7 @@ export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
   entityIdPagination: true,
   entityIdLookup: true,
   syncSchemaTableV2: getSyncSchemaTableConfig(),
+  syncSchemaCasV1: getSyncSchemaCasConfig(),
 });
 
 /**
@@ -992,6 +1022,14 @@ export const parseMemoryProtocolFlags = (
   if (
     syncSchemaTableV2 !== undefined &&
     typeof syncSchemaTableV2 !== "boolean"
+  ) {
+    return null;
+  }
+
+  const syncSchemaCasV1 = value.syncSchemaCasV1;
+  if (
+    syncSchemaCasV1 !== undefined &&
+    typeof syncSchemaCasV1 !== "boolean"
   ) {
     return null;
   }
@@ -1049,6 +1087,9 @@ export const parseMemoryProtocolFlags = (
     persistentSchedulerState: persistentSchedulerState === true,
     commitPreconditions: commitPreconditions === true,
     syncSchemaTableV2: syncSchemaTableV2 === true,
+    // Absent (a peer that speaks only the frame-local table) parses to false,
+    // which keeps that peer on self-describing frames.
+    syncSchemaCasV1: syncSchemaCasV1 === true,
     // Absent (an older peer) parses to false: the capability must be
     // POSITIVELY advertised for the runner to relax its write gate.
     sqliteCommitRowLabelEval: sqliteCommitRowLabelEval === true,
@@ -1075,6 +1116,7 @@ export const wireMemoryProtocolFlags = (
   persistentSchedulerState: flags.persistentSchedulerState,
   commitPreconditions: flags.commitPreconditions,
   syncSchemaTableV2: flags.syncSchemaTableV2,
+  syncSchemaCasV1: flags.syncSchemaCasV1,
   sqliteCommitRowLabelEval: flags.sqliteCommitRowLabelEval,
   pendingReadStacks: flags.pendingReadStacks,
   verdictCatchUpMarkers: flags.verdictCatchUpMarkers,

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -166,13 +166,23 @@ export class Client {
   // for other spaces on this client alive.
   #fatalError: Error | null = null;
   // Schema bodies delivered under the connection-scoped encoding, by tagged
-  // hash. Deliberately NOT cleared on reconnect: the server tracks what it has
-  // delivered per Connection, so a reconnect makes the SERVER forget while
-  // this client remembers, and it re-sends bodies already held here — wasteful
-  // and correct. The unsafe drift is the reverse, and it cannot happen: this
-  // map dies only with the Client, and a new Client means a new socket, hence
-  // a new Connection with an empty delivered set.
+  // hash. Every entry was verified against the hash naming it, so holding one
+  // the server no longer counts as delivered costs bytes, never correctness.
+  //
+  // Deliberately NOT cleared on reconnect: the server tracks delivery per
+  // Connection, so a reconnect makes the SERVER forget while this map
+  // remembers, and it re-sends bodies already held here. The reverse — this
+  // map behind what the server counts as delivered — is what strands a
+  // connection, and the two ways to reach it are both closed: the map dies
+  // only with the Client, whose replacement means a new Connection, and a
+  // frame that fails to populate it discards the connection
+  // (`discardConnectionIfSchemaCas`).
   #schemaCache: SchemaCache = new Map();
+  // Whether the last handshake negotiated the connection-scoped schema
+  // encoding, mirroring the server's own negotiation. Frames on such a
+  // connection are not self-describing, which changes what a frame this client
+  // fails to process costs — see #discardConnection.
+  #schemaCasNegotiated = false;
 
   private constructor(
     private readonly transport: Transport,
@@ -376,6 +386,7 @@ export class Client {
         this.#helloPending.reject(error);
       } else {
         this.rejectPending(error);
+        this.discardConnectionIfSchemaCas(error);
       }
       return;
     }
@@ -402,6 +413,8 @@ export class Client {
         // consumers (e.g. the runner's sqlite write-gate relaxation) read
         // these; absent-on-old-server keys parse to false — fail closed.
         this.#serverFlags = helloOk.flags;
+        this.#schemaCasNegotiated = helloOk.flags.syncSchemaCasV1 === true &&
+          expectedFlags.syncSchemaCasV1 === true;
         try {
           this.#sessionOpenAuthContext = requireSessionOpenAuthMetadata(
             helloOk.sessionOpen,
@@ -486,6 +499,35 @@ export class Client {
     if (this.#fatalError) {
       throw this.#fatalError;
     }
+  }
+
+  /**
+   * Drops the transport so later frames arrive on a fresh connection, when
+   * this one carries schema bodies across frames.
+   *
+   * A frame this client fails to process may have carried schema bodies the
+   * server has already recorded as delivered. Under the frame-local encoding
+   * that costs exactly one frame: the next one describes itself and the
+   * connection heals. Under the connection-scoped encoding it is terminal —
+   * every later reference to those bodies is unresolvable, and there is no
+   * protocol request for a schema by hash, so the connection would keep
+   * failing frames while looking healthy. A new connection starts the server's
+   * delivered set empty, which re-teaches the bodies.
+   */
+  private discardConnectionIfSchemaCas(error: Error): void {
+    if (!this.#schemaCasNegotiated || this.#closed || !this.#connected) {
+      return;
+    }
+    // Closing comes FIRST: reconnect() reuses a transport whose socket is
+    // still open, which would keep the server's Connection — and the
+    // delivered set that is the problem — alive. The transport's close
+    // receiver then drives the usual reconnect; a transport that has none is
+    // driven here instead.
+    void this.transport.close().catch(() => undefined).finally(() => {
+      if (this.#connected && !this.#closed) {
+        this.onClose(error);
+      }
+    });
   }
 
   private onClose(error?: Error): void {

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -37,7 +37,10 @@ import {
 import type { Server } from "./server.ts";
 import type { AppliedCommit } from "./engine.ts";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
-import { expandServerMessageSchemas } from "./sync-schema-table.ts";
+import {
+  expandServerMessageSchemas,
+  type SchemaCache,
+} from "./sync-schema-table.ts";
 import { containsReservedSchemaRefSubstring } from "./sync-schema-ref.ts";
 
 export type Transport = {
@@ -162,6 +165,14 @@ export class Client {
   // it terminates only that session (see SpaceSession.restore), leaving sessions
   // for other spaces on this client alive.
   #fatalError: Error | null = null;
+  // Schema bodies delivered under the connection-scoped encoding, by tagged
+  // hash. Deliberately NOT cleared on reconnect: the server tracks what it has
+  // delivered per Connection, so a reconnect makes the SERVER forget while
+  // this client remembers, and it re-sends bodies already held here — wasteful
+  // and correct. The unsafe drift is the reverse, and it cannot happen: this
+  // map dies only with the Client, and a new Client means a new socket, hence
+  // a new Connection with an empty delivered set.
+  #schemaCache: SchemaCache = new Map();
 
   private constructor(
     private readonly transport: Transport,
@@ -354,7 +365,7 @@ export class Client {
       // on encodeMemoryBoundary), so the expansion walk over its upserts is
       // skipped entirely.
       if (containsReservedSchemaRefSubstring(payload)) {
-        message = expandServerMessageSchemas(message);
+        message = expandServerMessageSchemas(message, this.#schemaCache);
       }
     } catch (cause) {
       const error = new Error("Unable to parse memory server message", {

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -518,27 +518,45 @@ export class Client {
     if (!this.#schemaCasNegotiated || this.#closed || !this.#connected) {
       return;
     }
-    // Closing comes FIRST: reconnect() reuses a transport whose socket is
-    // still open, which would keep the server's Connection — and the
-    // delivered set that is the problem — alive. The transport's close
-    // receiver then drives the usual reconnect; a transport that has none is
-    // driven here instead.
-    void this.transport.close().catch(() => undefined).finally(() => {
-      if (this.#connected && !this.#closed) {
-        this.onClose(error);
-      }
-    });
+    // Leave the connected state SYNCHRONOUSLY, before yielding to the close.
+    // A transport's close can take arbitrarily long — a half-open socket is
+    // exactly where a frame gets mangled — and anything that observed a
+    // connected client meanwhile would send on a transport already on its way
+    // out: `ensureConnected` would skip the handshake, and the transport would
+    // open a fresh socket that never receives a `hello`. Clearing the flag
+    // here also makes this single-flight, so the further frames a desynced
+    // connection is expected to fail start no second discard.
+    this.markDisconnected(error);
+    void this.transport.close()
+      .catch(() => undefined)
+      .then(() => this.#closed ? undefined : this.reconnect())
+      .catch(() => undefined);
+  }
+
+  /** The state half of a disconnect: stop reporting connected, tell the
+   *  sessions, and settle everything in flight. Split out of {@link onClose}
+   *  so a discard can take it synchronously and leave the reconnect to its
+   *  own sequencing. */
+  private markDisconnected(error?: Error): void {
+    this.#connected = false;
+    for (const session of this.#spaces) {
+      session.handleDisconnect();
+    }
+    this.rejectPending(toConnectionError(error));
   }
 
   private onClose(error?: Error): void {
     if (this.#closed) {
       return;
     }
-    this.#connected = false;
-    for (const session of this.#spaces) {
-      session.handleDisconnect();
-    }
-    this.rejectPending(toConnectionError(error));
+    // Runs on the close a discard initiated as well as on an unsolicited one.
+    // Both halves tolerate the repeat: `handleDisconnect` only clears a flag,
+    // `rejectPending` finds the map already drained, and `reconnect` is
+    // single-flighted, so the second caller joins the first attempt rather
+    // than starting a competing one. This must NOT be skipped while
+    // disconnected — a close arriving mid-handshake is what settles the
+    // pending hello and lets the reconnect loop take its next attempt.
+    this.markDisconnected(error);
     void this.reconnect().catch(() => undefined);
   }
 
@@ -1685,21 +1703,38 @@ export const connect = Client.connect;
 
 export const loopback = (server: Server): Transport => {
   let receiver = (_payload: string) => {};
-  const connection = server.connect((message) => {
-    receiver(encodeMemoryBoundary(message));
-  });
+  let closeReceiver = (_error?: Error) => {};
+  let connection: ReturnType<Server["connect"]> | null = null;
+  // Opened on demand rather than once, so a client that closes this transport
+  // can reconnect through it — a closed Connection refuses every message, and
+  // binding one for the transport's lifetime would strand the client mid
+  // handshake. Mirrors WebSocketTransport, which opens a fresh socket whenever
+  // it has none.
+  const open = () => {
+    connection ??= server.connect((message) => {
+      receiver(encodeMemoryBoundary(message));
+    });
+    return connection;
+  };
   return {
     async send(payload: string) {
-      await connection.receive(payload);
+      await open().receive(payload);
     },
     close() {
-      connection.close();
+      const current = connection;
+      connection = null;
+      current?.close();
+      if (current !== null) {
+        closeReceiver();
+      }
       return Promise.resolve();
     },
     setReceiver(next) {
       receiver = next;
     },
-    setCloseReceiver() {},
+    setCloseReceiver(next) {
+      closeReceiver = next;
+    },
   };
 };
 

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -371,7 +371,16 @@ export class Client {
       ]);
       this.#connected = true;
     } finally {
-      this.#helloPending = null;
+      // Only retire the handshake this call installed. A failed handshake can
+      // have a REPLACEMENT already in flight by the time it unwinds — closing
+      // the transport drives `onClose`, which a transport may report
+      // synchronously, and the reconnect that follows installs its own
+      // pending. Clearing unconditionally would retire that one, leaving its
+      // `hello.ok` unrecognized and its handshake awaiting an ack nothing
+      // will ever resolve.
+      if (this.#helloPending === ack) {
+        this.#helloPending = null;
+      }
     }
   }
 

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -393,6 +393,14 @@ export class Client {
       error.name = "InvalidMessageError";
       if (this.#helloPending !== null) {
         this.#helloPending.reject(error);
+        // A frame arriving in the handshake window that this client cannot
+        // read leaves the server's connection having already answered a
+        // `hello`, so the reconnect loop's next attempt on this transport is
+        // refused as a repeat and no retry can ever succeed on it. Drop the
+        // transport so that attempt opens a fresh one. Deliberately not the
+        // cas discard: nothing is connected yet, and this hazard belongs to
+        // the handshake rather than to either schema encoding.
+        void this.transport.close().catch(() => undefined);
       } else {
         this.rejectPending(error);
         this.discardConnectionIfSchemaCas(error);

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -183,6 +183,8 @@ export class Client {
   // connection are not self-describing, which changes what a frame this client
   // fails to process costs — see `discardConnectionIfSchemaCas`.
   #schemaCasNegotiated = false;
+  // The flags the in-flight or most recent `hello` advertised. See hello().
+  #advertisedFlags: MemoryProtocolFlags | null = null;
 
   private constructor(
     private readonly transport: Transport,
@@ -351,12 +353,19 @@ export class Client {
   private async hello(): Promise<void> {
     const ack = Promise.withResolvers<void>();
     this.#helloPending = ack;
+    // Read the ambient flags ONCE and keep what this handshake advertised.
+    // The server negotiates against the flags it received, so a decision that
+    // must match the server's — which encoding this connection speaks — has
+    // to be made against these, not against a second read that a config
+    // change between send and `hello.ok` could answer differently.
+    const advertised = getMemoryProtocolFlags();
+    this.#advertisedFlags = advertised;
     try {
       await Promise.all([
         this.transport.send(encodeMemoryBoundary({
           type: "hello",
           protocol: MEMORY_PROTOCOL,
-          flags: getMemoryProtocolFlags(),
+          flags: advertised,
         })),
         ack.promise,
       ]);
@@ -414,7 +423,7 @@ export class Client {
         // these; absent-on-old-server keys parse to false — fail closed.
         this.#serverFlags = helloOk.flags;
         this.#schemaCasNegotiated = helloOk.flags.syncSchemaCasV1 === true &&
-          expectedFlags.syncSchemaCasV1 === true;
+          this.#advertisedFlags?.syncSchemaCasV1 === true;
         try {
           this.#sessionOpenAuthContext = requireSessionOpenAuthMetadata(
             helloOk.sessionOpen,

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -593,6 +593,16 @@ export class Client {
     if (this.#fatalError) {
       throw this.#fatalError;
     }
+    // Never handshake a connection that is already up. A server connection
+    // accepts one `hello` and refuses the next as a repeat — an error no
+    // retry can clear and nothing marks permanent — so a redundant attempt
+    // spins forever while every request waits on it. Callers that observed a
+    // disconnect clear the flag before arriving; this guards the caller whose
+    // observation went STALE, which a deferred reconnect becomes whenever its
+    // transport close outlives a reconnect somebody else completed meanwhile.
+    if (this.#connected) {
+      return;
+    }
     if (this.#reconnecting) {
       return await this.#reconnecting;
     }

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -181,7 +181,7 @@ export class Client {
   // Whether the last handshake negotiated the connection-scoped schema
   // encoding, mirroring the server's own negotiation. Frames on such a
   // connection are not self-describing, which changes what a frame this client
-  // fails to process costs — see #discardConnection.
+  // fails to process costs — see `discardConnectionIfSchemaCas`.
   #schemaCasNegotiated = false;
 
   private constructor(

--- a/packages/memory/v2/schema-table-links.ts
+++ b/packages/memory/v2/schema-table-links.ts
@@ -7,7 +7,18 @@ import type { FabricPlainObject, FabricValue } from "@commonfabric/api";
 import type { MutableFabricPlainObjectLayer } from "@commonfabric/data-model/fabric-value";
 import { isPlainObject } from "@commonfabric/utils/types";
 
-export const REQUEST_SCHEMA_CAS_REF_PREFIX = "schema-cas@1:";
+/**
+ * Connection-scoped schema reference — `schema-cas@1:` followed by a tagged
+ * schema hash. The body rides in the `schemaTable` of the frame that first
+ * names it on a connection; every later frame on that connection carries the
+ * reference alone, and the peer resolves it from what it has already been
+ * delivered. Contrast {@link SYNC_SCHEMA_REF_PREFIX}, whose table is
+ * frame-local, so each frame is self-describing.
+ *
+ * Reserved: the engine refuses to persist a document with either prefix in a
+ * schema position, so a reference can only ever be minted by the compressor.
+ */
+export const SCHEMA_CAS_REF_PREFIX = "schema-cas@1:";
 
 /** Optional request-local accounting for recursive schema-bearing values. */
 export type LinkSchemaTraversal = {

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -381,6 +381,16 @@ class Connection {
   // and this set dies with the connection. A peer that receives a frame but
   // fails to process it discards the connection for the same reason
   // (`discardConnectionIfSchemaCas` in v2/client.ts).
+  //
+  // Scoped to the CONNECTION, deliberately unlike the session's `entities`
+  // cache next to it, which answers the same "what does the peer already
+  // hold" question for documents and survives a resume. The matching
+  // lifetime for schema bodies is the connection's, because the peer's half
+  // of this ledger is the `Client`'s `#schemaCache` and a Client holds one
+  // connection at a time. A session is the wrong axis in both directions: it
+  // outlives the connection, and it can be resumed by a DIFFERENT client
+  // whose cache is empty — inheriting "already delivered" there would send
+  // that client references it could never resolve.
   #deliveredSchemas = new Set<string>();
   // Negotiated persistentSchedulerState: when both sides carry the flag,
   // subscription sync pushes to this connection include the scheduler

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -368,11 +368,19 @@ class Connection {
   // instead of to each frame. Exclusive with #syncSchemaTable — a peer must
   // know from the handshake whether a frame is self-describing.
   #syncSchemaCas = false;
-  // Tagged hashes of the schema bodies this connection has DELIVERED. A hash
-  // enters only after its carrying frame reached the transport: send() is the
+  // Tagged hashes of the schema bodies handed to this connection's transport.
+  // A hash enters only after its carrying frame was accepted: send() is the
   // commit point for sync state (see the rollback in flushDirty), and a body
-  // recorded but never delivered would strand every later reference naming
-  // it, with no way for the peer to ask for it.
+  // recorded but never sent would strand every later reference naming it, with
+  // no way for the peer to ask for it.
+  //
+  // Acceptance is weaker than arrival, and the gap is closed on both sides
+  // rather than here. A transport that discards instead of throwing does so
+  // because its socket is no longer open, and a socket that cannot carry this
+  // frame carries no later one either — the stranded reference is never sent,
+  // and this set dies with the connection. A peer that receives a frame but
+  // fails to process it discards the connection for the same reason
+  // (`discardConnectionIfSchemaCas` in v2/client.ts).
   #deliveredSchemas = new Set<string>();
   // Negotiated persistentSchedulerState: when both sides carry the flag,
   // subscription sync pushes to this connection include the scheduler

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -3015,10 +3015,14 @@ export class Server {
    * evaluation cannot elide them as already-snapshotted), re-stage its
    * marker obligation, and re-dirty its ids origin-less so a pass is
    * scheduled and the docs fan out authoritatively. Rollback rather than
-   * buffering: only a locally-throwing send is visible in-process, and a
-   * dying socket loses "successfully sent" frames just the same — the
-   * durable repair for that is resume-time catch-up, not a server-side
-   * buffer. A doc REMOVED by the lost frame is the accepted residue: its
+   * buffering: only a locally-throwing send is visible in-process, so this is
+   * the whole repair, and it reaches only the losses it is told about. A frame
+   * a dying socket accepted and dropped, or one the peer received and failed
+   * to process, already advanced this cache at build time; resume-time
+   * catch-up diffs against that advanced cache and so does not re-send it.
+   * Those frames' contents are lost to that client until a full
+   * re-evaluation. A doc REMOVED by the lost frame is the accepted residue:
+   * its
    * cache entry is already gone and cannot be re-diffed; the client keeps
    * it until a full re-evaluation or reconnect (watch-shrink removes are
    * advisory today). */

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -3032,8 +3032,7 @@ export class Server {
    * catch-up diffs against that advanced cache and so does not re-send it.
    * Those frames' contents are lost to that client until a full
    * re-evaluation. A doc REMOVED by the lost frame is the accepted residue:
-   * its
-   * cache entry is already gone and cannot be re-diffed; the client keeps
+   * its cache entry is already gone and cannot be re-diffed; the client keeps
    * it until a full re-evaluation or reconnect (watch-shrink removes are
    * advisory today). */
   rollbackUndeliveredSync(

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -364,6 +364,16 @@ class Connection {
   #ready = false;
   #closed = false;
   #syncSchemaTable = false;
+  // Negotiated syncSchemaCasV1: schema bodies are scoped to this connection
+  // instead of to each frame. Exclusive with #syncSchemaTable — a peer must
+  // know from the handshake whether a frame is self-describing.
+  #syncSchemaCas = false;
+  // Tagged hashes of the schema bodies this connection has DELIVERED. A hash
+  // enters only after its carrying frame reached the transport: send() is the
+  // commit point for sync state (see the rollback in flushDirty), and a body
+  // recorded but never delivered would strand every later reference naming
+  // it, with no way for the peer to ask for it.
+  #deliveredSchemas = new Set<string>();
   // Negotiated persistentSchedulerState: when both sides carry the flag,
   // subscription sync pushes to this connection include the scheduler
   // observation rows of the sync window, so its runtimes can ADOPT other
@@ -383,9 +393,21 @@ class Connection {
   ) {}
 
   private send(message: ServerMessage): void {
-    this.sendRaw(
-      this.#syncSchemaTable ? compressServerMessageSchemas(message) : message,
+    if (!this.#syncSchemaTable && !this.#syncSchemaCas) {
+      this.sendRaw(message);
+      return;
+    }
+    const { message: compressed, staged } = compressServerMessageSchemas(
+      message,
+      this.#syncSchemaCas ? this.#deliveredSchemas : undefined,
     );
+    // A throw propagates before the staged hashes are recorded, so the peer's
+    // known set and the sync delivery state roll back together: the frame is
+    // recomputed from durable state and re-carries the bodies.
+    this.sendRaw(compressed);
+    for (const hash of staged) {
+      this.#deliveredSchemas.add(hash);
+    }
   }
 
   hasSession(space: string, sessionId: string): boolean {
@@ -614,7 +636,10 @@ class Connection {
       }
       const clientFlags = parseMemoryProtocolFlags(parsed.flags);
       const serverFlags = parseMemoryProtocolFlags(response.flags);
-      this.#syncSchemaTable = clientFlags?.syncSchemaTableV2 === true &&
+      this.#syncSchemaCas = clientFlags?.syncSchemaCasV1 === true &&
+        serverFlags?.syncSchemaCasV1 === true;
+      this.#syncSchemaTable = !this.#syncSchemaCas &&
+        clientFlags?.syncSchemaTableV2 === true &&
         serverFlags?.syncSchemaTableV2 === true;
       this.#persistentSchedulerState =
         clientFlags?.persistentSchedulerState === true &&

--- a/packages/memory/v2/sync-schema-ref.ts
+++ b/packages/memory/v2/sync-schema-ref.ts
@@ -1,7 +1,13 @@
 import { isLinkRef, linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import { isPlainObject } from "@commonfabric/utils/types";
-import { REQUEST_SCHEMA_CAS_REF_PREFIX } from "./schema-table-links.ts";
+import { SCHEMA_CAS_REF_PREFIX } from "./schema-table-links.ts";
 
+/**
+ * Frame-local schema reference — `schema-ref@2:` followed by a tagged schema
+ * hash, resolved against the `schemaTable` of the same frame. Contrast
+ * {@link SCHEMA_CAS_REF_PREFIX}, which resolves against everything the
+ * connection has delivered.
+ */
 export const SYNC_SCHEMA_REF_PREFIX = "schema-ref@2:";
 
 const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
@@ -9,7 +15,7 @@ const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
 
 const isReservedSchemaRef = (value: string): boolean =>
   value.startsWith(SYNC_SCHEMA_REF_PREFIX) ||
-  value.startsWith(REQUEST_SCHEMA_CAS_REF_PREFIX);
+  value.startsWith(SCHEMA_CAS_REF_PREFIX);
 
 /**
  * Whether serialized text contains a reserved reference prefix anywhere.
@@ -21,7 +27,7 @@ const isReservedSchemaRef = (value: string): boolean =>
  */
 export const containsReservedSchemaRefSubstring = (value: string): boolean =>
   value.includes(SYNC_SCHEMA_REF_PREFIX) ||
-  value.includes(REQUEST_SCHEMA_CAS_REF_PREFIX);
+  value.includes(SCHEMA_CAS_REF_PREFIX);
 
 const payloadSchemaRef = (
   payload: Record<string, unknown>,

--- a/packages/memory/v2/sync-schema-table.ts
+++ b/packages/memory/v2/sync-schema-table.ts
@@ -44,9 +44,9 @@ export type CompressedServerMessage = {
   message: ServerMessage;
   /**
    * Tagged hashes whose schema bodies ride on THIS message — what the sender
-   * may add to its {@link DeliveredSchemas} once the message reaches the
-   * transport, and not one moment sooner: a staged body that never arrives
-   * strands every later reference naming it. Always empty under the
+   * may add to its {@link DeliveredSchemas} once the transport has accepted
+   * the message, and not one moment sooner: a staged body the transport
+   * rejects strands every later reference naming it. Always empty under the
    * frame-local encoding, which re-sends every body and so has nothing to
    * remember.
    */
@@ -213,8 +213,9 @@ export const expandSessionSyncSchemas = (
     // sits at a position this expander does not interpret — a legacy `$alias`
     // schema position interned by an older server — so there is nothing to
     // rewrite; report it rather than hand the session cache a ref as data.
-    // A connection-scoped receiver never takes this path: its references are
-    // expected to outlive the frame that carried their bodies.
+    // Passing a cache opts out of this shortcut, because under the
+    // connection-scoped encoding an empty table is the steady state and its
+    // references resolve against earlier frames.
     for (const upsert of sync.upserts) {
       const ref = findSyncSchemaRef(upsert.doc);
       if (ref !== undefined) {

--- a/packages/memory/v2/sync-schema-table.ts
+++ b/packages/memory/v2/sync-schema-table.ts
@@ -11,7 +11,7 @@ import {
   findSyncSchemaRef,
   SYNC_SCHEMA_REF_PREFIX,
 } from "./sync-schema-ref.ts";
-import { mapLinkSchemas } from "./schema-table-links.ts";
+import { mapLinkSchemas, SCHEMA_CAS_REF_PREFIX } from "./schema-table-links.ts";
 
 type SchemaTable = Record<string, JSONSchema>;
 
@@ -19,10 +19,46 @@ export type SchemaTableSessionSync = SessionSync & {
   schemaTable?: SchemaTable;
 };
 
+/**
+ * Tagged hashes of the schema bodies a peer already holds.
+ *
+ * Passing one selects the connection-scoped encoding: a schema is written to
+ * the frame's `schemaTable` only when the peer does not hold it yet, and every
+ * reference is minted under {@link SCHEMA_CAS_REF_PREFIX}. Omitting it selects
+ * the frame-local encoding, where each frame carries the body of every schema
+ * it names.
+ */
+export type DeliveredSchemas = ReadonlySet<string>;
+
+/**
+ * Schema bodies a peer has been delivered, by tagged hash.
+ *
+ * The receiving half of {@link DeliveredSchemas}: entries are added as frames
+ * carry them and read back when a later frame names a hash without carrying
+ * its body.
+ */
+export type SchemaCache = Map<string, JSONSchema>;
+
+/** A compressed message, and what its delivery would teach the peer. */
+export type CompressedServerMessage = {
+  message: ServerMessage;
+  /**
+   * Tagged hashes whose schema bodies ride on THIS message — what the sender
+   * may add to its {@link DeliveredSchemas} once the message reaches the
+   * transport, and not one moment sooner: a staged body that never arrives
+   * strands every later reference naming it. Always empty under the
+   * frame-local encoding, which re-sends every body and so has nothing to
+   * remember.
+   */
+  staged: ReadonlySet<string>;
+};
+
+const NO_STAGED_SCHEMAS: ReadonlySet<string> = new Set();
+
 type RewriteState = {
   schemas: Map<string, JSONSchema>;
   changed: boolean;
-  onSchema?: (schema: JSONSchema) => void;
+  delivered?: DeliveredSchemas;
 };
 
 const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
@@ -37,40 +73,65 @@ const schemaRefFor = (
 ): string => {
   const schemaAndHash = internSchema(schema, true);
   const hash = schemaAndHash.taggedHashString;
-  if (!state.schemas.has(hash)) {
+  if (state.delivered === undefined) {
     state.schemas.set(hash, schemaAndHash.schema);
-    state.onSchema?.(schemaAndHash.schema);
+    return `${SYNC_SCHEMA_REF_PREFIX}${hash}`;
   }
-  return `${SYNC_SCHEMA_REF_PREFIX}${hash}`;
+  // Connection-scoped: a body the peer already holds is not written again,
+  // so a steady-state frame carries references and no table at all.
+  if (!state.delivered.has(hash)) {
+    state.schemas.set(hash, schemaAndHash.schema);
+  }
+  return `${SCHEMA_CAS_REF_PREFIX}${hash}`;
+};
+
+/**
+ * The reserved prefix `value` carries, or undefined when it is not a
+ * reference. A `schema-cas@1:` reference may resolve from the cache; a
+ * `schema-ref@2:` one may not — its contract is that the body travels on the
+ * same frame, so a missing table entry is a sender defect and must be
+ * reported as one rather than silently satisfied by an unrelated cache hit.
+ */
+const refPrefixOf = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  if (value.startsWith(SYNC_SCHEMA_REF_PREFIX)) return SYNC_SCHEMA_REF_PREFIX;
+  if (value.startsWith(SCHEMA_CAS_REF_PREFIX)) return SCHEMA_CAS_REF_PREFIX;
+  return undefined;
 };
 
 const expandSchemaRef = (
   value: unknown,
   schemas: SchemaTable | undefined,
-  onSchema?: (schema: JSONSchema) => void,
+  cache?: SchemaCache,
 ): JSONSchema | undefined => {
+  const prefix = refPrefixOf(value);
+  if (prefix === undefined) return undefined;
+  const ref = value as string;
+  const hash = ref.slice(prefix.length);
+
   if (
-    typeof value !== "string" ||
-    !value.startsWith(SYNC_SCHEMA_REF_PREFIX)
+    hash.length > 0 && schemas !== undefined && Object.hasOwn(schemas, hash)
   ) {
-    return undefined;
+    const schemaAndHash = internSchema(schemas[hash], true);
+    if (schemaAndHash.taggedHashString !== hash) {
+      throw new Error(
+        `Invalid sync schema table content for reference: ${ref}`,
+      );
+    }
+    // Verified once, on arrival: the cache holds interned bodies whose hash
+    // has already been checked against the reference that carried them.
+    if (prefix === SCHEMA_CAS_REF_PREFIX) {
+      cache?.set(hash, schemaAndHash.schema);
+    }
+    return schemaAndHash.schema;
   }
-  const hash = value.slice(SYNC_SCHEMA_REF_PREFIX.length);
-  if (
-    hash.length === 0 || schemas === undefined ||
-    !Object.hasOwn(schemas, hash)
-  ) {
-    throw new Error(`Invalid sync schema table reference: ${value}`);
+
+  if (prefix === SCHEMA_CAS_REF_PREFIX && hash.length > 0) {
+    const cached = cache?.get(hash);
+    if (cached !== undefined) return cached;
   }
-  const schema = schemas[hash];
-  const schemaAndHash = internSchema(schema, true);
-  if (schemaAndHash.taggedHashString !== hash) {
-    throw new Error(
-      `Invalid sync schema table content for reference: ${value}`,
-    );
-  }
-  onSchema?.(schemaAndHash.schema);
-  return schemaAndHash.schema;
+
+  throw new Error(`Invalid sync schema table reference: ${ref}`);
 };
 
 const rewriteSchemaValue = (
@@ -87,8 +148,8 @@ const rewriteSchemaValue = (
 const expandSchemaValue = (
   value: FabricValue,
   schemas: SchemaTable | undefined,
-  onSchema?: (schema: JSONSchema) => void,
-): FabricValue => expandSchemaRef(value, schemas, onSchema) ?? value;
+  cache?: SchemaCache,
+): FabricValue => expandSchemaRef(value, schemas, cache) ?? value;
 
 const rewriteValue = (value: FabricValue, state: RewriteState): FabricValue =>
   mapLinkSchemas(value, (schema) => rewriteSchemaValue(schema, state));
@@ -96,21 +157,21 @@ const rewriteValue = (value: FabricValue, state: RewriteState): FabricValue =>
 const expandValue = (
   value: FabricValue,
   schemas: SchemaTable | undefined,
-  onSchema?: (schema: JSONSchema) => void,
+  cache?: SchemaCache,
 ): FabricValue =>
   mapLinkSchemas(
     value,
-    (schema) => expandSchemaValue(schema, schemas, onSchema),
+    (schema) => expandSchemaValue(schema, schemas, cache),
   );
 
 export const compressSessionSyncSchemas = (
   sync: SessionSync,
-  onSchema?: (schema: JSONSchema) => void,
+  delivered?: DeliveredSchemas,
 ): SessionSync | SchemaTableSessionSync => {
   const state: RewriteState = {
     schemas: new Map(),
     changed: false,
-    onSchema,
+    delivered,
   };
   const upserts = sync.upserts.map((upsert) => {
     if (upsert.doc === undefined) {
@@ -130,20 +191,34 @@ export const compressSessionSyncSchemas = (
   return {
     ...sync,
     upserts,
-    schemaTable: Object.fromEntries(state.schemas),
+    // A connection-scoped frame that names only already-delivered schemas
+    // has no table to carry; omitting the key keeps it off the wire rather
+    // than shipping an empty object on every steady-state frame.
+    ...(state.schemas.size > 0
+      ? { schemaTable: Object.fromEntries(state.schemas) }
+      : {}),
   };
 };
 
 export const expandSessionSyncSchemas = (
   sync: SessionSync | SchemaTableSessionSync,
-  onSchema?: (schema: JSONSchema) => void,
+  cache?: SchemaCache,
 ): SessionSync => {
   const schemas = (sync as SchemaTableSessionSync).schemaTable;
-  if (schemas === undefined || Object.keys(schemas).length === 0) {
+  if (
+    cache === undefined &&
+    (schemas === undefined || Object.keys(schemas).length === 0)
+  ) {
+    // Frame-local encoding with nothing to resolve against. A reference here
+    // sits at a position this expander does not interpret — a legacy `$alias`
+    // schema position interned by an older server — so there is nothing to
+    // rewrite; report it rather than hand the session cache a ref as data.
+    // A connection-scoped receiver never takes this path: its references are
+    // expected to outlive the frame that carried their bodies.
     for (const upsert of sync.upserts) {
       const ref = findSyncSchemaRef(upsert.doc);
       if (ref !== undefined) {
-        expandSchemaRef(ref, schemas, onSchema);
+        expandSchemaRef(ref, schemas, undefined);
       }
     }
     return sync;
@@ -153,7 +228,7 @@ export const expandSessionSyncSchemas = (
     if (upsert.doc === undefined) {
       return upsert;
     }
-    const doc = expandValue(upsert.doc, schemas, onSchema);
+    const doc = expandValue(upsert.doc, schemas, cache);
     // A ref surviving expansion sits at a position this expander does not
     // interpret — e.g. a legacy `$alias` schema position interned by an
     // older server. Delivering it would hand the session cache a ref
@@ -176,36 +251,48 @@ export const expandSessionSyncSchemas = (
   return deepFreeze(expanded as SessionSync);
 };
 
+/** The hashes a compressed sync placed on its frame — exactly its table's
+ *  keys, since a body is written there only when the peer lacks it. */
+const stagedFrom = (
+  sync: SessionSync | SchemaTableSessionSync,
+): ReadonlySet<string> => {
+  const table = (sync as SchemaTableSessionSync).schemaTable;
+  return table === undefined ? NO_STAGED_SCHEMAS : new Set(Object.keys(table));
+};
+
 const compressResponseSync = (
   message: ServerMessage,
-  onSchema?: (schema: JSONSchema) => void,
-): ServerMessage => {
+  delivered?: DeliveredSchemas,
+): CompressedServerMessage => {
   if (message.type !== "response" || message.ok === undefined) {
-    return message;
+    return { message, staged: NO_STAGED_SCHEMAS };
   }
   if (!isPlainRecord(message.ok)) {
-    return message;
+    return { message, staged: NO_STAGED_SCHEMAS };
   }
   const sync = message.ok.sync;
   if (!isPlainRecord(sync) || sync.type !== "sync") {
-    return message;
+    return { message, staged: NO_STAGED_SCHEMAS };
   }
 
+  const compressed = compressSessionSyncSchemas(
+    sync as unknown as SessionSync,
+    delivered,
+  );
   return {
-    ...message,
-    ok: {
-      ...message.ok,
-      sync: compressSessionSyncSchemas(
-        sync as unknown as SessionSync,
-        onSchema,
-      ),
+    message: {
+      ...message,
+      ok: { ...message.ok, sync: compressed },
     },
+    staged: delivered === undefined
+      ? NO_STAGED_SCHEMAS
+      : stagedFrom(compressed),
   };
 };
 
 const expandResponseSync = (
   message: unknown,
-  onSchema?: (schema: JSONSchema) => void,
+  cache?: SchemaCache,
 ): unknown => {
   if (!isPlainRecord(message) || message.type !== "response") {
     return message;
@@ -224,37 +311,52 @@ const expandResponseSync = (
       ...message.ok,
       sync: expandSessionSyncSchemas(
         sync as unknown as SchemaTableSessionSync,
-        onSchema,
+        cache,
       ),
     },
   };
 };
 
+/**
+ * Rewrites the schemas a server message carries into hash references.
+ *
+ * With `delivered`, the connection-scoped encoding applies: a body travels
+ * only on the first frame of the connection that names it, and the returned
+ * `staged` set names what this frame teaches the peer. Without it, the
+ * frame-local encoding applies and `staged` is empty.
+ */
 export const compressServerMessageSchemas = (
   message: ServerMessage,
-  onSchema?: (schema: JSONSchema) => void,
-): ServerMessage => {
+  delivered?: DeliveredSchemas,
+): CompressedServerMessage => {
   if (message.type === "session/effect") {
+    const effect = compressSessionSyncSchemas(message.effect, delivered);
     return {
-      ...message,
-      effect: compressSessionSyncSchemas(message.effect, onSchema),
-    } as SessionEffectMessage;
+      message: { ...message, effect } as SessionEffectMessage,
+      staged: delivered === undefined ? NO_STAGED_SCHEMAS : stagedFrom(effect),
+    };
   }
-  return compressResponseSync(message, onSchema);
+  return compressResponseSync(message, delivered);
 };
 
+/**
+ * Restores the schemas a server message references.
+ *
+ * With `cache`, connection-scoped references resolve against bodies delivered
+ * on earlier frames, and bodies arriving on this one are recorded there.
+ */
 export const expandServerMessageSchemas = (
   message: unknown,
-  onSchema?: (schema: JSONSchema) => void,
+  cache?: SchemaCache,
 ): unknown => {
   if (isPlainRecord(message) && message.type === "session/effect") {
     return {
       ...message,
       effect: expandSessionSyncSchemas(
         message.effect as SchemaTableSessionSync,
-        onSchema,
+        cache,
       ),
     };
   }
-  return expandResponseSync(message, onSchema);
+  return expandResponseSync(message, cache);
 };

--- a/packages/runner/src/runtime-presets.ts
+++ b/packages/runner/src/runtime-presets.ts
@@ -200,6 +200,11 @@ export const EXPERIMENTAL_ENV_VARS = {
   plainResultReceipts: "EXPERIMENTAL_PLAIN_RESULT_RECEIPTS",
   systemPatternAutoUpdate: "EXPERIMENTAL_SYSTEM_PATTERN_AUTOUPDATE",
   computedCellIds: "EXPERIMENTAL_COMPUTED_CELL_IDS",
+  // Connection-scoped memory schema tables: default-off during a staged
+  // rollout, and env-reachable because turning it on is a per-deployment
+  // decision — the server advertises the capability from the same ambient
+  // flag this sets, so a toolshed enables both ends by setting it.
+  syncSchemaCasV1: "EXPERIMENTAL_SYNC_SCHEMA_CAS",
 } as const satisfies Record<keyof ExperimentalOptions, string | null>;
 
 /**

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -20,10 +20,13 @@ import {
 import {
   getCommitPreconditionsConfig,
   getPersistentSchedulerStateConfig,
+  getSyncSchemaCasConfig,
   resetCommitPreconditionsConfig,
   resetPersistentSchedulerStateConfig,
+  resetSyncSchemaCasConfig,
   setCommitPreconditionsConfig,
   setPersistentSchedulerStateConfig,
+  setSyncSchemaCasConfig,
 } from "@commonfabric/memory/v2";
 import { PatternEnvironment, setPatternEnvironment } from "./builder/env.ts";
 import {
@@ -210,6 +213,15 @@ export interface ExperimentalOptions {
   persistentSchedulerState?: boolean | undefined;
   /** Enforce scheduler-v2 lineage and event-receipt commit preconditions (default on). */
   commitPreconditions?: boolean | undefined;
+  /**
+   * Scope the memory sync frame's hash-keyed schema table to the CONNECTION
+   * rather than to each frame, so a schema body travels on the first frame
+   * naming it and later frames carry the reference alone. Negotiated per
+   * connection and exclusive with the frame-local table. Wire-size only — it
+   * changes when a body travels, never what a peer ends up holding. Defaults
+   * to off; see `docs/development/EXPERIMENTAL_OPTIONS.md`.
+   */
+  syncSchemaCasV1?: boolean | undefined;
   /**
    * Project a handler's plain JSON return into its per-event receipt cell
    * instead of the empty `{}` witness, so a caller — or a same-id retry that
@@ -1000,6 +1012,8 @@ export class Runtime {
       getPersistentSchedulerStateConfig();
     setCommitPreconditionsConfig(this.experimental.commitPreconditions);
     this.experimental.commitPreconditions = getCommitPreconditionsConfig();
+    setSyncSchemaCasConfig(this.experimental.syncSchemaCasV1);
+    this.experimental.syncSchemaCasV1 = getSyncSchemaCasConfig();
     // Unlike the flags above, only propagate when EXPLICITLY set: the ambient
     // flag is also a test seam (tests toggle `setEagerSourceAnnotation`
     // directly around runtime construction), and an unconditional
@@ -1428,6 +1442,7 @@ export class Runtime {
     resetModernCellRepConfig();
     resetPersistentSchedulerStateConfig();
     resetCommitPreconditionsConfig();
+    resetSyncSchemaCasConfig();
 
     // Clear the current runtime reference
     // Removed setCurrentRuntime call - no longer using singleton pattern

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -180,13 +180,19 @@ export class WebSocketTransport implements MemoryClient.Transport {
         }
       });
       socket.addEventListener("close", () => {
-        if (this.#socket === socket) {
+        const current = this.#socket === socket;
+        if (current) {
           this.#socket = null;
         }
         if (this.#opening === opening) {
           this.#opening = null;
         }
-        this.#closeReceiver();
+        // Only the socket this transport is still using may report a close.
+        // A socket already replaced — closed explicitly, then superseded by
+        // the next open() — would otherwise tear down its live successor.
+        if (current) {
+          this.#closeReceiver();
+        }
         if (!opened) {
           reject(new Error("memory websocket transport closed before opening"));
         }

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -9,9 +9,12 @@ import {
 } from "@commonfabric/data-model/cell-rep";
 import {
   getCommitPreconditionsConfig,
+  getMemoryProtocolFlags,
   getPersistentSchedulerStateConfig,
+  getSyncSchemaCasConfig,
   resetCommitPreconditionsConfig,
   resetPersistentSchedulerStateConfig,
+  resetSyncSchemaCasConfig,
 } from "@commonfabric/memory/v2";
 
 const signer = await Identity.fromPassphrase("test experimental");
@@ -26,6 +29,7 @@ describe("ExperimentalOptions", () => {
     resetModernCellRepConfig();
     resetCommitPreconditionsConfig();
     resetPersistentSchedulerStateConfig();
+    resetSyncSchemaCasConfig();
   });
 
   describe("Runtime construction", () => {
@@ -45,6 +49,7 @@ describe("ExperimentalOptions", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: false,
+        syncSchemaCasV1: false,
         plainResultReceipts: false,
         computedCellIds: false,
         // Read back from the ambient flag (a test seam that deliberately does
@@ -68,6 +73,7 @@ describe("ExperimentalOptions", () => {
         modernCellRep: true,
         persistentSchedulerState: false,
         commitPreconditions: true,
+        syncSchemaCasV1: false,
         plainResultReceipts: true,
         computedCellIds: true,
         eagerSourceAnnotation: false,
@@ -87,6 +93,7 @@ describe("ExperimentalOptions", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: true,
+        syncSchemaCasV1: false,
         plainResultReceipts: true,
         computedCellIds: true,
         // Read back from the ambient flag (a test seam that deliberately does
@@ -112,6 +119,27 @@ describe("ExperimentalOptions", () => {
       expect(getModernCellRepConfig()).toBe(true);
 
       await runtime.dispose();
+      await sm.close();
+    });
+
+    it("constructing Runtime with syncSchemaCasV1 sets global config", async () => {
+      const sm = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: sm,
+        experimental: {
+          syncSchemaCasV1: true,
+        },
+      });
+
+      expect(getSyncSchemaCasConfig()).toBe(true);
+      // The handshake advertises from the same ambient flag, so setting it on
+      // a process arms BOTH ends it hosts — a toolshed's memory server as well
+      // as its runtime's client.
+      expect(getMemoryProtocolFlags().syncSchemaCasV1).toBe(true);
+
+      await runtime.dispose();
+      expect(getSyncSchemaCasConfig()).toBe(false);
       await sm.close();
     });
 

--- a/packages/runner/test/runtime-presets.test.ts
+++ b/packages/runner/test/runtime-presets.test.ts
@@ -316,10 +316,12 @@ describe("runtimePresets conformance (CT-1814)", () => {
       const env: Record<string, string> = {
         EXPERIMENTAL_MODERN_CELL_REP: "true",
         EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: "false",
+        EXPERIMENTAL_SYNC_SCHEMA_CAS: "true",
       };
       expect(experimentalOptionsFromEnv((name) => env[name])).toEqual({
         modernCellRep: true,
         persistentSchedulerState: false,
+        syncSchemaCasV1: true,
       });
       expect(experimentalOptionsFromEnv(() => undefined)).toEqual({});
     });


### PR DESCRIPTION
## What

`syncSchemaTableV2` interns each link schema into a hash-keyed table so a frame names it once instead of repeating it inline. That table is **frame-local**: a schema referenced by a long-lived subscription travels again on every frame that names it. The session-scoped "send only what the peer is missing" that `session.entities` gives documents never applied to schemas.

`syncSchemaCasV1` scopes the table to the **connection**. A body is written to `schemaTable` only on the first frame that names its hash; later frames carry the `schema-cas@1:` reference alone, and a steady-state frame carries no table at all.

## Turning it on

```
EXPERIMENTAL_SYNC_SCHEMA_CAS=true
```

or `RuntimeOptions.experimental.syncSchemaCasV1`. Off by default. The memory server builds its handshake from the same ambient flag its runtime's client reads, so setting it on a process arms both ends that process hosts.

Before defaulting it on, someone should measure the distinct-schema count per connection. Both sides grow monotonically and neither caps: the server keeps tagged hashes per `Connection`, the client keeps whole bodies for the life of the `Client` — a browser tab's lifetime, since a reconnect reuses it. If that turns out to matter, a cap with an inline fallback is free, because an inline schema is always decodable and exceeding the cap just degrades to today's behavior.

## Design decisions worth reviewing

**The encodings are exclusive per connection**, and cas wins when both are negotiated. A peer must know from the handshake alone whether a frame is self-describing, so a connection never mixes them.

**`schema-ref@2:` deliberately does not resolve from the connection cache.** Its contract is that the body travels on the same frame, so a missing table entry is a sender defect and stays reportable rather than being silently satisfied by an unrelated cache hit.

**The delivered set is scoped to the connection, not to the session** that caches delivered *documents*. The two answer the same question for different things and are deliberately not aligned: a session outlives its connection and can be resumed by a **different** client whose schema store is empty. Inheriting a delivered set across such a resume would send that client references it can never resolve. The peer's half of this ledger is the `Client`'s cache, and a `Client` holds one connection at a time — that is the matching lifetime.

**A body is recorded as delivered only after the transport accepts its frame.** `send` is the commit point for sync state, and a throwing `sendRaw` already rolls delivery back for recomputation. Acceptance is weaker than arrival, and the gap is closed at both ends rather than papered over: a transport that discards silently does so because its socket is no longer open, and `readyState` is monotonic, so no later frame goes out on that connection either; and a peer that receives a frame it cannot process discards the connection.

**No new reservation was needed.** `schema-cas@1:` was already refused by the engine's write-path validator, so a reference still cannot be replayed out of stored data.

## What review found

Three adversarial passes ran on this branch. Each found a real bug, and two found bugs *introduced by the previous pass's fix* — all in the client's connection/handshake state machine, which this encoding newly exercises because a cas connection must be discarded when a frame is lost. All fixed, all mutation-tested:

- a client that received a frame and failed to process it was permanently, **silently** desynced: the server counted that frame's bodies as delivered, so every later reference arrived bare and unresolvable, forever, while the client still looked healthy
- the discard left the client reporting connected during an async close, so a send in that window skipped the handshake and opened a socket that never received a `hello`
- `hello()` retired whatever pending handshake it found, so a failed one could retire its replacement's and hang `connect()` outright
- `reconnect()` would handshake a connection that was already up, which a server refuses as a repeat with an error nothing marks permanent — an infinite loop with every request waiting behind it

Two latent transport defects were exposed too, both previously unreachable because `transport.close()` had a single terminal call site inside `Client.close()`: `WebSocketTransport`'s close listener let a superseded socket tear down its successor, and `loopback()` could not carry a client through a reconnect at all — which matters beyond this PR, since it backs `StorageManager.emulate`.

Wiring the flag then caught one more: `setSyncSchemaCasConfig` defaulted an absent argument to `true`, copied from `setSyncSchemaTableConfig`, whose feature ships on. The Runtime propagates the option unconditionally, so that would have armed the capability for every runtime that never asked for it. The flag was not safely off before — it was unreachable, and two faults were cancelling out.

The suite could not have caught the reconnect bug: `loopback()` reports its close synchronously and resolves immediately, so the discard's reconnect always joined one already in flight. `WebSocketTransport` does neither. Tests now carry a loopback shaped like the real transport — detach first, settle later, stay silent for a replaced socket.

## API change

`compressServerMessageSchemas` now returns `{message, staged}` — `staged` is what the frame teaches the peer, and the caller commits it after the send. The unused `onSchema` observer on the compress/expand pair is removed; it was the placeholder seam for exactly this and had no production caller.

## Known, pre-existing, not fixed here

`reconnect()` awaits `session.restore()`, and `restore()` issues requests that route through `ensureConnected()`. If the connection drops mid-restore, that call joins the very loop awaiting it. Reachable on `main` via `onClose`; this branch widens the window because the discard clears `#connected` synchronously from a receive callback. Wants its own change rather than a speculative fix here.

## Testing

- `packages/memory` — 490 passed
- `packages/runner` — 1156 passed
- `packages/toolshed` runtime-options / env — 5 passed
- `deno task check`, `fmt --check`, `lint`, `check-docs`, `check-skill-facts`, `check-conflict-markers` — clean

Every new test was mutation-checked: each fails with the behavior it names reverted. That check found two commits that had shipped with tests passing either way, both since covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/5424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
