### PR TITLE
feat(api,schema-generator,ts-transformers,piece): prototype Demand<T> marking and the foreign-output embedding warning

### DIFF
--- a/docs/common/ai/pattern-critique-guide.md
+++ b/docs/common/ai/pattern-critique-guide.md
@@ -291,6 +291,13 @@ invalid element voids the entire array read. See
 `packages/runner/test/traverse-required-links.test.ts` and
 `docs/common/patterns/composition.md#keep-external-data-contracts-narrow`.
 
+A consumer-owned type for stored pieces should be wrapped in `Demand<T>`, so
+the schema records it as a demand (`demand: true`) and the update gate can
+treat later narrowing as safe; suggest the wrapper when it is missing. The
+compiler already warns when an argument embeds another pattern's output type
+(`contract:foreign-output-embedding`); a genuinely shared protocol type
+opts out with a `@sharedContract` JSDoc tag on its declaration.
+
 Do not flag a genuinely shared protocol (for example, a stream event or enum),
 a cohesive domain model co-owned by one pattern family, a test intentionally
 checking the complete public result, or a wrapper whose stated purpose is to

--- a/docs/common/patterns/composition.md
+++ b/docs/common/patterns/composition.md
@@ -99,7 +99,17 @@ Do not import another pattern's entire `FooInput` or `FooOutput`, or derive a
 `Pick`/`Omit` from it, merely because it contains the needed fields. Spelling
 the minimal local shape is intentional duplication: the producer can evolve
 unrelated state, UI, and mutation streams without changing this consumer's
-contract.
+contract. The compiler warns when a pattern's argument embeds another
+pattern's output type (`contract:foreign-output-embedding`).
+
+A demand can say so in the type: wrap it in `Demand<T>` and the generated
+schema marks that subtree `demand: true`, so tooling can tell a demand from
+owned state. The update gate then treats dropping fields beneath the marker
+as the narrowing it is (once the marker has been deployed for at least one
+update), and an update that newly marks already-deployed state is called
+out as an advisory. The narrow-demand exemplar is the verb walkthrough's
+board (`packages/cli/integration/pattern/verb-results.tsx`), which demands
+only the note title it projects.
 
 An output type must be exported so TypeScript can name the default pattern
 factory's return contract. That visibility requirement is not an invitation for
@@ -128,7 +138,10 @@ protocol: for example, a stream event, an enum, or a cohesive domain model
 co-owned by one pattern family. A wrapper that deliberately forwards a complete
 contract may also use that complete contract. The test is whether every named
 field and capability belongs to the relationship, not whether centralizing the
-type removes duplicate TypeScript.
+type removes duplicate TypeScript. A type that passes that test can say so:
+a `@sharedContract` JSDoc tag on its declaration exempts it from the
+embedding warning. Reserve the tag for genuine protocol types —
+`MentionablePiece` is the exhibit of what qualifies.
 
 ## Merging Complex Objects from Pattern Inputs
 

--- a/docs/plans/verb-evolution.md
+++ b/docs/plans/verb-evolution.md
@@ -596,10 +596,14 @@ One question is open by design, and it is the one the cross product exposes:
 **how a deployed holder moves.** Narrow demands, required-verb demands and
 versioned demands are all reachable when a holder is written and none of
 them afterwards, so every adoption path runs through a scoped acknowledgment
-or a migration that rewrites holders. Which carries it — and whether the
-gate should learn that removal beneath a demand marker is narrowing rather
-than breakage — decides how much of this design applies to what is already
-running.
+or a migration that rewrites holders. Which carries it decides how much of
+this design applies to what is already running. One half is now decided:
+the gate learned that removal beneath a demand marker is narrowing rather
+than breakage (#5746), with a timing condition — the marker must be present
+on both the deployed and candidate contracts, so a declaration predates any
+drop beneath it by one deploy — and an advisory that names an update newly
+marking already-deployed state as a demand, which is what a two-step
+adoption sounds like until scoped acknowledgment exists.
 
 One direction belongs in that conversation, recorded as intent rather than
 mechanism: **the provider tells holders how to move.** A pattern that

--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -564,6 +564,25 @@ both survive: `PerUser<Cell<PerSession<string>>>` → `{ asCell: [{ kind:
 "cell", scope: "user" }], scope: "session", type: "string" }` (fixture
 `scoped-wrappers`).
 
+### Demand Marker (`Demand<T>`)
+
+`Demand<T>` (api: optional `DEMAND_BRAND`-typed intersection) marks a
+holder-side demand — the shape a pattern requires of a piece it stores, as
+distinct from state it owns — and lowers to a bare `demand: true` key on
+the wrapped subtree's schema (`applyDemandWrapperSemantics`,
+`common-fabric-formatter.ts`). Detection is this section's mechanism: node
+name or aliasSymbol name (`DEMAND_WRAPPER_NAME`); the node path shares
+`formatMarkerWrapperInner` with the scope wrappers. Placement rides the
+REFERENCING node — `note: Demand<NotePreview>` → `{ "$ref":
+"#/$defs/NotePreview", "demand": true }` — so a hoisted def stays neutral
+and each use site declares its own demand-ness. Unlike scope, the key never
+merges into `asCell` (it records the contract's provenance, not the cell's
+capability), and nesting collapses: `Demand<Demand<T>>` is one demand
+(demand-wrapper.test.ts). The key is annotation-class for the update gate
+(`ANNOTATION_KEYS`, `packages/piece/src/schema-compatibility.ts`), where a
+two-sided marker also relaxes evolution-mode removal to narrowing
+(`demandSubtree`; introduced with the #5746 prototype).
+
 ## 11. CFC Alias Lowering (`ifc` Metadata)
 
 The canonical authoring surface contains 18 names. The inventory is
@@ -860,6 +879,7 @@ canonical; update prose from it, not the other way around. Paths relative to
 | Capability-kind subset (§6.3) | `CELL_CAPABILITY_KIND_MAP` (`src/formatters/common-fabric-formatter.ts`) | exhaustive over `CellWrapperKind` |
 | `asCell` entry shape (§6.2, §10) | `AsCellEntry` / `CellKind` / `SchemaScope` (`packages/api/index.ts`) | — |
 | Scope wrapper map (§10) | `SCOPE_WRAPPER_SCOPES` (`src/formatters/common-fabric-formatter.ts`) | scoped-wrappers fixture |
+| Demand marker (§10) | `DEMAND_WRAPPER_NAME` / `applyDemandWrapperSemantics` (`src/formatters/common-fabric-formatter.ts`) | demand-wrapper.test.ts |
 | CFC alias set (§11) | `CFC_CANONICAL_ALIAS_NAMES` (`packages/api/cfc.ts`) | — |
 | CFC payload map (§11) | `buildIfcMetadataForAlias` switch (`src/formatters/common-fabric-formatter.ts`) | cfc-authoring tests |
 | `ifc` key vocabulary (§11) | `JSONSchemaObj.ifc` (`packages/api/index.ts`) | — |

--- a/docs/specs/schema-generator/ts_to_json_schema_mapping.md
+++ b/docs/specs/schema-generator/ts_to_json_schema_mapping.md
@@ -581,7 +581,12 @@ capability), and nesting collapses: `Demand<Demand<T>>` is one demand
 (demand-wrapper.test.ts). The key is annotation-class for the update gate
 (`ANNOTATION_KEYS`, `packages/piece/src/schema-compatibility.ts`), where a
 two-sided marker also relaxes evolution-mode removal to narrowing
-(`demandSubtree`; introduced with the #5746 prototype).
+(`demandSubtree`; introduced with the #5746 prototype). The link-proof
+safe-ancestor set (`LINK_PATH_SAFE_ANCESTOR_KEYS`,
+`packages/piece/src/ops/piece-controller.ts`) derives from
+`ANNOTATION_KEYS`, so an annotation key is link-path safe by
+classification rather than by a second registration — `deprecated`,
+`tier`, and `demand` each missed the older hand list in turn.
 
 ## 11. CFC Alias Lowering (`ifc` Metadata)
 

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -755,9 +755,15 @@ report these through the same collector (deduplicated via §2.2's
   (a true pipeline bug) and for the culprit-already-compute disagreement
   shape.
 - **Warning** `contract:foreign-output-embedding`
-  (`foreign-output-embedding.ts`, invoked from the pattern branch of
-  `schema-injection.ts`) — a pattern's argument or result contract embeds
-  a type that is the Output-position type argument of a DIFFERENT
+  (`src/lints/foreign-output-embedding.ts`) — the first **contract lint**:
+  a read-only, program-scoped analysis whose subject is a design rule
+  rather than compiler correctness. Lints live behind
+  `src/lints/mod.ts` — pure detection returning findings, severity mapped
+  in the registry's policy table (advisory by default), one
+  `runContractLints` hook called from the pattern branch of
+  `schema-injection.ts` after contract resolution, and never any effect on
+  emission. This one fires when a pattern's argument or result contract
+  embeds a type that is the Output-position type argument of a DIFFERENT
   `pattern<I, O>` call somewhere in the program (Output symbols are indexed
   program-wide, WeakMap-cached per `ts.Program`). The pattern's own
   output-position symbol is exempt (self-reference is the documented

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -754,6 +754,19 @@ report these through the same collector (deduplicated via §2.2's
   rework); the internal throw remains only for compiler-synthesized culprits
   (a true pipeline bug) and for the culprit-already-compute disagreement
   shape.
+- **Warning** `contract:foreign-output-embedding`
+  (`foreign-output-embedding.ts`, invoked from the pattern branch of
+  `schema-injection.ts`) — a pattern's argument or result contract embeds
+  a type that is the Output-position type argument of a DIFFERENT
+  `pattern<I, O>` call somewhere in the program (Output symbols are indexed
+  program-wide, WeakMap-cached per `ts.Program`). The pattern's own
+  output-position symbol is exempt (self-reference is the documented
+  shape), a `@sharedContract` JSDoc tag on the declaration opts a genuine
+  protocol type out, and anonymous shapes are never indexed. Advisory
+  severity while the demand-substrate prototype (#5746) is evaluated. The
+  schema-argument form (`pattern(fn, schemaLiteral)`) is outside the check:
+  a hand-authored literal has no type-symbol provenance to index, the same
+  boundary the transformer's schema stamps draw.
 
 ## 7. JSX Expression Site Routing And Early Rewriting
 

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -762,7 +762,10 @@ report these through the same collector (deduplicated via §2.2's
   in the registry's policy table (advisory by default), one
   `runContractLints` hook called from the pattern branch of
   `schema-injection.ts` after contract resolution, and never any effect on
-  emission. This one fires when a pattern's argument or result contract
+  emission. This one fires when a pattern's argument contract — argument
+  side only, by review ruling: result-side re-exposure is the documented
+  composition shape, and the branch returns when Fabric-types makes result
+  contracts load-bearing —
   embeds a type that is the Output-position type argument of a DIFFERENT
   `pattern<I, O>` call somewhere in the program (Output symbols are indexed
   program-wide, WeakMap-cached per `ts.Program`). The pattern's own

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -451,6 +451,16 @@ export type PerUser<T> = Scoped<T, "user">;
 export type PerSession<T> = Scoped<T, "session">;
 export type PerAny<T> = Scoped<T, "any">;
 
+export declare const DEMAND_BRAND: unique symbol;
+/**
+ * Marks a holder-side demand: the shape this pattern requires of a piece it
+ * stores or binds, as distinct from state the pattern owns. Compile-time
+ * only — at runtime `Demand<T>` is just `T`. The schema generator stamps
+ * `demand: true` on the marked subtree so tooling can tell a demand from
+ * owned state; validation is unaffected.
+ */
+export type Demand<T> = T & { readonly [DEMAND_BRAND]?: true };
+
 type ScopedConstructorResult<
   Scope extends CellScope,
   T,
@@ -1960,6 +1970,10 @@ export type JSONSchemaObj = {
   readonly tags?: readonly string[];
   // makes it so that your handler gets a Cell object for that property. So you can call .set()/.update()/.push()/etc on it.
   readonly asCell?: readonly AsCellType[];
+  // Holder-side demand marker: this subtree describes what the pattern
+  // requires of a piece it stores or binds, not state it owns. Emitted by
+  // the schema generator from `Demand<T>`; validation-neutral.
+  readonly demand?: true;
   // temporarily used to assign labels like "confidential"
   readonly ifc?: {
     readonly confidentiality?: readonly JSONValue[];

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -452,6 +452,14 @@ export type PerSession<T> = Scoped<T, "session">;
 export type PerAny<T> = Scoped<T, "any">;
 
 export declare const DEMAND_BRAND: unique symbol;
+/** The brand rides a NAMED exported interface, not an inline literal: an
+ * anonymous symbol-keyed type in an exported position trips TypeScript's
+ * private-name check (`Default export of the module has or is using
+ * private name 'DEMAND_BRAND'`) the moment a pattern's contract expands
+ * through `Demand<T>`. */
+export interface DemandMarker {
+  readonly [DEMAND_BRAND]?: true;
+}
 /**
  * Marks a holder-side demand: the shape this pattern requires of a piece it
  * stores or binds, as distinct from state the pattern owns. Compile-time
@@ -459,7 +467,7 @@ export declare const DEMAND_BRAND: unique symbol;
  * `demand: true` on the marked subtree so tooling can tell a demand from
  * owned state; validation is unaffected.
  */
-export type Demand<T> = T & { readonly [DEMAND_BRAND]?: true };
+export type Demand<T> = T & DemandMarker;
 
 type ScopedConstructorResult<
   Scope extends CellScope,
@@ -1612,7 +1620,15 @@ type StripCellInner<T> = [T] extends [AnyStream] ? T // Preserve the stream whol
   : [T] extends [ReadonlyArray<infer U>] ? readonly StripCell<U>[]
   // deno-lint-ignore ban-types
   : [T] extends [Function] ? T // Preserve function types
-  : [T] extends [object] ? { [K in keyof T]: StripCell<T[K]> }
+  // The demand brand is erased here the way Default's brand is stripped in
+  // its own machinery: it is a compile-time marker for schema generation,
+  // and mapping it through would re-expose DEMAND_BRAND as a private name
+  // on every exported factory whose contract mentions a demand.
+  : [T] extends [object] ? {
+      [K in keyof T as K extends typeof DEMAND_BRAND ? never : K]: StripCell<
+        T[K]
+      >;
+    }
   : T;
 
 /**

--- a/packages/cli/integration/pattern/verb-results.tsx
+++ b/packages/cli/integration/pattern/verb-results.tsx
@@ -28,7 +28,14 @@ import {
 } from "commonfabric";
 
 /** One note. Deliberately small: this fixture is about what a verb hands back,
- * not about modelling notes. */
+ * not about modelling notes.
+ *
+ * The board below stores `NoteOutput[]` on purpose — the walkthrough's whole
+ * subject is calling verbs on a stored child — so this is the deliberate
+ * full-contract forwarding composition.md permits, and the tag records that
+ * intent for the foreign-output embedding check.
+ *
+ * @sharedContract */
 export interface NoteOutput {
   [NAME]: string;
   title: string;

--- a/packages/cli/integration/pattern/verb-results.tsx
+++ b/packages/cli/integration/pattern/verb-results.tsx
@@ -21,6 +21,7 @@ import {
   action,
   computed,
   type Default,
+  type Demand,
   NAME,
   pattern,
   type Stream,
@@ -28,14 +29,7 @@ import {
 } from "commonfabric";
 
 /** One note. Deliberately small: this fixture is about what a verb hands back,
- * not about modelling notes.
- *
- * The board below stores `NoteOutput[]` on purpose — the walkthrough's whole
- * subject is calling verbs on a stored child — so this is the deliberate
- * full-contract forwarding composition.md permits, and the tag records that
- * intent for the foreign-output embedding check.
- *
- * @sharedContract */
+ * not about modelling notes. */
 export interface NoteOutput {
   [NAME]: string;
   title: string;
@@ -112,15 +106,24 @@ interface SetLabelResult {
   revision: number;
 }
 
+/** The board's demand on the notes it stores: only the title it projects.
+ * This is the narrow-demand exemplar — the board never calls `append`, so
+ * it does not mention it, and adding verbs to notes never touches the
+ * board's shape. The walkthrough reaches note contents and verbs through
+ * each note's own address and schema, not through this demand. */
+interface NotePreview {
+  title?: string;
+}
+
 interface BoardInput {
-  notes?: Writable<NoteOutput[] | Default<[]>>;
+  notes?: Writable<Demand<NotePreview>[] | Default<[]>>;
   label?: Writable<string | Default<"untitled">>;
   revision?: Writable<number | Default<0>>;
 }
 
 interface BoardOutput {
   [NAME]: string;
-  notes: NoteOutput[];
+  notes: NotePreview[];
   noteCount: number;
   label: string;
   revision: number;

--- a/packages/piece/src/ops/piece-controller.ts
+++ b/packages/piece/src/ops/piece-controller.ts
@@ -50,9 +50,17 @@ import type { PiecesController } from "./pieces-controller.ts";
 import { nameSchema } from "@commonfabric/runner/schemas";
 import { compileProgram } from "./utils.ts";
 import {
+  ANNOTATION_KEYS,
   assertPatternSchemasBackwardCompatible,
   assertSchemaSubset,
+  collectNewDemandDeclarationAdvisories,
 } from "../schema-compatibility.ts";
+import { getLogger } from "@commonfabric/utils/logger";
+
+const pieceUpdateLogger = getLogger("piece.update", {
+  enabled: true,
+  level: "warn",
+});
 import {
   qualifyFabricOrigin,
   readPieceOrigin,
@@ -386,6 +394,15 @@ export interface PieceSourceCompatibilityIssues {
    * this one reasons about what is physically at rest.
    */
   cfc?: string;
+  /**
+   * Non-blocking findings the update proceeds over. Today: argument nodes
+   * the candidate newly declares a demand — the loud first step of the
+   * two-step adoption path, since a later update may narrow beneath them
+   * (`collectNewDemandDeclarationAdvisories`). Excluded from
+   * `hasPieceSourceCompatibilityIssues` by construction; graduates into
+   * scoped acknowledgment when that mechanism exists.
+   */
+  advisories?: string[];
 }
 
 /**
@@ -446,18 +463,17 @@ function storedCellTopology(
   }
 }
 
-const LINK_PATH_SAFE_ANCESTOR_KEYS = new Set([
-  "$comment",
-  "$defs",
-  "$id",
+// Structural keys a link-path ancestor may carry without correlating the
+// linked field with its parent value. The annotation-class keys are safe
+// here BY DEFINITION — validation-neutral is exactly "constrains nothing" —
+// so the set below unions this list with `ANNOTATION_KEYS` instead of
+// re-listing it: `deprecated`, `tier`, and `demand` each missed the old
+// hand list in turn, and every one was a link-proof regression the gate's
+// own classification had already ruled out.
+const LINK_PATH_STRUCTURAL_ANCESTOR_KEYS = [
   "$ref",
-  "$schema",
   "additionalProperties",
   "asCell",
-  "default",
-  "definitions",
-  "description",
-  "examples",
   "ifc",
   "items",
   "maxItems",
@@ -468,10 +484,13 @@ const LINK_PATH_SAFE_ANCESTOR_KEYS = new Set([
   "readOnly",
   "required",
   "scope",
-  "tags",
-  "title",
   "type",
   "writeOnly",
+] as const;
+
+const LINK_PATH_SAFE_ANCESTOR_KEYS = new Set<string>([
+  ...ANNOTATION_KEYS,
+  ...LINK_PATH_STRUCTURAL_ANCESTOR_KEYS,
 ]);
 
 const SCHEMA_ANNOTATION_KEYS = new Set([
@@ -3909,6 +3928,17 @@ async function pieceSourceCompatibilityReview(
     assertPatternSchemasBackwardCompatible(previousPattern, candidate);
   } catch (error) {
     issues.schema = error instanceof Error ? error.message : String(error);
+  }
+
+  const advisories = collectNewDemandDeclarationAdvisories(
+    previousPattern,
+    candidate,
+  );
+  if (advisories.length > 0) {
+    issues.advisories = advisories;
+    for (const advisory of advisories) {
+      pieceUpdateLogger.warn("new-demand-declaration", advisory);
+    }
   }
 
   const argumentCell = pieces.getArgument(piece);

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -61,10 +61,13 @@ interface CompatibilityContext {
    * contract broken: the holder asks less of the pieces it stores, which
    * only widens what it accepts — plain subset logic, which the evolution
    * removal rule is deliberately stricter than. Requiring the marker on
-   * BOTH sides means the deployed contract itself declared the subtree a
-   * demand before anything relaxes beneath it. The allowance never applies
-   * inside a verb event, and never to the result role: what a pattern
-   * re-exposes from a demand is still something its readers rely on.
+   * BOTH sides is a TIMING requirement — the declaration must predate any
+   * drop beneath it by one deploy — not laundering prevention: the marker
+   * is a self-declaration the gate cannot verify, and
+   * `collectNewDemandDeclarationAdvisories` is what makes that first
+   * deploy loud. The allowance never applies inside a verb event, and
+   * never to the result role: what a pattern re-exposes from a demand is
+   * still something its readers rely on.
    */
   demandSubtree?: boolean;
 }
@@ -79,7 +82,13 @@ type ActivePairsByRoot = WeakMap<
   WeakMap<object, WeakMap<object, WeakSet<object>>>
 >;
 
-const ANNOTATION_KEYS = new Set([
+// Exported because the link-proof safe-ancestor set in
+// `ops/piece-controller.ts` derives from it: annotation-class means
+// validation-neutral, and validation-neutral is exactly "constrains
+// nothing", which is what that set's membership asserts. Deriving replaced
+// hand-listing after `deprecated`, `tier`, and `demand` each missed the
+// hand list in turn.
+export const ANNOTATION_KEYS = new Set([
   "$comment",
   "$defs",
   "$id",
@@ -775,6 +784,110 @@ function declaresVerbStream(schema: JSONSchema): boolean {
 function schemaMarksDemand(schema: JSONSchema | undefined): boolean {
   return typeof schema === "object" && schema !== null &&
     (schema as SchemaObject).demand === true;
+}
+
+/**
+ * Advisory scan: name every argument node the candidate newly declares a
+ * demand over deployed, previously unmarked contract.
+ *
+ * The two-sided condition on `demandSubtree` is a TIMING requirement — the
+ * declaration must predate any drop beneath it by one deploy — not
+ * laundering prevention: the marker is a self-declaration the gate cannot
+ * verify. This scan makes the first step of that two-step loud, so an
+ * operator reviewing an update sees "this subtree may narrow next deploy"
+ * at the moment it becomes true. It reports at the boundary node only
+ * (everything beneath a new demand is implied), skips properties the
+ * previous contract never carried (nothing deployed is being re-labeled),
+ * and graduates into scoped acknowledgment when that mechanism exists.
+ */
+export function collectNewDemandDeclarationAdvisories(
+  previous: Pattern,
+  candidate: Pattern,
+): string[] {
+  const advisories: string[] = [];
+  const visited = new Set<object>();
+
+  const walk = (
+    previousInput: JSONSchema,
+    candidateInput: JSONSchema,
+    path: string,
+    previousRoot: JSONSchema,
+    candidateRoot: JSONSchema,
+  ): void => {
+    const previousResolution = resolveSchema(previousInput, previousRoot);
+    const candidateResolution = resolveSchema(candidateInput, candidateRoot);
+    const previousSchema = previousResolution.schema;
+    const candidateSchema = candidateResolution.schema;
+    if (
+      typeof candidateSchema !== "object" || candidateSchema === null ||
+      visited.has(candidateSchema)
+    ) {
+      return;
+    }
+    visited.add(candidateSchema);
+
+    const candidateMarks = schemaMarksDemand(candidateInput) ||
+      schemaMarksDemand(candidateSchema);
+    const previousMarks = schemaMarksDemand(previousInput) ||
+      schemaMarksDemand(previousSchema);
+    if (candidateMarks && !previousMarks) {
+      advisories.push(
+        `${path} is newly declared a demand; a future update may narrow ` +
+          `beneath it`,
+      );
+      return;
+    }
+    if (typeof previousSchema !== "object" || previousSchema === null) return;
+
+    const previousProperties = previousSchema.properties ?? {};
+    const candidateProperties = candidateSchema.properties ?? {};
+    for (const property of Object.keys(candidateProperties)) {
+      if (!Object.hasOwn(previousProperties, property)) continue;
+      walk(
+        previousProperties[property]!,
+        candidateProperties[property]!,
+        `${path}.${property}`,
+        previousResolution.root,
+        candidateResolution.root,
+      );
+    }
+    if (
+      typeof previousSchema.items === "object" &&
+      typeof candidateSchema.items === "object"
+    ) {
+      walk(
+        previousSchema.items,
+        candidateSchema.items,
+        `${path}[]`,
+        previousResolution.root,
+        candidateResolution.root,
+      );
+    }
+    const previousPrefix = previousSchema.prefixItems ?? [];
+    const candidatePrefix = candidateSchema.prefixItems ?? [];
+    for (
+      let i = 0;
+      i < Math.min(previousPrefix.length, candidatePrefix.length);
+      i++
+    ) {
+      walk(
+        previousPrefix[i]!,
+        candidatePrefix[i]!,
+        `${path}[${i}]`,
+        previousResolution.root,
+        candidateResolution.root,
+      );
+    }
+  };
+
+  walk(
+    previous.argumentSchema,
+    candidate.argumentSchema,
+    "argument",
+    previous.argumentSchema,
+    candidate.argumentSchema,
+  );
+  return advisories;
 }
 
 function additionalPropertiesSubsetIssue(

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -73,6 +73,12 @@ const ANNOTATION_KEYS = new Set([
   "$schema",
   "default",
   "definitions",
+  // Holder-side demand marker (`Demand<T>` in the API): records that a
+  // subtree is what a holder requires of a stored piece rather than state
+  // it owns. Validation-neutral by construction, so it must add and remove
+  // freely across pattern updates — classified here BEFORE the generator
+  // emits it anywhere, per the C3 append-only lesson.
+  "demand",
   // Standard JSON Schema annotation. The generator emits it from
   // `@deprecated` JSDoc so `cf piece verbs` can hide legacy streams by
   // default; it is validation-neutral by spec, so it must add and remove

--- a/packages/piece/src/schema-compatibility.ts
+++ b/packages/piece/src/schema-compatibility.ts
@@ -54,6 +54,19 @@ interface CompatibilityContext {
    * must not read as a contract break.
    */
   verbEvent?: boolean;
+  /**
+   * True below a node BOTH contracts mark `demand: true` — a holder-side
+   * demand subtree (the `Demand<T>` marker). There, in the argument role,
+   * a property the candidate no longer names is a demand given up, not a
+   * contract broken: the holder asks less of the pieces it stores, which
+   * only widens what it accepts — plain subset logic, which the evolution
+   * removal rule is deliberately stricter than. Requiring the marker on
+   * BOTH sides means the deployed contract itself declared the subtree a
+   * demand before anything relaxes beneath it. The allowance never applies
+   * inside a verb event, and never to the result role: what a pattern
+   * re-exposes from a demand is still something its readers rely on.
+   */
+  demandSubtree?: boolean;
 }
 
 export interface SchemaSubsetOptions {
@@ -316,11 +329,19 @@ function schemaSubsetIssue(
   const entersVerbEvent = !context.verbEvent &&
     (declaresVerbStream(sourceInput) || declaresVerbStream(source)) &&
     (declaresVerbStream(targetInput) || declaresVerbStream(target));
+  // The demand marker rides the referencing node the same way. Both
+  // contracts must agree the subtree is a demand — the deployed shape
+  // declared it one and the candidate still does; a one-sided marker is a
+  // shape change the ordinary rules judge, not an exemption.
+  const entersDemandSubtree = !context.demandSubtree &&
+    (schemaMarksDemand(sourceInput) || schemaMarksDemand(source)) &&
+    (schemaMarksDemand(targetInput) || schemaMarksDemand(target));
   context = {
     ...context,
     sourceRoot: sourceResolution.root,
     targetRoot: targetResolution.root,
     ...(entersVerbEvent ? { verbEvent: true } : {}),
+    ...(entersDemandSubtree ? { demandSubtree: true } : {}),
   };
   if (
     context.defaultComparison === "target" &&
@@ -516,23 +537,40 @@ function objectSubsetIssue(
     ? source.patternProperties
     : target.patternProperties;
 
+  const allowEvolutionPolicy = context.allowEvolutionPolicy &&
+    !hasComplexSameInstanceConstraints(source) &&
+    !hasComplexSameInstanceConstraints(target);
+
   // Pattern evolution preserves named fields as part of the public contract,
   // even when the candidate object is otherwise open. A durable-link subset
   // proof is different: a source may name additional fields that an open
   // target accepts through patternProperties/additionalProperties. Treating
   // those fields as "removed" rejects valid Fabric projections such as $FS.
+  //
+  // Beneath a demand marker the argument role reads the other way: a
+  // property the candidate no longer names is a demand given up, which only
+  // widens what the holder accepts (see `demandSubtree`). The removed
+  // property may also BE the demand — its own referencing node carries the
+  // marker on the deployed side — and giving up a whole demand is the same
+  // narrowing. The result role keeps the strict rule, and verb events keep
+  // their own.
   if (context.defaultComparison === "evolution") {
     for (const property of Object.keys(previousProperties)) {
       if (Object.hasOwn(candidateProperties, property)) continue;
+      if (
+        context.role === "argument" && !context.verbEvent &&
+        allowEvolutionPolicy &&
+        (context.demandSubtree === true ||
+          schemaMarksDemand(previousProperties[property]))
+      ) {
+        continue;
+      }
       return `${path}.${property}: existing ${context.role} field was removed`;
     }
   }
 
   const sourceRequired = new Set(source.required ?? []);
   const targetRequired = new Set(target.required ?? []);
-  const allowEvolutionPolicy = context.allowEvolutionPolicy &&
-    !hasComplexSameInstanceConstraints(source) &&
-    !hasComplexSameInstanceConstraints(target);
   const allowEvolutionDefaults = allowEvolutionPolicy &&
     context.allowEvolutionDefaults;
   if (context.role === "argument") {
@@ -731,6 +769,12 @@ function declaresVerbStream(schema: JSONSchema): boolean {
   if (typeof schema !== "object" || schema === null) return false;
   const asCell = (schema as SchemaObject).asCell;
   return Array.isArray(asCell) && asCell.includes("stream");
+}
+
+/** The demand marker rides a referencing node, like the stream marker. */
+function schemaMarksDemand(schema: JSONSchema | undefined): boolean {
+  return typeof schema === "object" && schema !== null &&
+    (schema as SchemaObject).demand === true;
 }
 
 function additionalPropertiesSubsetIssue(

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -4866,6 +4866,102 @@ describe("piece pull materialization", () => {
     ).rejects.toThrow(/anyOf correlates the linked field/);
   });
 
+  // Annotation-class keys constrain nothing, so a link-path ancestor may
+  // carry them: the safe-ancestor set derives from ANNOTATION_KEYS.
+  // `deprecated`, `tier`, and `demand` each missed the old hand list in
+  // turn; the two below pin the derivation from both directions of that
+  // history.
+  it("proves path links beneath demand-marked ancestors", async () => {
+    const sourcePiece = await pieces.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: { type: "object", properties: {} },
+        resultSchema: {
+          type: "object",
+          properties: { value: { type: "string" } },
+          required: ["value"],
+        },
+        result: { value: "linked" },
+        nodes: [],
+      }),
+      {},
+      undefined,
+      { start: true },
+    );
+    const targetPiece = await pieces.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: {
+          type: "object",
+          properties: {
+            notes: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: { title: { type: "string" } },
+                demand: true,
+              },
+            },
+          },
+        },
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }),
+      { notes: [{ title: "seed" }] },
+      undefined,
+      { start: true },
+    );
+
+    const controller = new PieceController(pieces, targetPiece);
+    await controller.input.set(sourcePiece.key("value"), [
+      "notes",
+      "0",
+      "title",
+    ]);
+    expect(await controller.input.get(["notes", "0", "title"])).toBe("linked");
+  });
+
+  it("proves path links beneath deprecated-marked ancestors", async () => {
+    const sourcePiece = await pieces.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: { type: "object", properties: {} },
+        resultSchema: {
+          type: "object",
+          properties: { value: { type: "string" } },
+          required: ["value"],
+        },
+        result: { value: "linked" },
+        nodes: [],
+      }),
+      {},
+      undefined,
+      { start: true },
+    );
+    const targetPiece = await pieces.runPersistent(
+      trustPattern(runtime, {
+        argumentSchema: {
+          type: "object",
+          properties: {
+            profile: {
+              type: "object",
+              properties: { name: { type: "string" } },
+              deprecated: true,
+            },
+          },
+        },
+        resultSchema: { type: "object", properties: {} },
+        result: {},
+        nodes: [],
+      }),
+      { profile: { name: "seed" } },
+      undefined,
+      { start: true },
+    );
+
+    const controller = new PieceController(pieces, targetPiece);
+    await controller.input.set(sourcePiece.key("value"), ["profile", "name"]);
+    expect(await controller.input.get(["profile", "name"])).toBe("linked");
+  });
+
   it("uses destination scope as a follow cap for every durable link", async () => {
     const sourcePattern: Pattern = {
       argumentSchema: { type: "object", properties: {} },

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -6,6 +6,7 @@ import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import {
   assertPatternSchemasBackwardCompatible,
   assertSchemaSubset,
+  collectNewDemandDeclarationAdvisories,
 } from "../src/schema-compatibility.ts";
 
 function pattern(
@@ -2297,5 +2298,71 @@ describe("demand-marked narrowing", () => {
         pattern(holderArgument(candidate), emptyResult),
       )
     ).toThrow(/existing argument field was removed/);
+  });
+});
+
+// The two-sided narrowing condition is a timing requirement: the marker
+// must predate any drop by one deploy. This scan makes the first deploy
+// loud — an update newly marking deployed contract as a demand is named,
+// so "a future update may narrow beneath it" is said when it becomes true.
+describe("new-demand declaration advisories", () => {
+  const emptyResult: JSONSchema = { type: "object", properties: {} };
+
+  const holder = (
+    marked: boolean,
+    inner?: Record<string, JSONSchema>,
+  ): JSONSchema => ({
+    type: "object",
+    properties: {
+      notes: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: { title: { type: "string" }, ...(inner ?? {}) },
+          ...(marked ? { demand: true } : {}),
+        },
+      },
+    },
+  });
+
+  it("names a deployed subtree the candidate newly marks", () => {
+    expect(collectNewDemandDeclarationAdvisories(
+      pattern(holder(false), emptyResult),
+      pattern(holder(true), emptyResult),
+    )).toEqual([
+      "argument.notes[] is newly declared a demand; a future update may " +
+      "narrow beneath it",
+    ]);
+  });
+
+  it("stays silent when the deployed contract already marked it", () => {
+    expect(collectNewDemandDeclarationAdvisories(
+      pattern(holder(true), emptyResult),
+      pattern(holder(true), emptyResult),
+    )).toEqual([]);
+  });
+
+  it("stays silent for a property the previous contract never carried", () => {
+    expect(collectNewDemandDeclarationAdvisories(
+      pattern({ type: "object", properties: {} }, emptyResult),
+      pattern(holder(true), emptyResult),
+    )).toEqual([]);
+  });
+
+  it("reports the boundary node only", () => {
+    const inner: Record<string, JSONSchema> = {
+      meta: {
+        type: "object",
+        properties: { origin: { type: "string" } },
+        demand: true,
+      },
+    };
+    expect(collectNewDemandDeclarationAdvisories(
+      pattern(holder(false), emptyResult),
+      pattern(holder(true, inner), emptyResult),
+    )).toEqual([
+      "argument.notes[] is newly declared a demand; a future update may " +
+      "narrow beneath it",
+    ]);
   });
 });

--- a/packages/piece/test/schema-compatibility.test.ts
+++ b/packages/piece/test/schema-compatibility.test.ts
@@ -2157,3 +2157,145 @@ describe("listing marks are annotation-class", () => {
     ).toThrow(/mysteryDial|unknown/i);
   });
 });
+
+// The demand marker (`Demand<T>`, PR #5746) makes a holder's demand on the
+// pieces it stores distinguishable from its own state. Beneath a marker BOTH
+// contracts carry, argument-role property removal is a demand given up —
+// narrowing, which plain subset logic already proves safe — rather than the
+// contract removal the evolution rule refuses elsewhere.
+describe("demand-marked narrowing", () => {
+  const emptyResult: JSONSchema = { type: "object", properties: {} };
+
+  const appendVerb: JSONSchema = {
+    type: "object",
+    properties: { text: { type: "string" } },
+    required: ["text"],
+    asCell: ["stream"],
+  };
+
+  const noteDemand = (
+    overrides: Partial<Record<string, JSONSchema>>,
+    marked: boolean,
+  ): JSONSchema => ({
+    type: "object",
+    properties: {
+      title: { type: "string" },
+      append: appendVerb,
+      ...overrides,
+    } as Record<string, JSONSchema>,
+    ...(marked ? { demand: true } : {}),
+  });
+
+  const holderArgument = (note: JSONSchema): JSONSchema => ({
+    type: "object",
+    properties: { notes: { type: "array", items: note } },
+  });
+
+  const dropped = (note: JSONSchema, name: string): JSONSchema => {
+    const properties = {
+      ...(note as Record<string, unknown>).properties as Record<
+        string,
+        JSONSchema
+      >,
+    };
+    delete properties[name];
+    return { ...(note as object), properties } as JSONSchema;
+  };
+
+  it("allows dropping a demanded verb beneath a two-sided marker", () => {
+    const previous = noteDemand({}, true);
+    const candidate = dropped(previous, "append");
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(holderArgument(previous), emptyResult),
+        pattern(holderArgument(candidate), emptyResult),
+      )
+    ).not.toThrow();
+  });
+
+  it("refuses the same drop when nothing is marked", () => {
+    const previous = noteDemand({}, false);
+    const candidate = dropped(previous, "append");
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(holderArgument(previous), emptyResult),
+        pattern(holderArgument(candidate), emptyResult),
+      )
+    ).toThrow(/existing argument field was removed/);
+  });
+
+  it("refuses when only the candidate carries the marker", () => {
+    const previous = noteDemand({}, false);
+    const candidate = dropped(noteDemand({}, true), "append");
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(holderArgument(previous), emptyResult),
+        pattern(holderArgument(candidate), emptyResult),
+      )
+    ).toThrow(/existing argument field was removed/);
+  });
+
+  it("allows giving up a whole property whose deployed node is the demand", () => {
+    const previousArgument: JSONSchema = {
+      type: "object",
+      properties: {
+        label: { type: "string" },
+        notes: { type: "array", items: noteDemand({}, false), demand: true },
+      },
+    };
+    const candidateArgument: JSONSchema = {
+      type: "object",
+      properties: { label: { type: "string" } },
+    };
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(previousArgument, emptyResult),
+        pattern(candidateArgument, emptyResult),
+      )
+    ).not.toThrow();
+  });
+
+  it("keeps the strict rule on the result role", () => {
+    const previous = noteDemand({}, true);
+    const candidate = dropped(previous, "append");
+    const exposing = (note: JSONSchema): JSONSchema => ({
+      type: "object",
+      properties: { notes: { type: "array", items: note } },
+    });
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern({ type: "object", properties: {} }, exposing(previous)),
+        pattern({ type: "object", properties: {} }, exposing(candidate)),
+      )
+    ).toThrow(/existing result field was removed/);
+  });
+
+  it("still checks retypes inside a demand subtree", () => {
+    const previous = noteDemand({}, true);
+    const candidate = noteDemand({ title: { type: "number" } }, true);
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(holderArgument(previous), emptyResult),
+        pattern(holderArgument(candidate), emptyResult),
+      )
+    ).toThrow(/not backward compatible/);
+  });
+
+  it("keeps verb-event rules inside a demanded verb", () => {
+    const widerEvent: JSONSchema = {
+      ...appendVerb,
+      properties: {
+        text: { type: "string" },
+        note: { type: "string" },
+      },
+    };
+    const previous = noteDemand({ append: widerEvent }, true);
+    const candidate = noteDemand({}, true);
+    expect(() =>
+      assertPatternSchemasBackwardCompatible(
+        pattern(holderArgument(previous), emptyResult),
+        pattern(holderArgument(candidate), emptyResult),
+      )
+    ).toThrow(/existing argument field was removed/);
+  });
+});

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -151,11 +151,10 @@ export class CommonFabricFormatter implements TypeFormatter {
       return true;
     }
 
-    if (isDemandWrapperName(aliasName)) {
-      return true;
-    }
-
-    if (resolveDemandWrapperNode(context.typeNode)) {
+    if (
+      isDemandWrapperName(aliasName) ||
+      resolveDemandWrapperNode(context.typeNode) !== undefined
+    ) {
       return true;
     }
 
@@ -245,9 +244,7 @@ export class CommonFabricFormatter implements TypeFormatter {
 
     if (isDemandWrapperName(aliasType.aliasSymbol?.name)) {
       const innerType = aliasType.aliasTypeArguments?.[0];
-      if (!innerType) {
-        throw new Error(`Demand<T> requires type argument`);
-      }
+      if (!innerType) throw new Error(`Demand<T> requires type argument`);
       const innerSchema = this.schemaGenerator.formatChildType(
         innerType,
         context,
@@ -540,14 +537,20 @@ export class CommonFabricFormatter implements TypeFormatter {
     return this.applyWrapperSemantics(innerSchema, wrapperKind);
   }
 
-  private formatScopeWrapperTypeFromNode(
+  /**
+   * Inner schema of a single-argument marker wrapper node (`PerUser<T>`,
+   * `Demand<T>`): the registry's resolution when it has one, the checker's
+   * otherwise, degrading to `any` rather than aborting generation when the
+   * checker cannot resolve the node.
+   */
+  private formatMarkerWrapperInner(
     typeRefNode: ts.TypeReferenceNode,
     context: GenerationContext,
-    scope: SchemaScope,
+    wrapperLabel: string,
   ): MutableJSONSchema {
     const innerTypeNode = typeRefNode.typeArguments?.[0];
     if (!innerTypeNode) {
-      throw new Error(`Scoped wrapper requires type argument`);
+      throw new Error(`${wrapperLabel} requires type argument`);
     }
 
     let innerType: ts.Type;
@@ -558,39 +561,31 @@ export class CommonFabricFormatter implements TypeFormatter {
       innerType = context.typeChecker.getAnyType();
     }
 
-    const innerSchema = this.schemaGenerator.formatChildType(
+    return this.schemaGenerator.formatChildType(
       innerType,
       context,
       innerTypeNode,
     );
+  }
 
-    return this.applyScopeWrapperSemantics(innerSchema, scope);
+  private formatScopeWrapperTypeFromNode(
+    typeRefNode: ts.TypeReferenceNode,
+    context: GenerationContext,
+    scope: SchemaScope,
+  ): MutableJSONSchema {
+    return this.applyScopeWrapperSemantics(
+      this.formatMarkerWrapperInner(typeRefNode, context, "Scoped wrapper"),
+      scope,
+    );
   }
 
   private formatDemandWrapperTypeFromNode(
     typeRefNode: ts.TypeReferenceNode,
     context: GenerationContext,
   ): MutableJSONSchema {
-    const innerTypeNode = typeRefNode.typeArguments?.[0];
-    if (!innerTypeNode) {
-      throw new Error(`Demand<T> requires type argument`);
-    }
-
-    let innerType: ts.Type;
-    try {
-      innerType = context.typeRegistry?.get(innerTypeNode) ??
-        context.typeChecker.getTypeFromTypeNode(innerTypeNode);
-    } catch {
-      innerType = context.typeChecker.getAnyType();
-    }
-
-    const innerSchema = this.schemaGenerator.formatChildType(
-      innerType,
-      context,
-      innerTypeNode,
+    return this.applyDemandWrapperSemantics(
+      this.formatMarkerWrapperInner(typeRefNode, context, "Demand<T>"),
     );
-
-    return this.applyDemandWrapperSemantics(innerSchema);
   }
 
   /**
@@ -602,10 +597,9 @@ export class CommonFabricFormatter implements TypeFormatter {
   private applyDemandWrapperSemantics(
     schema: MutableJSONSchema,
   ): MutableJSONSchema {
-    if (typeof schema === "boolean") {
-      return schema === false ? { not: true, demand: true } : { demand: true };
-    }
-    return { ...schema, demand: true };
+    return typeof schema === "boolean"
+      ? (schema === false ? { not: true, demand: true } : { demand: true })
+      : { ...schema, demand: true };
   }
 
   private applyScopeWrapperSemantics(

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -96,6 +96,23 @@ const resolveScopeWrapperNode = (
   return scope === undefined ? undefined : { scope, node: typeNode };
 };
 
+const DEMAND_WRAPPER_NAME = "Demand";
+
+const isDemandWrapperName = (name: string | undefined): boolean =>
+  name === DEMAND_WRAPPER_NAME;
+
+const resolveDemandWrapperNode = (
+  typeNode: ts.TypeNode | undefined,
+): ts.TypeReferenceNode | undefined => {
+  if (!typeNode || !ts.isTypeReferenceNode(typeNode)) {
+    return undefined;
+  }
+  const name = ts.isIdentifier(typeNode.typeName)
+    ? typeNode.typeName.text
+    : typeNode.typeName.right.text;
+  return isDemandWrapperName(name) ? typeNode : undefined;
+};
+
 const applyScopeToAsCellEntry = (
   entry: AsCellEntry,
   scope: SchemaScope,
@@ -131,6 +148,14 @@ export class CommonFabricFormatter implements TypeFormatter {
     }
 
     if (resolveScopeWrapperNode(context.typeNode)) {
+      return true;
+    }
+
+    if (isDemandWrapperName(aliasName)) {
+      return true;
+    }
+
+    if (resolveDemandWrapperNode(context.typeNode)) {
       return true;
     }
 
@@ -208,6 +233,27 @@ export class CommonFabricFormatter implements TypeFormatter {
         undefined,
       );
       return this.applyScopeWrapperSemantics(innerSchema, aliasScope);
+    }
+
+    const resolvedDemandWrapper = resolveDemandWrapperNode(n);
+    if (resolvedDemandWrapper) {
+      return this.formatDemandWrapperTypeFromNode(
+        resolvedDemandWrapper,
+        context,
+      );
+    }
+
+    if (isDemandWrapperName(aliasType.aliasSymbol?.name)) {
+      const innerType = aliasType.aliasTypeArguments?.[0];
+      if (!innerType) {
+        throw new Error(`Demand<T> requires type argument`);
+      }
+      const innerSchema = this.schemaGenerator.formatChildType(
+        innerType,
+        context,
+        undefined,
+      );
+      return this.applyDemandWrapperSemantics(innerSchema);
     }
 
     const resolvedCfcAlias = this.resolveCfcAliasInstantiation(
@@ -519,6 +565,47 @@ export class CommonFabricFormatter implements TypeFormatter {
     );
 
     return this.applyScopeWrapperSemantics(innerSchema, scope);
+  }
+
+  private formatDemandWrapperTypeFromNode(
+    typeRefNode: ts.TypeReferenceNode,
+    context: GenerationContext,
+  ): MutableJSONSchema {
+    const innerTypeNode = typeRefNode.typeArguments?.[0];
+    if (!innerTypeNode) {
+      throw new Error(`Demand<T> requires type argument`);
+    }
+
+    let innerType: ts.Type;
+    try {
+      innerType = context.typeRegistry?.get(innerTypeNode) ??
+        context.typeChecker.getTypeFromTypeNode(innerTypeNode);
+    } catch {
+      innerType = context.typeChecker.getAnyType();
+    }
+
+    const innerSchema = this.schemaGenerator.formatChildType(
+      innerType,
+      context,
+      innerTypeNode,
+    );
+
+    return this.applyDemandWrapperSemantics(innerSchema);
+  }
+
+  /**
+   * `demand: true` marks the subtree as a holder-side demand. Unlike scope,
+   * nesting is harmless (`Demand<Demand<T>>` is one demand), and the marker
+   * stays on the subtree root rather than riding an `asCell` entry: it
+   * records the contract's provenance, not the cell's capability.
+   */
+  private applyDemandWrapperSemantics(
+    schema: MutableJSONSchema,
+  ): MutableJSONSchema {
+    if (typeof schema === "boolean") {
+      return schema === false ? { not: true, demand: true } : { demand: true };
+    }
+    return { ...schema, demand: true };
   }
 
   private applyScopeWrapperSemantics(

--- a/packages/schema-generator/test/demand-wrapper.test.ts
+++ b/packages/schema-generator/test/demand-wrapper.test.ts
@@ -43,7 +43,7 @@ interface SchemaRoot {
     expect(note.demand).toBe(true);
     expect(note.$ref).toBe("#/$defs/NotePreview");
     const def = (schema.$defs as Record<string, JSONSchemaObj>).NotePreview!;
-    expect(def.demand).toBeUndefined();
+    expect(def).not.toHaveProperty("demand");
     expect((def.properties as Record<string, JSONSchemaObj>).title).toEqual(
       { type: "string" },
     );

--- a/packages/schema-generator/test/demand-wrapper.test.ts
+++ b/packages/schema-generator/test/demand-wrapper.test.ts
@@ -64,6 +64,35 @@ interface SchemaRoot {
     expect((notes.items as JSONSchemaObj).demand).toBe(true);
   });
 
+  it("survives alias erasure through a generic instantiation", async () => {
+    // `Box<Demand<NotePreview>>`: the property's declared node says `T`, so
+    // the node path cannot see the wrapper — only the resolved type still
+    // carries `aliasSymbol === Demand`. This is the fallback that keeps the
+    // marker from silently vanishing wherever nodes are lost.
+    const schema = await schemaFor(`
+interface NotePreview {
+  title?: string;
+}
+
+interface Box<T> {
+  boxed: T;
+}
+
+interface SchemaRoot {
+  note: Box<Demand<NotePreview>>;
+}
+`);
+    const note = properties(schema).note!;
+    const target = note.$ref
+      ? (schema.$defs as Record<string, JSONSchemaObj>)[
+        (note.$ref as string).replace("#/$defs/", "")
+      ]!
+      : note;
+    expect(
+      (target.properties as Record<string, JSONSchemaObj>).boxed!.demand,
+    ).toBe(true);
+  });
+
   it("treats nested Demand as one demand", async () => {
     const schema = await schemaFor(`
 interface SchemaRoot {

--- a/packages/schema-generator/test/demand-wrapper.test.ts
+++ b/packages/schema-generator/test/demand-wrapper.test.ts
@@ -1,0 +1,78 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import type { JSONSchemaObj } from "@commonfabric/api";
+import { SchemaGenerator } from "../src/schema-generator.ts";
+import { getTypeFromCode } from "./utils.ts";
+
+// `Demand<T>` marks a holder-side demand — the shape a pattern requires of a
+// piece it stores, as distinct from state it owns. The generator stamps
+// `demand: true` on the marked subtree and otherwise emits the inner type
+// unchanged (verb-evolution brief, PR #5682).
+
+async function schemaFor(code: string): Promise<JSONSchemaObj> {
+  const { type, checker, typeNode } = await getTypeFromCode(
+    code,
+    "SchemaRoot",
+  );
+  return new SchemaGenerator().generateSchema(
+    type,
+    checker,
+    typeNode,
+  ) as JSONSchemaObj;
+}
+
+function properties(schema: JSONSchemaObj): Record<string, JSONSchemaObj> {
+  return (schema.properties ?? {}) as Record<string, JSONSchemaObj>;
+}
+
+describe("Demand wrapper", () => {
+  it("stamps demand on the referencing node, not the shared def", async () => {
+    const schema = await schemaFor(`
+interface NotePreview {
+  title?: string;
+}
+
+interface SchemaRoot {
+  note: Demand<NotePreview>;
+}
+`);
+    // The marker rides the USE site (like asCell on a $ref): the same type
+    // can be a demand in one property and owned shape in another, so the
+    // hoisted def must stay neutral.
+    const note = properties(schema).note!;
+    expect(note.demand).toBe(true);
+    expect(note.$ref).toBe("#/$defs/NotePreview");
+    const def = (schema.$defs as Record<string, JSONSchemaObj>).NotePreview!;
+    expect(def.demand).toBeUndefined();
+    expect((def.properties as Record<string, JSONSchemaObj>).title).toEqual(
+      { type: "string" },
+    );
+  });
+
+  it("stamps demand on array element demands", async () => {
+    const schema = await schemaFor(`
+interface NotePreview {
+  title?: string;
+}
+
+interface SchemaRoot {
+  notes: Demand<NotePreview>[];
+}
+`);
+    const notes = properties(schema).notes!;
+    expect(notes.type).toBe("array");
+    expect((notes.items as JSONSchemaObj).demand).toBe(true);
+  });
+
+  it("treats nested Demand as one demand", async () => {
+    const schema = await schemaFor(`
+interface SchemaRoot {
+  value: Demand<Demand<string>>;
+}
+`);
+    expect(properties(schema).value).toEqual({
+      type: "string",
+      demand: true,
+    });
+  });
+});

--- a/packages/schema-generator/test/utils.ts
+++ b/packages/schema-generator/test/utils.ts
@@ -38,6 +38,9 @@ declare type PerSpace<T> = T & { readonly [SCOPE_BRAND]?: "space" };
 declare type PerUser<T> = T & { readonly [SCOPE_BRAND]?: "user" };
 declare type PerSession<T> = T & { readonly [SCOPE_BRAND]?: "session" };
 declare type PerAny<T> = T & { readonly [SCOPE_BRAND]?: "any" };
+
+declare const DEMAND_BRAND: unique symbol;
+declare type Demand<T> = T & { readonly [DEMAND_BRAND]?: true };
 `;
 
 /**

--- a/packages/schema-generator/test/utils.ts
+++ b/packages/schema-generator/test/utils.ts
@@ -40,7 +40,10 @@ declare type PerSession<T> = T & { readonly [SCOPE_BRAND]?: "session" };
 declare type PerAny<T> = T & { readonly [SCOPE_BRAND]?: "any" };
 
 declare const DEMAND_BRAND: unique symbol;
-declare type Demand<T> = T & { readonly [DEMAND_BRAND]?: true };
+declare interface DemandMarker {
+  readonly [DEMAND_BRAND]?: true;
+}
+declare type Demand<T> = T & DemandMarker;
 `;
 
 /**

--- a/packages/ts-transformers/src/ast/type-building.ts
+++ b/packages/ts-transformers/src/ast/type-building.ts
@@ -574,7 +574,8 @@ export function shouldPreserveBindingDeclaredTypeNode(
       name === "PerUser" ||
       name === "PerSession" ||
       name === "PerAny" ||
-      name === "Default"
+      name === "Default" ||
+      name === "Demand"
     );
   }
 

--- a/packages/ts-transformers/src/lints/foreign-output-embedding.ts
+++ b/packages/ts-transformers/src/lints/foreign-output-embedding.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { getLogger } from "@commonfabric/utils/logger";
 import { detectCallKind, getTypeFromTypeNodeWithFallback } from "../ast/mod.ts";
 import type { ContractLintFinding, ContractLintInput } from "./mod.ts";
 
@@ -42,7 +43,16 @@ export const FOREIGN_OUTPUT_EMBEDDING_DIAGNOSTIC =
 
 const SHARED_CONTRACT_TAG = "sharedContract";
 
+// Depth cap for the type walk in `collectEmbeddingHits`. The visited set
+// already breaks cycles; this bounds non-cyclic explosion through deeply
+// instantiated generics. A realistic contract costs one to two depth per
+// structural level, so 8 covers what the fleet writes — and when it trips
+// anyway, the disabled-by-default logger below records a debug note, so
+// the truncation is observable (in counts, and in output when the logger
+// is enabled) rather than silent.
 const WALK_DEPTH_LIMIT = 8;
+
+const lintLogger = getLogger("contract-lints", { enabled: false });
 
 interface IndexedOutput {
   readonly typeName: string;
@@ -150,12 +160,17 @@ function collectEmbeddingHits(
   location: ts.Node,
   index: OutputSymbolIndex,
   ownSymbols: ReadonlySet<ts.Symbol>,
-): EmbeddingHit[] {
+): { hits: EmbeddingHit[]; capTripped: boolean } {
   const hits = new Map<ts.Symbol, EmbeddingHit>();
   const visited = new Set<ts.Type>();
+  let capTripped = false;
 
   const visit = (type: ts.Type, depth: number): void => {
-    if (depth > WALK_DEPTH_LIMIT || visited.has(type)) return;
+    if (depth > WALK_DEPTH_LIMIT) {
+      capTripped = true;
+      return;
+    }
+    if (visited.has(type)) return;
     visited.add(type);
 
     const symbol = namedSymbolForType(type);
@@ -197,7 +212,7 @@ function collectEmbeddingHits(
   };
 
   visit(root, 0);
-  return [...hits.values()];
+  return { hits: [...hits.values()], capTripped };
 }
 
 /** Best-effort syntactic anchor: the reference node that names the symbol. */
@@ -262,14 +277,26 @@ export function foreignOutputEmbeddingLint(
     const type = side.type ??
       getTypeFromTypeNodeWithFallback(side.typeNode, checker);
 
-    const hits = collectEmbeddingHits(
+    const walk = collectEmbeddingHits(
       type,
       checker,
       callNode,
       index,
       ownSymbols,
     );
-    for (const hit of hits) {
+    if (walk.capTripped) {
+      // The note composes from context.sourceFile, never from the call
+      // node: earlier pipeline stages can hand this lint a synthetic node
+      // with no source file attached.
+      lintLogger.debug(
+        "walk-depth-cap",
+        `type walk stopped at depth ${WALK_DEPTH_LIMIT} in the ` +
+          `${side.role} contract of a pattern call in ` +
+          `${context.sourceFile.fileName}; deeper structure was not ` +
+          "scanned for foreign outputs",
+      );
+    }
+    for (const hit of walk.hits) {
       const anchor =
         referenceNodeForSymbol(side.typeNode, hit.symbol, checker) ?? callNode;
       findings.push({

--- a/packages/ts-transformers/src/lints/foreign-output-embedding.ts
+++ b/packages/ts-transformers/src/lints/foreign-output-embedding.ts
@@ -108,10 +108,14 @@ function outputSymbolIndex(
         if (
           callKind?.kind === "builder" && callKind.builderName === "pattern"
         ) {
-          // `pattern<Input, Output>` — Output rides second; `pattern<T>` —
-          // T serves both positions. The guard above proves one exists.
-          const outputNode = node.typeArguments[1] ?? node.typeArguments[0]!;
-          const symbol = namedSymbolForTypeNode(outputNode, checker);
+          // Only `pattern<Input, Output>` names an Output — it rides
+          // second. The one-generic form's argument is the INPUT (the api
+          // overload returns `PatternFactory<StripCell<T>, any>`), and an
+          // inferred result has no name to index.
+          const outputNode = node.typeArguments[1];
+          const symbol = outputNode
+            ? namedSymbolForTypeNode(outputNode, checker)
+            : undefined;
           if (symbol && !hasSharedContractTag(symbol)) {
             index.set(symbol, {
               typeName: symbol.name,
@@ -232,21 +236,17 @@ export function foreignOutputEmbeddingLint(
   const index = outputSymbolIndex(program, checker);
   if (index.size === 0) return [];
 
-  // Only the OUTPUT-position type argument is exempt: a pattern's own
-  // output referencing itself is the documented self-reference shape. A
-  // foreign Output in the INPUT position is the anti-pattern at its
-  // largest — the whole contract embedded as the argument — and stays
-  // eligible. (`pattern<T>`'s single argument serves both positions, so
-  // its self-reference stays exempt through the same expression.)
+  // Only the pattern's own RESULT contract is exempt: an output
+  // referencing itself is the documented self-reference shape. For
+  // `pattern<I, O>` the result node IS the second type argument; for the
+  // one-generic form the single argument is the INPUT (the api overload
+  // returns `PatternFactory<StripCell<T>, any>`), so nothing explicit is
+  // exempt and a foreign Output used as that input stays eligible — the
+  // anti-pattern at its largest, the whole contract embedded as the
+  // argument.
   const ownSymbols = new Set<ts.Symbol>();
-  const typeArgs = callNode.typeArguments;
-  if (typeArgs && typeArgs.length > 0) {
-    const symbol = namedSymbolForTypeNode(
-      typeArgs[1] ?? typeArgs[0]!,
-      checker,
-    );
-    if (symbol) ownSymbols.add(symbol);
-  }
+  const resultSymbol = namedSymbolForTypeNode(input.resultTypeNode, checker);
+  if (resultSymbol) ownSymbols.add(resultSymbol);
 
   const sides: ReadonlyArray<{
     role: "argument" | "result";

--- a/packages/ts-transformers/src/lints/foreign-output-embedding.ts
+++ b/packages/ts-transformers/src/lints/foreign-output-embedding.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
 import { detectCallKind, getTypeFromTypeNodeWithFallback } from "../ast/mod.ts";
-import type { TransformationContext } from "../core/mod.ts";
+import type { ContractLintFinding, ContractLintInput } from "./mod.ts";
 
 /**
  * Foreign-output embedding check (prototype for the verb-evolution brief,
@@ -25,8 +25,9 @@ import type { TransformationContext } from "../core/mod.ts";
  * is the documented shape), and a provider can opt a type out with a
  * `@sharedContract` JSDoc tag when the type itself is the intended protocol.
  *
- * Severity is "warning" while this is a prototype: it surfaces the coupling
- * without failing anyone's build.
+ * Severity belongs to the registry's policy map (`lints/mod.ts`), advisory
+ * while this is a prototype: the coupling is surfaced without failing
+ * anyone's build.
  *
  * Scope: the check reasons over declared TYPE symbols. The schema-argument
  * form (`pattern(fn, inputSchemaLiteral)`) is outside it — a hand-authored
@@ -217,27 +218,19 @@ function referenceNodeForSymbol(
   return found;
 }
 
-export interface ForeignOutputEmbeddingCheckInput {
-  readonly context: TransformationContext;
-  readonly callNode: ts.CallExpression;
-  readonly inputType: ts.Type | undefined;
-  readonly inputTypeNode: ts.TypeNode;
-  readonly resultType: ts.Type | undefined;
-  readonly resultTypeNode: ts.TypeNode;
-}
-
 /**
- * Report a warning for every foreign pattern Output type embedded in this
- * pattern call's argument or result contract.
+ * One finding for every foreign pattern Output type embedded in this
+ * pattern call's argument or result contract. Pure detection: severity is
+ * the registry's business (`lints/mod.ts`).
  */
-export function checkForeignOutputEmbedding(
-  input: ForeignOutputEmbeddingCheckInput,
-): void {
+export function foreignOutputEmbeddingLint(
+  input: ContractLintInput,
+): ContractLintFinding[] {
   const { context, callNode } = input;
   const { checker, program } = context;
 
   const index = outputSymbolIndex(program, checker);
-  if (index.size === 0) return;
+  if (index.size === 0) return [];
 
   // Only the OUTPUT-position type argument is exempt: a pattern's own
   // output referencing itself is the documented self-reference shape. A
@@ -264,6 +257,7 @@ export function checkForeignOutputEmbedding(
     { role: "result", type: input.resultType, typeNode: input.resultTypeNode },
   ];
 
+  const findings: ContractLintFinding[] = [];
   for (const side of sides) {
     const type = side.type ??
       getTypeFromTypeNodeWithFallback(side.typeNode, checker);
@@ -278,8 +272,7 @@ export function checkForeignOutputEmbedding(
     for (const hit of hits) {
       const anchor =
         referenceNodeForSymbol(side.typeNode, hit.symbol, checker) ?? callNode;
-      context.reportDiagnosticOnce({
-        severity: "warning",
+      findings.push({
         type: FOREIGN_OUTPUT_EMBEDDING_DIAGNOSTIC,
         node: anchor,
         message: `Pattern ${side.role} embeds ${hit.info.typeName}, the ` +
@@ -292,4 +285,5 @@ export function checkForeignOutputEmbedding(
       });
     }
   }
+  return findings;
 }

--- a/packages/ts-transformers/src/lints/foreign-output-embedding.ts
+++ b/packages/ts-transformers/src/lints/foreign-output-embedding.ts
@@ -267,54 +267,44 @@ export function foreignOutputEmbeddingLint(
   const resultSymbol = namedSymbolForTypeNode(input.resultTypeNode, checker);
   if (resultSymbol) ownSymbols.add(resultSymbol);
 
-  const sides: ReadonlyArray<{
-    role: "argument" | "result";
-    type: ts.Type | undefined;
-    typeNode: ts.TypeNode;
-  }> = [
-    { role: "argument", type: input.inputType, typeNode: input.inputTypeNode },
-    { role: "result", type: input.resultType, typeNode: input.resultTypeNode },
-  ];
+  // Argument side only, by ruling: result-side re-exposure
+  // (`BoardOutput { notes: NoteOutput[] }`) is the documented composition
+  // shape, the design's cost table has no result-side refusal, and most
+  // result hits would duplicate the argument-side hit on the same pattern.
+  // The result branch can return with its own message and evidence once
+  // Fabric-types makes result contracts load-bearing.
+  const type = input.inputType ??
+    getTypeFromTypeNodeWithFallback(input.inputTypeNode, checker);
+
+  const walk = collectEmbeddingHits(type, checker, callNode, index, ownSymbols);
+  if (walk.capTripped) {
+    // The note composes from context.sourceFile, never from the call
+    // node: earlier pipeline stages can hand this lint a synthetic node
+    // with no source file attached.
+    lintLogger.debug(
+      "walk-depth-cap",
+      `type walk stopped at depth ${WALK_DEPTH_LIMIT} in the argument ` +
+        `contract of a pattern call in ${context.sourceFile.fileName}; ` +
+        "deeper structure was not scanned for foreign outputs",
+    );
+  }
 
   const findings: ContractLintFinding[] = [];
-  for (const side of sides) {
-    const type = side.type ??
-      getTypeFromTypeNodeWithFallback(side.typeNode, checker);
-
-    const walk = collectEmbeddingHits(
-      type,
-      checker,
-      callNode,
-      index,
-      ownSymbols,
-    );
-    if (walk.capTripped) {
-      // The note composes from context.sourceFile, never from the call
-      // node: earlier pipeline stages can hand this lint a synthetic node
-      // with no source file attached.
-      lintLogger.debug(
-        "walk-depth-cap",
-        `type walk stopped at depth ${WALK_DEPTH_LIMIT} in the ` +
-          `${side.role} contract of a pattern call in ` +
-          `${context.sourceFile.fileName}; deeper structure was not ` +
-          "scanned for foreign outputs",
-      );
-    }
-    for (const hit of walk.hits) {
-      const anchor =
-        referenceNodeForSymbol(side.typeNode, hit.symbol, checker) ?? callNode;
-      findings.push({
-        type: FOREIGN_OUTPUT_EMBEDDING_DIAGNOSTIC,
-        node: anchor,
-        message: `Pattern ${side.role} embeds ${hit.info.typeName}, the ` +
-          `output type of another pattern. A holder should declare only its ` +
-          `demand — the fields it reads and the verbs it calls — as its own ` +
-          `narrow type (optionally marked Demand<T>); embedding the full ` +
-          `output ties this pattern's update gate to the provider's whole ` +
-          `shape. If ${hit.info.typeName} is itself the intended shared ` +
-          `protocol, tag its declaration @sharedContract.`,
-      });
-    }
+  for (const hit of walk.hits) {
+    const anchor =
+      referenceNodeForSymbol(input.inputTypeNode, hit.symbol, checker) ??
+        callNode;
+    findings.push({
+      type: FOREIGN_OUTPUT_EMBEDDING_DIAGNOSTIC,
+      node: anchor,
+      message: `Pattern argument embeds ${hit.info.typeName}, the ` +
+        `output type of another pattern. A holder should declare only its ` +
+        `demand — the fields it reads and the verbs it calls — as its own ` +
+        `narrow type (optionally marked Demand<T>); embedding the full ` +
+        `output ties this pattern's update gate to the provider's whole ` +
+        `shape. If ${hit.info.typeName} is itself the intended shared ` +
+        `protocol, tag its declaration @sharedContract.`,
+    });
   }
   return findings;
 }

--- a/packages/ts-transformers/src/lints/foreign-output-embedding.ts
+++ b/packages/ts-transformers/src/lints/foreign-output-embedding.ts
@@ -166,11 +166,15 @@ function collectEmbeddingHits(
   let capTripped = false;
 
   const visit = (type: ts.Type, depth: number): void => {
+    // Visited wins over the depth cap: a type first explored at a shallow
+    // depth expanded to the absolute cap from there, which is strictly
+    // more than a deeper re-encounter could reach — so meeting it again
+    // past the cap truncates nothing, and must not count as truncation.
+    if (visited.has(type)) return;
     if (depth > WALK_DEPTH_LIMIT) {
       capTripped = true;
       return;
     }
-    if (visited.has(type)) return;
     visited.add(type);
 
     const symbol = namedSymbolForType(type);

--- a/packages/ts-transformers/src/lints/mod.ts
+++ b/packages/ts-transformers/src/lints/mod.ts
@@ -1,0 +1,85 @@
+import type ts from "typescript";
+import type { DiagnosticSeverity, TransformationContext } from "../core/mod.ts";
+import {
+  FOREIGN_OUTPUT_EMBEDDING_DIAGNOSTIC,
+  foreignOutputEmbeddingLint,
+} from "./foreign-output-embedding.ts";
+
+/**
+ * Contract lints: read-only, program-scoped analyses of the cross-pattern
+ * relationships a compile can see.
+ *
+ * A lint is none of the things a transformer is. It rewrites nothing, its
+ * subject is a design rule rather than compiler correctness, and it may
+ * look across the whole program instead of at one node. It rides the
+ * pipeline anyway because this is where the resolved contract types
+ * already are, and because the compile is the one tool every pattern
+ * author touches — the rules have to reach authors who will never read
+ * them.
+ *
+ * Three boundaries keep the category honest:
+ *
+ * - A lint receives the pattern call and its resolved contract types and
+ *   emits findings. It never mutates the tree and never changes emission.
+ * - Severity is policy, not detection: findings map to severity in
+ *   {@link FINDING_SEVERITY}, so an advisory can later become a lint error
+ *   without touching a detector.
+ * - Hard enforcement never lives in the compiler. When a rule graduates
+ *   from advisory, the failure belongs to the CI gates that already
+ *   collect these diagnostics from the compiles they run — the same tier
+ *   as the update gate, which refuses at deploy, not at compile.
+ */
+
+export interface ContractLintInput {
+  readonly context: TransformationContext;
+  readonly callNode: ts.CallExpression;
+  readonly inputType: ts.Type | undefined;
+  readonly inputTypeNode: ts.TypeNode;
+  readonly resultType: ts.Type | undefined;
+  readonly resultTypeNode: ts.TypeNode;
+}
+
+export interface ContractLintFinding {
+  /** Diagnostic type id, e.g. `contract:foreign-output-embedding`. */
+  readonly type: string;
+  readonly message: string;
+  /** Anchor for the diagnostic range. */
+  readonly node: ts.Node;
+}
+
+/** A contract lint: pure detection, findings out, no mutation. */
+export type ContractLint = (input: ContractLintInput) => ContractLintFinding[];
+
+/**
+ * Findings map to severity here, not in the lints. Absent entries default
+ * to "warning": a new lint is advisory until policy says otherwise.
+ */
+const FINDING_SEVERITY: Readonly<Record<string, DiagnosticSeverity>> = {
+  [FOREIGN_OUTPUT_EMBEDDING_DIAGNOSTIC]: "warning",
+};
+
+const CONTRACT_LINTS: readonly ContractLint[] = [
+  foreignOutputEmbeddingLint,
+];
+
+/**
+ * The pipeline's single hook: schema injection calls this once per pattern
+ * call, after contract resolution. New lints register in
+ * {@link CONTRACT_LINTS}; the caller never changes.
+ */
+export function runContractLints(input: ContractLintInput): void {
+  for (const lint of CONTRACT_LINTS) {
+    for (const finding of lint(input)) {
+      input.context.reportDiagnosticOnce({
+        severity: FINDING_SEVERITY[finding.type] ?? "warning",
+        type: finding.type,
+        message: finding.message,
+        node: finding.node,
+      });
+    }
+  }
+}
+
+export {
+  FOREIGN_OUTPUT_EMBEDDING_DIAGNOSTIC,
+} from "./foreign-output-embedding.ts";

--- a/packages/ts-transformers/src/transformers/foreign-output-embedding.ts
+++ b/packages/ts-transformers/src/transformers/foreign-output-embedding.ts
@@ -27,6 +27,13 @@ import type { TransformationContext } from "../core/mod.ts";
  *
  * Severity is "warning" while this is a prototype: it surfaces the coupling
  * without failing anyone's build.
+ *
+ * Scope: the check reasons over declared TYPE symbols. The schema-argument
+ * form (`pattern(fn, inputSchemaLiteral)`) is outside it — a hand-authored
+ * schema literal has no type-symbol provenance to index, the same boundary
+ * the transformer's schema stamps draw. And marker detection is
+ * best-effort by node or alias name, the same exposure the scope wrappers
+ * carry.
  */
 
 export const FOREIGN_OUTPUT_EMBEDDING_DIAGNOSTIC =
@@ -232,9 +239,19 @@ export function checkForeignOutputEmbedding(
   const index = outputSymbolIndex(program, checker);
   if (index.size === 0) return;
 
+  // Only the OUTPUT-position type argument is exempt: a pattern's own
+  // output referencing itself is the documented self-reference shape. A
+  // foreign Output in the INPUT position is the anti-pattern at its
+  // largest — the whole contract embedded as the argument — and stays
+  // eligible. (`pattern<T>`'s single argument serves both positions, so
+  // its self-reference stays exempt through the same expression.)
   const ownSymbols = new Set<ts.Symbol>();
-  for (const typeArg of callNode.typeArguments ?? []) {
-    const symbol = namedSymbolForTypeNode(typeArg, checker);
+  const typeArgs = callNode.typeArguments;
+  if (typeArgs && typeArgs.length > 0) {
+    const symbol = namedSymbolForTypeNode(
+      typeArgs[1] ?? typeArgs[0]!,
+      checker,
+    );
     if (symbol) ownSymbols.add(symbol);
   }
 

--- a/packages/ts-transformers/src/transformers/foreign-output-embedding.ts
+++ b/packages/ts-transformers/src/transformers/foreign-output-embedding.ts
@@ -1,0 +1,307 @@
+import ts from "typescript";
+import { detectCallKind } from "../ast/mod.ts";
+import type { TransformationContext } from "../core/mod.ts";
+
+/**
+ * Foreign-output embedding check (prototype for the verb-evolution brief,
+ * PR #5682).
+ *
+ * A pattern that stores pieces of another pattern and types them with that
+ * pattern's own Output type embeds the provider's WHOLE contract — verbs
+ * included — into its own schema. The update gate then refuses the provider's
+ * most ordinary evolution step (adding a verb) as a change to the *holder*.
+ * The documented alternative is a consumer-owned narrow type: declare only
+ * the fields read and the verbs called (composition.md, "Keep External Data
+ * Contracts Narrow").
+ *
+ * The unenforceable spelling of that rule is "don't export your Output type"
+ * — export is required for factory nameability, and the refusal reproduces
+ * same-file with no import at all. The enforceable spelling is checked here:
+ * no pattern's argument or result schema may embed a type that is the
+ * Output-position type argument of a DIFFERENT pattern factory call anywhere
+ * in the program.
+ *
+ * Self-reference stays legal (a TreeNode whose children are TreeNodeOutput[]
+ * is the documented shape), and a provider can opt a type out with a
+ * `@sharedContract` JSDoc tag when the type itself is the intended protocol.
+ *
+ * Severity is "warning" while this is a prototype: it surfaces the coupling
+ * without failing anyone's build.
+ */
+
+export const FOREIGN_OUTPUT_EMBEDDING_DIAGNOSTIC =
+  "contract:foreign-output-embedding";
+
+const SHARED_CONTRACT_TAG = "sharedContract";
+
+const WALK_DEPTH_LIMIT = 8;
+
+interface IndexedOutput {
+  readonly typeName: string;
+  readonly fileName: string;
+}
+
+type OutputSymbolIndex = Map<ts.Symbol, IndexedOutput>;
+
+const indexCache = new WeakMap<ts.Program, OutputSymbolIndex>();
+
+/** Resolve the named symbol a type-argument node refers to, if any. */
+function namedSymbolForTypeNode(
+  node: ts.TypeNode,
+  checker: ts.TypeChecker,
+): ts.Symbol | undefined {
+  if (!ts.isTypeReferenceNode(node)) return undefined;
+  let type: ts.Type;
+  try {
+    type = checker.getTypeFromTypeNode(node);
+  } catch {
+    return undefined;
+  }
+  return namedSymbolForType(type);
+}
+
+function namedSymbolForType(type: ts.Type): ts.Symbol | undefined {
+  const withInternals = type as ts.Type & { aliasSymbol?: ts.Symbol };
+  const symbol = withInternals.aliasSymbol ?? type.getSymbol();
+  if (!symbol) return undefined;
+  // Anonymous shapes (inline literals) have no name to hold anyone to.
+  if (symbol.name === "__type" || symbol.name === "__object") return undefined;
+  if (!symbol.declarations || symbol.declarations.length === 0) {
+    return undefined;
+  }
+  return symbol;
+}
+
+function hasSharedContractTag(symbol: ts.Symbol): boolean {
+  return (symbol.declarations ?? []).some((declaration) =>
+    ts.getJSDocTags(declaration).some(
+      (tag) => tag.tagName.text === SHARED_CONTRACT_TAG,
+    )
+  );
+}
+
+/** The Output-position type argument of a pattern factory call. */
+function outputTypeArgument(
+  call: ts.CallExpression,
+): ts.TypeNode | undefined {
+  const typeArgs = call.typeArguments;
+  if (!typeArgs || typeArgs.length === 0) return undefined;
+  // `pattern<Input, Output>` — Output rides second; `pattern<T>` — T serves
+  // both positions.
+  return typeArgs[1] ?? typeArgs[0];
+}
+
+/**
+ * Collect the Output-position symbol of every pattern factory call in the
+ * program. Cached per program: the set is a fact about the whole compile,
+ * not about the file currently being transformed.
+ */
+function outputSymbolIndex(
+  program: ts.Program,
+  checker: ts.TypeChecker,
+): OutputSymbolIndex {
+  const cached = indexCache.get(program);
+  if (cached) return cached;
+
+  const index: OutputSymbolIndex = new Map();
+  for (const sourceFile of program.getSourceFiles()) {
+    if (sourceFile.isDeclarationFile) continue;
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isCallExpression(node) &&
+        node.typeArguments && node.typeArguments.length > 0
+      ) {
+        const callKind = detectCallKind(node, checker);
+        if (
+          callKind?.kind === "builder" && callKind.builderName === "pattern"
+        ) {
+          const outputNode = outputTypeArgument(node);
+          const symbol = outputNode
+            ? namedSymbolForTypeNode(outputNode, checker)
+            : undefined;
+          if (symbol && !hasSharedContractTag(symbol)) {
+            index.set(symbol, {
+              typeName: symbol.name,
+              fileName: sourceFile.fileName,
+            });
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+
+  indexCache.set(program, index);
+  return index;
+}
+
+interface EmbeddingHit {
+  readonly symbol: ts.Symbol;
+  readonly info: IndexedOutput;
+}
+
+/**
+ * Walk a type's reachable structure looking for references to indexed Output
+ * symbols. Stops at the first hit per symbol and does not recurse into a hit
+ * — one report per foreign type is enough, and its members are the
+ * provider's business.
+ */
+function collectEmbeddingHits(
+  root: ts.Type,
+  checker: ts.TypeChecker,
+  location: ts.Node,
+  index: OutputSymbolIndex,
+  ownSymbols: ReadonlySet<ts.Symbol>,
+): EmbeddingHit[] {
+  const hits = new Map<ts.Symbol, EmbeddingHit>();
+  const visited = new Set<ts.Type>();
+
+  const visit = (type: ts.Type, depth: number): void => {
+    if (depth > WALK_DEPTH_LIMIT || visited.has(type)) return;
+    visited.add(type);
+
+    const symbol = namedSymbolForType(type);
+    if (symbol && index.has(symbol) && !ownSymbols.has(symbol)) {
+      if (!hits.has(symbol)) {
+        hits.set(symbol, { symbol, info: index.get(symbol)! });
+      }
+      return;
+    }
+
+    if (type.isUnionOrIntersection()) {
+      for (const member of type.types) visit(member, depth + 1);
+      return;
+    }
+
+    const withInternals = type as ts.Type & {
+      aliasTypeArguments?: readonly ts.Type[];
+    };
+    for (const argument of withInternals.aliasTypeArguments ?? []) {
+      visit(argument, depth + 1);
+    }
+
+    if (
+      (type.flags & ts.TypeFlags.Object) !== 0 &&
+      ((type as ts.ObjectType).objectFlags & ts.ObjectFlags.Reference) !== 0
+    ) {
+      for (
+        const argument of checker.getTypeArguments(type as ts.TypeReference)
+      ) {
+        visit(argument, depth + 1);
+      }
+    }
+
+    if ((type.flags & ts.TypeFlags.Object) !== 0) {
+      for (const property of checker.getPropertiesOfType(type)) {
+        let propertyType: ts.Type;
+        try {
+          propertyType = checker.getTypeOfSymbolAtLocation(property, location);
+        } catch {
+          continue;
+        }
+        visit(propertyType, depth + 1);
+      }
+    }
+  };
+
+  visit(root, 0);
+  return [...hits.values()];
+}
+
+/** Best-effort syntactic anchor: the reference node that names the symbol. */
+function referenceNodeForSymbol(
+  typeNode: ts.TypeNode | undefined,
+  symbol: ts.Symbol,
+  checker: ts.TypeChecker,
+): ts.Node | undefined {
+  if (!typeNode) return undefined;
+  let found: ts.Node | undefined;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (
+      ts.isTypeReferenceNode(node) &&
+      namedSymbolForTypeNode(node, checker) === symbol
+    ) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(typeNode);
+  return found;
+}
+
+export interface ForeignOutputEmbeddingCheckInput {
+  readonly context: TransformationContext;
+  readonly callNode: ts.CallExpression;
+  readonly inputType: ts.Type | undefined;
+  readonly inputTypeNode: ts.TypeNode | undefined;
+  readonly resultType: ts.Type | undefined;
+  readonly resultTypeNode: ts.TypeNode | undefined;
+}
+
+/**
+ * Report a warning for every foreign pattern Output type embedded in this
+ * pattern call's argument or result contract.
+ */
+export function checkForeignOutputEmbedding(
+  input: ForeignOutputEmbeddingCheckInput,
+): void {
+  const { context, callNode } = input;
+  const { checker, program } = context;
+
+  const index = outputSymbolIndex(program, checker);
+  if (index.size === 0) return;
+
+  const ownSymbols = new Set<ts.Symbol>();
+  for (const typeArg of callNode.typeArguments ?? []) {
+    const symbol = namedSymbolForTypeNode(typeArg, checker);
+    if (symbol) ownSymbols.add(symbol);
+  }
+
+  const sides: ReadonlyArray<{
+    role: "argument" | "result";
+    type: ts.Type | undefined;
+    typeNode: ts.TypeNode | undefined;
+  }> = [
+    { role: "argument", type: input.inputType, typeNode: input.inputTypeNode },
+    { role: "result", type: input.resultType, typeNode: input.resultTypeNode },
+  ];
+
+  for (const side of sides) {
+    let type = side.type;
+    if (!type && side.typeNode) {
+      try {
+        type = checker.getTypeFromTypeNode(side.typeNode);
+      } catch {
+        type = undefined;
+      }
+    }
+    if (!type) continue;
+
+    const hits = collectEmbeddingHits(
+      type,
+      checker,
+      callNode,
+      index,
+      ownSymbols,
+    );
+    for (const hit of hits) {
+      const anchor =
+        referenceNodeForSymbol(side.typeNode, hit.symbol, checker) ?? callNode;
+      context.reportDiagnosticOnce({
+        severity: "warning",
+        type: FOREIGN_OUTPUT_EMBEDDING_DIAGNOSTIC,
+        node: anchor,
+        message: `Pattern ${side.role} embeds ${hit.info.typeName}, the ` +
+          `output type of another pattern. A holder should declare only its ` +
+          `demand — the fields it reads and the verbs it calls — as its own ` +
+          `narrow type (optionally marked Demand<T>); embedding the full ` +
+          `output ties this pattern's update gate to the provider's whole ` +
+          `shape. If ${hit.info.typeName} is itself the intended shared ` +
+          `protocol, tag its declaration @sharedContract.`,
+      });
+    }
+  }
+}

--- a/packages/ts-transformers/src/transformers/foreign-output-embedding.ts
+++ b/packages/ts-transformers/src/transformers/foreign-output-embedding.ts
@@ -1,5 +1,5 @@
 import ts from "typescript";
-import { detectCallKind } from "../ast/mod.ts";
+import { detectCallKind, getTypeFromTypeNodeWithFallback } from "../ast/mod.ts";
 import type { TransformationContext } from "../core/mod.ts";
 
 /**
@@ -51,22 +51,18 @@ function namedSymbolForTypeNode(
   checker: ts.TypeChecker,
 ): ts.Symbol | undefined {
   if (!ts.isTypeReferenceNode(node)) return undefined;
-  let type: ts.Type;
-  try {
-    type = checker.getTypeFromTypeNode(node);
-  } catch {
-    return undefined;
-  }
-  return namedSymbolForType(type);
+  return namedSymbolForType(getTypeFromTypeNodeWithFallback(node, checker));
 }
 
 function namedSymbolForType(type: ts.Type): ts.Symbol | undefined {
   const withInternals = type as ts.Type & { aliasSymbol?: ts.Symbol };
   const symbol = withInternals.aliasSymbol ?? type.getSymbol();
-  if (!symbol) return undefined;
-  // Anonymous shapes (inline literals) have no name to hold anyone to.
-  if (symbol.name === "__type" || symbol.name === "__object") return undefined;
-  if (!symbol.declarations || symbol.declarations.length === 0) {
+  // Anonymous shapes (inline literals, `__type`/`__object`) have no name to
+  // hold anyone to, and a symbol without declarations has no tag to read.
+  if (
+    !symbol || symbol.name === "__type" || symbol.name === "__object" ||
+    !symbol.declarations || symbol.declarations.length === 0
+  ) {
     return undefined;
   }
   return symbol;
@@ -78,17 +74,6 @@ function hasSharedContractTag(symbol: ts.Symbol): boolean {
       (tag) => tag.tagName.text === SHARED_CONTRACT_TAG,
     )
   );
-}
-
-/** The Output-position type argument of a pattern factory call. */
-function outputTypeArgument(
-  call: ts.CallExpression,
-): ts.TypeNode | undefined {
-  const typeArgs = call.typeArguments;
-  if (!typeArgs || typeArgs.length === 0) return undefined;
-  // `pattern<Input, Output>` — Output rides second; `pattern<T>` — T serves
-  // both positions.
-  return typeArgs[1] ?? typeArgs[0];
 }
 
 /**
@@ -115,10 +100,10 @@ function outputSymbolIndex(
         if (
           callKind?.kind === "builder" && callKind.builderName === "pattern"
         ) {
-          const outputNode = outputTypeArgument(node);
-          const symbol = outputNode
-            ? namedSymbolForTypeNode(outputNode, checker)
-            : undefined;
+          // `pattern<Input, Output>` — Output rides second; `pattern<T>` —
+          // T serves both positions. The guard above proves one exists.
+          const outputNode = node.typeArguments[1] ?? node.typeArguments[0]!;
+          const symbol = namedSymbolForTypeNode(outputNode, checker);
           if (symbol && !hasSharedContractTag(symbol)) {
             index.set(symbol, {
               typeName: symbol.name,
@@ -194,13 +179,7 @@ function collectEmbeddingHits(
 
     if ((type.flags & ts.TypeFlags.Object) !== 0) {
       for (const property of checker.getPropertiesOfType(type)) {
-        let propertyType: ts.Type;
-        try {
-          propertyType = checker.getTypeOfSymbolAtLocation(property, location);
-        } catch {
-          continue;
-        }
-        visit(propertyType, depth + 1);
+        visit(checker.getTypeOfSymbolAtLocation(property, location), depth + 1);
       }
     }
   };
@@ -211,11 +190,10 @@ function collectEmbeddingHits(
 
 /** Best-effort syntactic anchor: the reference node that names the symbol. */
 function referenceNodeForSymbol(
-  typeNode: ts.TypeNode | undefined,
+  typeNode: ts.TypeNode,
   symbol: ts.Symbol,
   checker: ts.TypeChecker,
 ): ts.Node | undefined {
-  if (!typeNode) return undefined;
   let found: ts.Node | undefined;
   const visit = (node: ts.Node): void => {
     if (found) return;
@@ -236,9 +214,9 @@ export interface ForeignOutputEmbeddingCheckInput {
   readonly context: TransformationContext;
   readonly callNode: ts.CallExpression;
   readonly inputType: ts.Type | undefined;
-  readonly inputTypeNode: ts.TypeNode | undefined;
+  readonly inputTypeNode: ts.TypeNode;
   readonly resultType: ts.Type | undefined;
-  readonly resultTypeNode: ts.TypeNode | undefined;
+  readonly resultTypeNode: ts.TypeNode;
 }
 
 /**
@@ -263,22 +241,15 @@ export function checkForeignOutputEmbedding(
   const sides: ReadonlyArray<{
     role: "argument" | "result";
     type: ts.Type | undefined;
-    typeNode: ts.TypeNode | undefined;
+    typeNode: ts.TypeNode;
   }> = [
     { role: "argument", type: input.inputType, typeNode: input.inputTypeNode },
     { role: "result", type: input.resultType, typeNode: input.resultTypeNode },
   ];
 
   for (const side of sides) {
-    let type = side.type;
-    if (!type && side.typeNode) {
-      try {
-        type = checker.getTypeFromTypeNode(side.typeNode);
-      } catch {
-        type = undefined;
-      }
-    }
-    if (!type) continue;
+    const type = side.type ??
+      getTypeFromTypeNodeWithFallback(side.typeNode, checker);
 
     const hits = collectEmbeddingHits(
       type,

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -53,6 +53,7 @@ import {
   printTypeNode,
 } from "./type-shrinking.ts";
 import { isPatternFactoryCalleeExpression } from "./structural-reactive-factory.ts";
+import { checkForeignOutputEmbedding } from "./foreign-output-embedding.ts";
 
 type UiContractHint = NonNullable<SchemaHint["cfcUiContract"]>;
 type CellScope = "space" | "user" | "session";
@@ -3020,6 +3021,18 @@ function handlePatternSchemaInjection(
   if (resultType && typeRegistry) {
     typeRegistry.set(resultSchemaCall, resultType);
   }
+
+  // Walk the ORIGINAL argument node: capability shrinking may have replaced
+  // `inputTypeNode` with a synthetic literal (and nulled `inputType`), and
+  // the embedding question is about the contract the author declared.
+  checkForeignOutputEmbedding({
+    context,
+    callNode: node,
+    inputType,
+    inputTypeNode: originalInputTypeNode,
+    resultType,
+    resultTypeNode,
+  });
 
   const updated = buildCallExpression(inputSchemaCall, resultSchemaCall);
   const visited = ts.visitEachChild(updated, visit, transformation);

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -53,7 +53,7 @@ import {
   printTypeNode,
 } from "./type-shrinking.ts";
 import { isPatternFactoryCalleeExpression } from "./structural-reactive-factory.ts";
-import { checkForeignOutputEmbedding } from "./foreign-output-embedding.ts";
+import { runContractLints } from "../lints/mod.ts";
 
 type UiContractHint = NonNullable<SchemaHint["cfcUiContract"]>;
 type CellScope = "space" | "user" | "session";
@@ -3023,11 +3023,11 @@ function handlePatternSchemaInjection(
     typeRegistry.set(resultSchemaCall, resultType);
   }
 
-  // Walk the ORIGINAL argument node and type: capability shrinking may have
-  // replaced `inputTypeNode` with a synthetic literal (and nulled
-  // `inputType`), and the embedding question is about the contract the
+  // The contract lints get the ORIGINAL argument node and type: capability
+  // shrinking may have replaced `inputTypeNode` with a synthetic literal
+  // (and nulled `inputType`), and a lint's subject is the contract the
   // author declared.
-  checkForeignOutputEmbedding({
+  runContractLints({
     context,
     callNode: node,
     inputType: originalInputType,

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -2971,6 +2971,7 @@ function handlePatternSchemaInjection(
   }
 
   const originalInputTypeNode = inputTypeNode;
+  const originalInputType = inputType;
   inputTypeNode = applyCapabilitySummaryToArgument(
     builderFunction,
     inputTypeNode,
@@ -3022,13 +3023,14 @@ function handlePatternSchemaInjection(
     typeRegistry.set(resultSchemaCall, resultType);
   }
 
-  // Walk the ORIGINAL argument node: capability shrinking may have replaced
-  // `inputTypeNode` with a synthetic literal (and nulled `inputType`), and
-  // the embedding question is about the contract the author declared.
+  // Walk the ORIGINAL argument node and type: capability shrinking may have
+  // replaced `inputTypeNode` with a synthetic literal (and nulled
+  // `inputType`), and the embedding question is about the contract the
+  // author declared.
   checkForeignOutputEmbedding({
     context,
     callNode: node,
-    inputType,
+    inputType: originalInputType,
     inputTypeNode: originalInputTypeNode,
     resultType,
     resultTypeNode,

--- a/packages/ts-transformers/test/foreign-output-embedding.test.ts
+++ b/packages/ts-transformers/test/foreign-output-embedding.test.ts
@@ -104,6 +104,47 @@ Deno.test("Foreign-output embedding check", async (t) => {
   );
 
   await t.step(
+    "warns when a foreign Output is the input-position type argument",
+    async () => {
+      // Using another pattern's Output as your own INPUT is the embedding
+      // at its largest — the whole contract as the argument — and must not
+      // ride the self-reference exemption, which covers only the pattern's
+      // own output position.
+      const source = [
+        'import { pattern } from "commonfabric";',
+        "",
+        "export interface NoteOutput {",
+        "  title: string;",
+        "}",
+        "",
+        "interface NoteInput {",
+        "  title?: string;",
+        "}",
+        "",
+        "export const Note = pattern<NoteInput, NoteOutput>(({ title }) => ({",
+        "  title,",
+        "}));",
+        "",
+        "interface WrapperOutput {",
+        "  wrapped: number;",
+        "}",
+        "",
+        "export default pattern<NoteOutput, WrapperOutput>(({ title }) => ({",
+        "  wrapped: title.length,",
+        "}));",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const warnings = embeddingWarnings(diagnostics);
+      assertEquals(warnings.length, 1);
+      assertStringIncludes(warnings[0]!.message, "NoteOutput");
+      assertStringIncludes(warnings[0]!.message, "argument");
+    },
+  );
+
+  await t.step(
     "stays silent for inline-literal type arguments",
     async () => {
       // An anonymous output shape has no name to hold anyone to, so it is

--- a/packages/ts-transformers/test/foreign-output-embedding.test.ts
+++ b/packages/ts-transformers/test/foreign-output-embedding.test.ts
@@ -1,0 +1,172 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { validateSource } from "./utils.ts";
+import type { TransformationDiagnostic } from "../src/mod.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+// Foreign-output embedding check (prototype for the verb-evolution brief,
+// PR #5682): a pattern whose argument or result contract embeds ANOTHER
+// pattern's Output-position type gets an advisory warning pointing at the
+// consumer-owned narrow type it should declare instead. Self-reference and
+// `@sharedContract`-tagged protocols stay silent.
+
+const DIAGNOSTIC_TYPE = "contract:foreign-output-embedding";
+
+function embeddingWarnings(
+  diagnostics: readonly TransformationDiagnostic[],
+): readonly TransformationDiagnostic[] {
+  return diagnostics.filter((d) => d.type === DIAGNOSTIC_TYPE);
+}
+
+Deno.test("Foreign-output embedding check", async (t) => {
+  await t.step(
+    "warns when a holder embeds another pattern's Output type",
+    async () => {
+      const source = [
+        'import { pattern } from "commonfabric";',
+        "",
+        "export interface NoteOutput {",
+        "  title: string;",
+        "}",
+        "",
+        "interface NoteInput {",
+        "  title?: string;",
+        "}",
+        "",
+        "export const Note = pattern<NoteInput, NoteOutput>(({ title }) => ({",
+        "  title,",
+        "}));",
+        "",
+        "interface BoardInput {",
+        "  notes?: NoteOutput[];",
+        "}",
+        "",
+        "interface BoardOutput {",
+        "  noteCount: number;",
+        "}",
+        "",
+        "export default pattern<BoardInput, BoardOutput>(() => ({",
+        "  noteCount: 0,",
+        "}));",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const warnings = embeddingWarnings(diagnostics);
+      assertEquals(warnings.length, 1);
+      assertEquals(warnings[0]!.severity, "warning");
+      assertStringIncludes(warnings[0]!.message, "NoteOutput");
+      assertStringIncludes(warnings[0]!.message, "argument");
+      assertStringIncludes(warnings[0]!.message, "Demand<T>");
+    },
+  );
+
+  await t.step(
+    "stays silent for a consumer-owned narrow type",
+    async () => {
+      const source = [
+        'import { pattern } from "commonfabric";',
+        "",
+        "export interface NoteOutput {",
+        "  title: string;",
+        "}",
+        "",
+        "interface NoteInput {",
+        "  title?: string;",
+        "}",
+        "",
+        "export const Note = pattern<NoteInput, NoteOutput>(({ title }) => ({",
+        "  title,",
+        "}));",
+        "",
+        "interface NotePreview {",
+        "  title?: string;",
+        "}",
+        "",
+        "interface BoardInput {",
+        "  notes?: NotePreview[];",
+        "}",
+        "",
+        "interface BoardOutput {",
+        "  noteCount: number;",
+        "}",
+        "",
+        "export default pattern<BoardInput, BoardOutput>(() => ({",
+        "  noteCount: 0,",
+        "}));",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      assertEquals(embeddingWarnings(diagnostics).length, 0);
+    },
+  );
+
+  await t.step(
+    "stays silent for documented self-reference",
+    async () => {
+      const source = [
+        'import { pattern } from "commonfabric";',
+        "",
+        "interface TreeInput {",
+        "  label?: string;",
+        "}",
+        "",
+        "export interface TreeOutput {",
+        "  label: string;",
+        "  children: TreeOutput[];",
+        "}",
+        "",
+        "export default pattern<TreeInput, TreeOutput>(() => ({",
+        '  label: "",',
+        "  children: [],",
+        "}));",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      assertEquals(embeddingWarnings(diagnostics).length, 0);
+    },
+  );
+
+  await t.step(
+    "stays silent for a @sharedContract-tagged protocol type",
+    async () => {
+      const source = [
+        'import { pattern } from "commonfabric";',
+        "",
+        "/** @sharedContract */",
+        "export interface NoteOutput {",
+        "  title: string;",
+        "}",
+        "",
+        "interface NoteInput {",
+        "  title?: string;",
+        "}",
+        "",
+        "export const Note = pattern<NoteInput, NoteOutput>(({ title }) => ({",
+        "  title,",
+        "}));",
+        "",
+        "interface BoardInput {",
+        "  notes?: NoteOutput[];",
+        "}",
+        "",
+        "interface BoardOutput {",
+        "  noteCount: number;",
+        "}",
+        "",
+        "export default pattern<BoardInput, BoardOutput>(() => ({",
+        "  noteCount: 0,",
+        "}));",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      assertEquals(embeddingWarnings(diagnostics).length, 0);
+    },
+  );
+});

--- a/packages/ts-transformers/test/foreign-output-embedding.test.ts
+++ b/packages/ts-transformers/test/foreign-output-embedding.test.ts
@@ -145,6 +145,79 @@ Deno.test("Foreign-output embedding check", async (t) => {
   );
 
   await t.step(
+    "warns when a foreign Output is the single-generic input",
+    async () => {
+      // `pattern<T>`'s one argument is the INPUT (the result is inferred),
+      // so a foreign Output there is the whole-contract embed and must not
+      // ride any self-reference exemption.
+      const source = [
+        'import { pattern } from "commonfabric";',
+        "",
+        "export interface NoteOutput {",
+        "  title: string;",
+        "}",
+        "",
+        "interface NoteInput {",
+        "  title?: string;",
+        "}",
+        "",
+        "export const Note = pattern<NoteInput, NoteOutput>(({ title }) => ({",
+        "  title,",
+        "}));",
+        "",
+        "export default pattern<NoteOutput>(({ title }) => ({",
+        "  label: title,",
+        "}));",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const warnings = embeddingWarnings(diagnostics);
+      assertEquals(warnings.length, 1);
+      assertStringIncludes(warnings[0]!.message, "NoteOutput");
+      assertStringIncludes(warnings[0]!.message, "argument");
+    },
+  );
+
+  await t.step(
+    "never indexes a single-generic pattern's input as an Output",
+    async () => {
+      // The provider below only ever declares its INPUT explicitly; its
+      // result is inferred. A consumer embedding that input type is not
+      // embedding anyone's output contract.
+      const source = [
+        'import { pattern } from "commonfabric";',
+        "",
+        "export interface NoteState {",
+        "  title?: string;",
+        "}",
+        "",
+        "export const Note = pattern<NoteState>(({ title }) => ({",
+        "  title,",
+        "}));",
+        "",
+        "interface BoardInput {",
+        "  notes?: NoteState[];",
+        "}",
+        "",
+        "interface BoardOutput {",
+        "  noteCount: number;",
+        "}",
+        "",
+        "export default pattern<BoardInput, BoardOutput>(() => ({",
+        "  noteCount: 0,",
+        "}));",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      assertEquals(embeddingWarnings(diagnostics).length, 0);
+    },
+  );
+
+  await t.step(
     "stays silent for inline-literal type arguments",
     async () => {
       // An anonymous output shape has no name to hold anyone to, so it is

--- a/packages/ts-transformers/test/foreign-output-embedding.test.ts
+++ b/packages/ts-transformers/test/foreign-output-embedding.test.ts
@@ -253,16 +253,20 @@ Deno.test("Foreign-output embedding check", async (t) => {
   await t.step(
     "stays silent for documented self-reference",
     async () => {
+      // Self-reference in the ARGUMENT contract: the tree holds pieces of
+      // its own pattern. The exemption keys on the result contract's root
+      // symbol, so `TreeOutput` inside `TreeInput` stays legal.
       const source = [
         'import { pattern } from "commonfabric";',
-        "",
-        "interface TreeInput {",
-        "  label?: string;",
-        "}",
         "",
         "export interface TreeOutput {",
         "  label: string;",
         "  children: TreeOutput[];",
+        "}",
+        "",
+        "interface TreeInput {",
+        "  label?: string;",
+        "  parent?: TreeOutput;",
         "}",
         "",
         "export default pattern<TreeInput, TreeOutput>(() => ({",

--- a/packages/ts-transformers/test/foreign-output-embedding.test.ts
+++ b/packages/ts-transformers/test/foreign-output-embedding.test.ts
@@ -104,6 +104,38 @@ Deno.test("Foreign-output embedding check", async (t) => {
   );
 
   await t.step(
+    "stays silent for inline-literal type arguments",
+    async () => {
+      // An anonymous output shape has no name to hold anyone to, so it is
+      // never indexed — and a holder embedding a plain literal is its own.
+      const source = [
+        'import { pattern } from "commonfabric";',
+        "",
+        "export const Note = pattern<{ title?: string }, { title: string }>(",
+        "  ({ title }) => ({ title }),",
+        ");",
+        "",
+        "interface BoardInput {",
+        "  notes?: { title?: string }[];",
+        "}",
+        "",
+        "interface BoardOutput {",
+        "  noteCount: number;",
+        "}",
+        "",
+        "export default pattern<BoardInput, BoardOutput>(() => ({",
+        "  noteCount: 0,",
+        "}));",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      assertEquals(embeddingWarnings(diagnostics).length, 0);
+    },
+  );
+
+  await t.step(
     "stays silent for documented self-reference",
     async () => {
       const source = [

--- a/packages/ts-transformers/test/foreign-output-embedding.test.ts
+++ b/packages/ts-transformers/test/foreign-output-embedding.test.ts
@@ -1,4 +1,5 @@
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
 import { validateSource } from "./utils.ts";
 import type { TransformationDiagnostic } from "../src/mod.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
@@ -313,6 +314,85 @@ Deno.test("Foreign-output embedding check", async (t) => {
         types: COMMONFABRIC_TYPES,
       });
       assertEquals(embeddingWarnings(diagnostics).length, 0);
+    },
+  );
+
+  // A chain of single-property interfaces: L1.next -> L2.next -> … -> leaf.
+  // From the argument root, the leaf sits at depth `links + 1`.
+  const chainTo = (links: number, leaf: string): string[] => {
+    const lines: string[] = [];
+    for (let i = 1; i <= links; i++) {
+      lines.push(
+        `interface L${i} {`,
+        `  next: ${i === links ? leaf : `L${i + 1}`};`,
+        `}`,
+        "",
+      );
+    }
+    return lines;
+  };
+
+  const boardAround = (chain: string[]): string =>
+    [
+      'import { pattern } from "commonfabric";',
+      "",
+      "export interface NoteOutput {",
+      "  title: string;",
+      "}",
+      "",
+      "interface NoteInput {",
+      "  title?: string;",
+      "}",
+      "",
+      "export const Note = pattern<NoteInput, NoteOutput>(({ title }) => ({",
+      "  title,",
+      "}));",
+      "",
+      ...chain,
+      "interface BoardInput {",
+      "  deep: L1;",
+      "}",
+      "",
+      "interface BoardOutput {",
+      "  noteCount: number;",
+      "}",
+      "",
+      "export default pattern<BoardInput, BoardOutput>(() => ({",
+      "  noteCount: 0,",
+      "}));",
+    ].join("\n");
+
+  await t.step(
+    "still finds a foreign Output deep inside the cap",
+    async () => {
+      // Six links put NoteOutput at depth 7 — under the cap of 8.
+      const { diagnostics } = await validateSource(
+        boardAround(chainTo(6, "NoteOutput")),
+        { types: COMMONFABRIC_TYPES },
+      );
+      assertEquals(embeddingWarnings(diagnostics).length, 1);
+    },
+  );
+
+  await t.step(
+    "records a debug note when the depth cap truncates the walk",
+    async () => {
+      const capCount = () =>
+        getLoggerCountsBreakdown()["contract-lints"]?.["walk-depth-cap"]
+          ?.debug ?? 0;
+      const before = capCount();
+
+      // Nine links put NoteOutput at depth 10 — past the cap, so no
+      // warning fires; the truncation must be recorded, not silent.
+      const { diagnostics } = await validateSource(
+        boardAround(chainTo(9, "NoteOutput")),
+        { types: COMMONFABRIC_TYPES },
+      );
+      assertEquals(embeddingWarnings(diagnostics).length, 0);
+      assert(
+        capCount() > before,
+        "expected the walk-depth-cap debug note to be recorded",
+      );
     },
   );
 });

--- a/packages/ts-transformers/test/foreign-output-embedding.test.ts
+++ b/packages/ts-transformers/test/foreign-output-embedding.test.ts
@@ -395,4 +395,62 @@ Deno.test("Foreign-output embedding check", async (t) => {
       );
     },
   );
+
+  await t.step(
+    "does not report truncation for a deep re-encounter of an explored type",
+    async () => {
+      const capCount = () =>
+        getLoggerCountsBreakdown()["contract-lints"]?.["walk-depth-cap"]
+          ?.debug ?? 0;
+      const before = capCount();
+
+      // `Tail` is fully explored at depth 1 through `a` (finding the
+      // foreign Output at depth 2), then re-encountered at depth 9 at the
+      // end of the eight-link chain under `b`. Nothing reachable goes
+      // unscanned, so the walk-depth note must not fire.
+      const source = [
+        'import { pattern } from "commonfabric";',
+        "",
+        "export interface NoteOutput {",
+        "  title: string;",
+        "}",
+        "",
+        "interface NoteInput {",
+        "  title?: string;",
+        "}",
+        "",
+        "export const Note = pattern<NoteInput, NoteOutput>(({ title }) => ({",
+        "  title,",
+        "}));",
+        "",
+        "interface Tail {",
+        "  note: NoteOutput;",
+        "}",
+        "",
+        ...chainTo(8, "Tail"),
+        "interface BoardInput {",
+        "  a: Tail;",
+        "  b: L1;",
+        "}",
+        "",
+        "interface BoardOutput {",
+        "  noteCount: number;",
+        "}",
+        "",
+        "export default pattern<BoardInput, BoardOutput>(() => ({",
+        "  noteCount: 0,",
+        "}));",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      assertEquals(embeddingWarnings(diagnostics).length, 1);
+      assertEquals(
+        capCount(),
+        before,
+        "a re-encounter of an already-explored type is not a truncation",
+      );
+    },
+  );
 });

--- a/packages/ts-transformers/test/schema-injection-coverage.test.ts
+++ b/packages/ts-transformers/test/schema-injection-coverage.test.ts
@@ -1,5 +1,6 @@
 import ts from "typescript";
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { shouldPreserveBindingDeclaredTypeNode } from "../src/ast/type-building.ts";
 import { transformSource, validateSource } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 import {
@@ -1147,4 +1148,41 @@ Deno.test("lift-applied untyped callback using Cell.get on a Cell input recovers
   const [input] = callSchemas(parseModule(output), "lift");
   assertEquals((input.properties as Obj).n.type, "number");
   assertEquals(input.asCell, ["readonly"]);
+});
+
+// ---------------------------------------------------------------------------
+// Demand<T> — the end-to-end seam: a pattern WRITTEN with the api's marker
+// yields a schema carrying `demand: true` on the referencing node.
+// ---------------------------------------------------------------------------
+
+Deno.test("pattern input Demand<T> emits demand on the referencing node", async () => {
+  const source = [
+    "/// <cts-enable />",
+    'import { type Demand, pattern } from "commonfabric";',
+    "interface NotePreview { title?: string }",
+    "interface In { notes?: Demand<NotePreview>[] }",
+    "interface Out { count: number }",
+    "export default pattern<In, Out>(() => ({ count: 0 }));",
+  ].join("\n");
+  const output = await t(source);
+  const { input } = patternSchemas(parseModule(output));
+  const notes = (input.properties as Obj).notes as Obj;
+  assertEquals(notes.items.demand, true);
+  // The marker records use-site provenance only: the inner shape survives
+  // unchanged, and nothing else in the property gains the key.
+  assertEquals(notes.demand, undefined);
+});
+
+Deno.test("shouldPreserveBindingDeclaredTypeNode keeps marker wrapper nodes", () => {
+  const reference = (name: string): ts.TypeNode =>
+    ts.factory.createTypeReferenceNode(name, [
+      ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+    ]);
+  for (const name of ["Demand", "Default", "PerSession"]) {
+    assert(
+      shouldPreserveBindingDeclaredTypeNode(reference(name)),
+      `${name} node must survive binding-type shrinking`,
+    );
+  }
+  assert(!shouldPreserveBindingDeclaredTypeNode(reference("NotePreview")));
 });


### PR DESCRIPTION
## Why

The verb-evolution decision brief (#5682) surfaced one missing substrate under
three separate asks: transformer strictness about cross-pattern contracts
(Berni), a consumer-impact report at break time (Ben), and scoped break
acknowledgment (the brief's do-anyway list) all need holder-side demands to be
visible **as demands**. Today a holder's demand is indistinguishable from its
own state in its schema — the storer-refusal path `argument.notes[].append`
IS the demand subtree, unmarked.

The discussed spelling of the discipline — "don't export the Output type" —
is unenforceable as stated: export is required for factory nameability
(composition.md, "An output type must be exported…"), 265 of 340 shipped
patterns do it, and the refusal reproduces same-file with no import at all
(the walkthrough fixture's board stores `NoteOutput[]` from the same module).
The enforceable joint is symbol embedding, not export.

This PR began as a draft prototyping the mechanical halves while the
decision was open. The brief has since merged (#5682), and what is here is
the substrate the ratified design names: demand markers recorded in the
shape, the embedding rule at its enforceable joint, and the gate treating a
given-up demand as narrowing.

## What Changed

**`Demand<T>`** (`packages/api`): a phantom-branded wrapper in the
`Scoped<T>` style. A holder writes
`notes?: Writable<Demand<NotePreview>[] | Default<[]>>` and the generated
schema carries `demand: true` on the marked subtree.

- `schema-generator`: `Demand` resolves by node or aliasSymbol exactly like
  the scope wrappers. The stamp rides the REFERENCING node
  (`{ $ref, demand: true }`), so a shared def stays neutral and each use site
  declares its own demand-ness — the same placement rule as `asCell` on
  verbs. `Demand<Demand<T>>` collapses to one demand.
- `piece`: `demand` joins `ANNOTATION_KEYS` — validation-neutral, free to add
  and remove across updates, classified BEFORE the generator emits it
  anywhere (the C3 append-only lesson).
- `ts-transformers`: `Demand` joins the alias-preservation list in
  `shouldPreserveBindingDeclaredTypeNode` so shrinking keeps the alias node
  visible to the generator.

**Foreign-output embedding check** (`ts-transformers`): at every
`pattern<I, O>` call, after schema resolution, an advisory warning
(`contract:foreign-output-embedding`) fires when the argument contract
embeds a type that is the Output-position type argument of a DIFFERENT
pattern factory anywhere in the program. Argument side only, per review
ruling: result-side re-exposure is the documented composition shape, and
that branch returns when Fabric-types makes result contracts load-bearing.

This check is structurally unlike the transformers around it — read-only,
program-scoped, and about a design rule rather than compiler correctness —
so it lives behind a new **contract-lint boundary** (`src/lints/`) rather
than inside the rewriting pipeline: lints are pure detection returning
findings; severity is mapped in the registry's policy table (advisory by
default — the strictness ladder later changes policy, not detectors);
`schema-injection` calls one `runContractLints` hook; and hard enforcement
is reserved for the CI gates that already collect these diagnostics from
the compiles they run — the compiler informs about policy, it enforces
only correctness.

- Output symbols are collected program-wide once, WeakMap-cached per
  `ts.Program`.
- Self-reference stays silent (a pattern's own type-argument symbols are
  excluded): `children: TreeNodeOutput[]` remains the documented shape.
- A provider opts a genuine protocol type out with a `@sharedContract` JSDoc
  tag on its declaration.
- The argument side walks the ORIGINAL declared node — capability shrinking
  may already have replaced the emission node with a synthetic literal.

**Demand-narrowing gate rule** (`packages/piece`, leg 2 — the gate half of
the brief's "how a deployed holder moves" question): in evolution mode,
argument role, a property the candidate no longer names beneath a demand
marker BOTH contracts carry is treated as a demand given up — narrowing,
which plain subset logic already proves safe — rather than the removal the
gate refuses elsewhere. Giving up a whole property whose deployed node is
the demand is the same narrowing. One-sided markers get no exemption
(mirroring the verb-event rule: "a one-sided marker is a shape change the
ordinary rules judge, not an exemption"), verb-event subtrees keep their
own rules, the result role stays strict (what a pattern re-exposes from a
demand is still something readers rely on), and the allowance rides the
same evolution-policy guard as the existing allowances.

## What this is not

- **The gate change is exactly one rule.** Leg 2 relaxes only the
  evolution-mode removal refusal, only in the argument role, only beneath
  two-sided demand markers. Retypes, required-ness, verb events, the result
  role, and durable-link proofs are untouched. The reverse index an impact
  report needs is still not built here.
- The check catches direct references, aliases, unions, arrays, and type
  arguments to depth 8. `Pick`/`Omit`-derived and mapped shapes are TODO;
  critique-guide category 17 still covers what the walk misses.
- Input-position embedding (importing a foreign `FooInput`) is out of scope.
- The schema-argument form (`pattern(fn, inputSchemaLiteral)`) is outside
  the embedding check: a hand-authored schema literal has no type-symbol
  provenance to index — the same boundary the transformer's schema stamps
  draw (hand-authored literals in that position are never stamped either).
- Warning severity throughout: nothing fails anyone's build while this is a
  prototype.

## Review response (Mike, 2026-08-14)

1. **Link proofs**: `LINK_PATH_SAFE_ANCESTOR_KEYS` now derives from
   `ANNOTATION_KEYS` (union with the structural keys) — `deprecated`,
   `tier`, and `demand` each missed the hand list in turn; two tests pin
   links proving beneath demand- and deprecated-marked ancestors, and the
   mapping spec's registry note names the derivation.
2. **End-to-end seam**: the walkthrough fixture now IS the seam — plus a
   pipeline test compiling real `Demand<T>` to `demand: true` on the
   referencing node, and a `shouldPreserveBindingDeclaredTypeNode` pin.
   Found en route: `StripCell`'s homomorphic map re-exposed the brand as a
   private name on every exported factory; it now erases the demand brand
   the way Default's machinery strips its own.
3. Confirmed as designed; no change.
4. **Two-step becomes loud**: `collectNewDemandDeclarationAdvisories`
   names every argument node an update newly declares a demand, rides the
   existing compatibility review as a non-blocking `advisories` slot, and
   logs through `piece.update`. Two-sidedness is documented as a timing
   requirement throughout.
5. **Argument-side only**: the result branch is dropped; the self-reference
   exemption keys on the result contract's root symbol and is pinned from
   the argument side.
6. **Fixture converted**: the board demands `Demand<NotePreview>[]` —
   title only — `@sharedContract` is gone from `NoteOutput`, and the tag's
   docs now reserve it for genuine protocol types with `MentionablePiece`
   as the exhibit.
7. **Docs ride along**: composition.md and critique category 17 teach
   `Demand<T>`/`@sharedContract`; `verb-evolution.md` records the decided
   half of its open question.

## Test plan

- New `packages/schema-generator/test/demand-wrapper.test.ts` (3 steps): the
  stamp rides the `$ref` while the hoisted def stays neutral; array-element
  demands; nested collapse.
- New `packages/ts-transformers/test/foreign-output-embedding.test.ts`
  (4 steps): warns on a foreign embed (argument side, message names the type
  and the remedy); silent for a consumer-owned narrow type, for
  self-reference, and for `@sharedContract`.
- New 7-step "demand-marked narrowing" block in
  `packages/piece/test/schema-compatibility.test.ts`: the drop is allowed
  beneath a two-sided marker and refused without one, refused with a
  candidate-only marker (the two-sided condition is a TIMING requirement —
  the declaration must predate the drop by one deploy; the marker is a
  self-declaration the gate cannot verify), whole-demand giveup allowed,
  result role still strict, retypes still checked, verb-event rules still
  win.
- Full suites, each run from its package directory: piece 38 ✓ (456
  steps), schema-generator 53 ✓ (226 steps), ts-transformers 1138 ✓ (759
  steps). (Running from the repo root instead trips pre-existing
  cwd-relative fixture paths in two suites — unrelated to this change.)
- `deno fmt --check` clean on all touched files (clean main carries 22
  pre-existing unformatted files, untouched here); `deno lint` clean scoped
  to the four packages.
- `pattern-compat` smoke: `--only reading-list` (a known embedder — compiles
  under the new warning, baselines still pass) and `--only bookmarks`
  (neutral). The full fleet runs in this PR's CI shards.

Part of the verb-evolution discussion: #5682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
