### PR TITLE
OW61: the replica ABSORBS a doc whose cid schema arrives later, instead of dismissing it

### DIFF
--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -7523,9 +7523,10 @@ supply; OW29/OW32/OW34 closed):
     was asked "why do we still need this approach" and could not
     answer from the boards it had). PR #6262 = main + the
     resume-watermark fix ALONE + the lane flip, with no park, no
-    pull and no escalation in the tree. Result: FIVE pattern shards
-    red (1, 2, 6, 9, 10) and package runtime-client red — against
-    board 4's single red shard and 3/3 package lanes. So the two
+    pull and no escalation in the tree. Result: SIX pattern shards
+    red (1, 2, 6, 8, 9, 10 — only 3, 4, 5 and 7 green) and package
+    runtime-client red — against board 4's single red shard and 3/3
+    package lanes. So the two
     halves are COMPLEMENTARY, not redundant, and the client-side
     absorb machinery stays: the server fix stops the delivery model
     from lying about what a resumed client holds, and the client fix

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -7433,6 +7433,41 @@ supply; OW29/OW32/OW34 closed):
     whole closure where one document would do; it was built that way
     only because the investigation's mandate fenced the server side
     off.
+    BOARD 3 (the resync made UPSERTS-ONLY): EIGHT of ten pattern
+    shards green and 3/3 package lanes — the ON lanes' progression
+    across four boards at the true topology is 2 -> 2 -> 4 -> 8
+    shards, 1/3 -> 3/3 -> 3/3 -> 3/3 package lanes. Board 2 had
+    caught the escalation HARMING what it was meant to help: pattern
+    shard 7, green on board 1, failed on board 2 inside
+    `shopping-list.tsx` (`hasTags is not a function`, destructured
+    undefined) — data vanishing under a live pattern, because
+    `buildFullSync` derives its removes by diffing the session cache
+    against the freshly evaluated closure, so a legitimately
+    different closure carries removes for documents a running
+    consumer still reads. The resync is a REPAIR and never a
+    watch-set authority; it now applies upserts only, and shard 7
+    returned to green with 4, 5 and 9 joining it. TWO RESIDUALS, both
+    diagnosed, neither closed:
+    (a) SHARD 6 is STILL THIS DEFECT — `cid:fid1:zgJY1m9lR0…` missing
+    64 times in one run with ZERO `schema-closure-resync-failed`, so
+    the escalation fires and still does not obtain the document. The
+    suspected floor beneath the floor is the GRAPH-level staging this
+    row already describes ("stages a closure doc only while the
+    tracked graph has never delivered it"): a second elision layer
+    that a full `watch.set` does not clear either, which would mean
+    NO request a client can make recovers the document. Unverified —
+    it is the next thing to pin.
+    (b) SHARD 10 is NOT this defect: its degradation gate fails
+    because `PatternManager.writeBackCompileCache`
+    (`runner/src/pattern-manager.ts` :2208) throws the `/sourceMap`
+    CFC prepare abort — #6248's third signature, outside the delivery
+    path, and its own scope decision.
+    The other two signatures #6248 recorded are GONE from every
+    failing shard (`Failed to create or find default pattern` and
+    `No data at cell` both at zero), which retires #6248's
+    attribution of its whole board to the quarantine: part of that
+    residue was a second blast radius, and part of it — shard 7's —
+    was this fix's own.
 
   - **OW62 — adopt-not-start: the piece-open seam is where the ON
     execution model's "one starter per piece" has to land. POST-FLIP

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -7287,6 +7287,79 @@ supply; OW29/OW32/OW34 closed):
     true never-fires net), and any live `schema-doc-quarantine` log
     — each occurrence is evidence for that investigation, not a
     server-side hole.
+    ABSORB-CONTRACT FIX (the investigation session, this row's
+    second closing PR): the dismissal is LOCATED and CLOSED, and it
+    is not an interleaving — it is unconditional. The arrival
+    validator met a document naming an unresolved `cid:` schema by
+    DROPPING it, and the only heal on offer was a re-delivery of that
+    document (the FULL evaluation: watch.set, reconnect). Under the
+    elision the owner's reversal restored, an unchanged document is
+    never re-sent mid-session, so the drop was permanent for the
+    session: the client had dismissed information the server had sent
+    and would never send again. That is the owner's contract broken
+    on the plain path, with no race required — the reason CI's
+    delivery-window timing decided whether it fired is only that the
+    timing decides whether a mention ever precedes its cid, not
+    whether the drop is recoverable. Watched red at `4ac3b2e70` by
+    the register's new pin
+    (`runner/test/schema-doc-sync.test.ts`, "absorbs a doc whose cid
+    arrives in a LATER frame, with no re-delivery of the doc"): frame
+    one carries the mentioning doc, frame two carries ONLY the cid —
+    the elision shape, the sole further information the session ever
+    gets — and the doc stayed absent. The fix ABSORBS instead: an
+    entry whose refs cannot resolve yet is PARKED verbatim
+    (`#parkedOnSchemaClosure`) against the hashes it waits on, and
+    RELEASED — re-entering `applySessionSync`, so it is re-validated
+    and a stale park can never install unverified content — as soon
+    as those hashes resolve from any later frame; the drain is
+    iterative (a released entry may be the schema document that frees
+    the next) and bounded by the park's size. What stays parked names
+    a document this replica has never seen, so it is PULLED
+    (`hydrateParkedSchemaClosures`) — the answer
+    `hydrateArrivedCfcSchemaRefs` already gave for the `/cfc`
+    metadata refs these link-position refs sit beside, which is why
+    the two ref classes had opposite answers to one question. A
+    FORGED replacement for a content-addressed id stays a hard drop
+    (no later arrival makes it applicable). Fail-closed is UNCHANGED:
+    a parked doc is not visible, and the `schema-doc-quarantine`
+    diagnostic stands. CONSEQUENCE FOR THE CONTAINMENT: it is NOT
+    retired and must not be — the park makes the compliant path
+    self-healing rather than dependent on perfect retention, so the
+    containment is now the net under a genuinely absent document (a
+    hash the server never installed) and under any future producer
+    bug. Its ensure-driven pin still passes unchanged, because that
+    simulation drops cid upserts on EVERY frame including the
+    hydration pull's answer. RETENTION, examined and NOT patched: no
+    path was found by which a cid this replica applied later
+    disappears from it — `applySessionSync`'s
+    `upsert.seq < record.confirmed.seq` skip is harmless for content-
+    addressed docs (the content cannot differ), and `reset()`'s
+    `#docs.clear()` has one caller (`replaceProvisionalReplica`),
+    which builds the replacement replica on a FRESH session whose
+    delivery cache re-ships the closure. Retention hardening was
+    therefore left unbuilt rather than added without a red pin; the
+    park+pull makes it moot for correctness either way. RULED OUT as
+    the OW61 mechanism, each with evidence:
+    `experimentalConcurrentWatchRefresh`'s deferred watch-response
+    apply (a real ordering inversion, but the flag is DEFAULT OFF and
+    was off on the board); `handleEffect` with a null `#watchView`
+    (`WatchView.fromSync` absorbs with `emit:false`, so the frame
+    reaches no consumer — but both nulling sites set `#closed` first
+    and `handleEffect` returns early on it, so it is unreachable
+    while open); and the runner's `#updatePromises.size === 0`
+    consumer gate (harmless, because `watchAddSync` REUSES
+    `#watchView` rather than handing back a fresh instance).
+    STANDING HAZARD, reported not fixed (outside this row's fix and
+    deliberately pinned as-is today): `refreshWatchSet`'s
+    `view.close()` on a failed frame closes the SHARED WatchView —
+    its comment reasons about a per-refresh view that the client's
+    reuse means does not exist — which would silence every later push
+    frame for the session. The quarantine and the park together mean
+    `applySessionSync` no longer throws for the schema class, so the
+    path is far less reachable; it wants the coordinator's call
+    because `runner/test/schema-doc-sync.test.ts`'s "closes the
+    staged watch view when a frame fails validation" pins the current
+    behavior on purpose.
 
   - **OW62 — adopt-not-start: the piece-open seam is where the ON
     execution model's "one starter per piece" has to land. POST-FLIP

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -7469,8 +7469,12 @@ supply; OW29/OW32/OW34 closed):
     residue was a second blast radius, and part of it — shard 7's —
     was this fix's own.
     THE FLOOR UNDER THE FLOOR, and OW61's last delivery-side
-    mechanism: `session.entities` records what the server SENT, not
-    what the client HOLDS, and it commits when a frame is BUILT. A
+    mechanism: `session.entities` is the server's MODEL OF WHAT THE
+    CLIENT HOLDS — not a transmission log (a refresh pass caches
+    every entry it recomputes, including ones the wire frame omits
+    precisely because the model already claims them) — and it
+    advances when a frame is BUILT, on the assumption that the frame
+    arrives. Nothing validated that assumption. A
     socket that dies mid-flight loses frames the server counts as
     delivered — `rollbackUndeliveredSync` repairs only a
     locally-throwing send, as its own comment concedes — so the cache
@@ -7490,10 +7494,14 @@ supply; OW29/OW32/OW34 closed):
     retransmission to a client that holds the data, and the elision
     the reversal ruling protects is untouched — a caught-up resume
     takes the incremental path exactly as before. Pinned both
-    directions and mutation-checked
-    (`memory/test/v2-session-resume-watermark.test.ts`): with the
-    flag unset the behind-resume step fails while the caught-up step
-    still passes. BOARD 4: NINE of ten pattern shards green, 3/3
+    registry cases
+    (`memory/test/v2-session-resume-watermark.test.ts`: a resume
+    BEHIND its last synced seq arms the flag, a caught-up resume does
+    not — the pair guards against a blanket always-true). The
+    discrimination itself was established by a manual mutation of the
+    flag assignment, which reds the behind case and leaves the
+    caught-up case green; that check is not itself recorded
+    coverage. BOARD 4: NINE of ten pattern shards green, 3/3
     package lanes. Shard 6 — the residual board 3 could not explain,
     the same cid unhealed with the escalation firing and reporting no
     error — went GREEN, which settles what it was: reconnects were
@@ -7509,6 +7517,23 @@ supply; OW29/OW32/OW34 closed):
     path, with `Failed to create or find default pattern` and `No
     data at cell` both at ZERO across every lane. It is #6248's own
     scope decision, not OW61's.
+    ABLATION, run because four cumulative boards prove only that
+    each fix helped GIVEN the ones before it — never that the earlier
+    ones are still load-bearing once the last lands (the coordinator
+    was asked "why do we still need this approach" and could not
+    answer from the boards it had). PR #6262 = main + the
+    resume-watermark fix ALONE + the lane flip, with no park, no
+    pull and no escalation in the tree. Result: FIVE pattern shards
+    red (1, 2, 6, 9, 10) and package runtime-client red — against
+    board 4's single red shard and 3/3 package lanes. So the two
+    halves are COMPLEMENTARY, not redundant, and the client-side
+    absorb machinery stays: the server fix stops the delivery model
+    from lying about what a resumed client holds, and the client fix
+    is what survives the window before a reconnect (and covers
+    runtime-client, which board 1 had already shown the absorb fix
+    alone takes from red to green). A shrink of this row's PR to the
+    one-line server change was the alternative on the table; the
+    ablation is the evidence against it.
 
   - **OW62 — adopt-not-start: the piece-open seam is where the ON
     execution model's "one starter per piece" has to land. POST-FLIP

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -7360,6 +7360,38 @@ supply; OW29/OW32/OW34 closed):
     because `runner/test/schema-doc-sync.test.ts`'s "closes the
     staged watch view when a frame fails validation" pins the current
     behavior on purpose.
+    REPRODUCTION, at the true topology: PR #6248's ensure-ON board is
+    the defect's best evidence and supersedes the original 13-file
+    crash board for this purpose — 1069 `schema-doc-quarantine` lines
+    across TEN lanes (pattern shards 1/2/4/6/7/8/9/10, package
+    runtime-client 249, package shell 13), ZERO worker kills, and the
+    quarantined pair byte-for-byte the board's original
+    (`computed:fid1:7BycCyHc…` / `cid:fid1:zgJY1m9lR0…`). Every
+    failure signature there is DOWNSTREAM of a doc that never applied:
+    `Failed to create or find default pattern`
+    (`piece/src/ops/pieces-controller.ts` :1762), `[alice] No data at
+    cell`, the `/sourceMap` CFC prepare abort, and the shell lane's
+    30-minute hang. That board is the containment working exactly as
+    shipped AND the dismissal costing the lanes their data — the two
+    halves of OW61 separated cleanly. Modeling its shape as a pin (the
+    cid installed in the space, elided for the session, the mentioning
+    doc unrecoverable) caught TWO defects in this fix, either of which
+    would have left that board red: (a) the release never ran after a
+    PULL, because `pull()` installs its documents directly rather than
+    through `applySessionSync`, so the frame-end hook never saw the
+    delivery the park was waiting for — the pull now releases on
+    completion, and its residency check, not its result, decides
+    whether to re-arm (a pull can report a connection error and still
+    have delivered); (b) the supersede rule discarded LIVE parks,
+    because a seq-0 absent-doc marker — the "no confirmed version"
+    answer to a pull, not a newer version — counted as a newer
+    arrival, so a sink's own pull for the not-yet-applied doc evicted
+    the park waiting to supply it; superseding now happens only where
+    a real delivery lands (seq > 0), plus on a remove. NOTE for
+    anyone reading a future ON board: with this fix a
+    `schema-doc-quarantine` line no longer means the doc was dropped —
+    it is held and healing, so the line is expected and the lane's
+    colour, not the quarantine count, is the health metric.
 
   - **OW62 — adopt-not-start: the piece-open seam is where the ON
     execution model's "one starter per piece" has to land. POST-FLIP

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -7468,6 +7468,47 @@ supply; OW29/OW32/OW34 closed):
     attribution of its whole board to the quarantine: part of that
     residue was a second blast radius, and part of it — shard 7's —
     was this fix's own.
+    THE FLOOR UNDER THE FLOOR, and OW61's last delivery-side
+    mechanism: `session.entities` records what the server SENT, not
+    what the client HOLDS, and it commits when a frame is BUILT. A
+    socket that dies mid-flight loses frames the server counts as
+    delivered — `rollbackUndeliveredSync` repairs only a
+    locally-throwing send, as its own comment concedes — so the cache
+    goes on claiming documents the client never received and the next
+    diff elides exactly those. A schema document elided that way is
+    unobtainable, which is what made this class terminal rather than
+    transient. The repair input was already on the wire and being
+    DISCARDED: a resuming client reports the highest server seq it
+    actually received (`client.ts` `reopen`, `seenSeq:
+    this.#serverSeq`), and `session-registry.ts` took
+    `Math.max(existing.seenSeq, client.seenSeq)` — throwing away the
+    only case that matters, a client admitting it is BEHIND. When
+    that report is below this session's `lastSyncedSeq`, the frames
+    between were sent and lost, and the next pass now routes through
+    the full evaluation (`forceFullResync`, existing machinery) that
+    re-ships the whole assembled state. No new protocol, no
+    retransmission to a client that holds the data, and the elision
+    the reversal ruling protects is untouched — a caught-up resume
+    takes the incremental path exactly as before. Pinned both
+    directions and mutation-checked
+    (`memory/test/v2-session-resume-watermark.test.ts`): with the
+    flag unset the behind-resume step fails while the caught-up step
+    still passes. BOARD 4: NINE of ten pattern shards green, 3/3
+    package lanes. Shard 6 — the residual board 3 could not explain,
+    the same cid unhealed with the escalation firing and reporting no
+    error — went GREEN, which settles what it was: reconnects were
+    live in those lanes, and the lost-frame-on-resume class was the
+    cause. (The reasoning that a reliable ordered socket means no
+    loss without death, so resume could not be implicated, was WRONG;
+    this board is what corrected it.) Full ON-lane progression across
+    five boards: 2 -> 2 -> 4 -> 8 -> 9 pattern shards, 1/3 -> 3/3
+    package lanes. THE LAST RESIDUAL IS NOT THIS DEFECT: shard 10's
+    degradation gate dies on `PatternManager.writeBackCompileCache`
+    (`runner/src/pattern-manager.ts` :2208) throwing the `/sourceMap`
+    CFC prepare abort — #6248's third signature, outside the delivery
+    path, with `Failed to create or find default pattern` and `No
+    data at cell` both at ZERO across every lane. It is #6248's own
+    scope decision, not OW61's.
 
   - **OW62 — adopt-not-start: the piece-open seam is where the ON
     execution model's "one starter per piece" has to land. POST-FLIP

--- a/docs/specs/server-side-execution/verification-coverage.md
+++ b/docs/specs/server-side-execution/verification-coverage.md
@@ -7392,6 +7392,47 @@ supply; OW29/OW32/OW34 closed):
     `schema-doc-quarantine` line no longer means the doc was dropped —
     it is held and healing, so the line is expected and the lane's
     colour, not the quarantine count, is the health metric.
+    THE FLOOR, found on the verification board (#6260 = this fix
+    under #6248's flip) and NOT a client defect: a pull issues
+    `session.watch.add`, and `watchAdd` DIFFS its answer against the
+    session's delivery cache (`memory/v2/server.ts` ~:3649,
+    `!sameSnapshot(session.entities…)`) — so a document the cache
+    claims delivered is elided EVEN WHEN THE REQUEST NAMES IT AS A
+    ROOT. Once the cache and a replica disagree about a document, the
+    replica cannot obtain it by asking: the frame comes back empty,
+    every time. That is the cache-claims-sent-but-never-sent shape,
+    and it is why the original board's clients could never recover —
+    the absorb fix's park+pull cleared every lane whose consumer
+    WAITS (package runtime-client, 249 quarantines on #6248, and
+    package shell, a 30-minute hang — both green on board 1) and
+    could not clear the ones that need the document to actually
+    arrive, whose logs show ONE cid missing 48 times in a single
+    shard. `watch.set` is the way back and needs no change to the
+    elision: `buildFullSync` (memory/v2/server-sync.ts) maps EVERY
+    entry to an upsert, diffing only removes, which is exactly the
+    "full evaluation" the quarantine diagnostic already names and
+    that nothing was reaching. The park therefore ESCALATES — a pull
+    that completes WITHOUT its document is the disagreement's
+    signature, not an absent document, so the replica requests one
+    full re-evaluation (`Session.resyncWatchSet`, single-flight) and
+    drains the park behind it. Pinned red-first ("ESCALATES to a full
+    evaluation when the session cache claims the cid was delivered
+    and the pull comes back empty"), mutation-checked against a
+    stubbed escalation. BOARD PROGRESSION on the ON lanes, all three
+    at the true topology: #6248 (no fix) 2 pattern shards green, 1 of
+    3 package lanes green; board 1 (absorb fix) 2 shards, 3 of 3
+    package lanes; board 2 (plus escalation) 4 shards (1, 2, 3, 8), 3
+    of 3 package lanes. Real movement, NOT closure — six shards (4,
+    5, 6, 7, 9, 10) still red and undiagnosed, so OW61 stays OPEN and
+    #6248 stays blocked on it. OWNER'S CALL WANTED, recorded here
+    because it is cheaper than what was built: making `watchAdd` not
+    elide a document the request explicitly NAMES as a root would fix
+    this at the seam, and answering a direct request for one named
+    document is not the "retransmit the schemas all the time" the
+    reversal ruling objected to. The client-side escalation re-ships a
+    whole closure where one document would do; it was built that way
+    only because the investigation's mandate fenced the server side
+    off.
 
   - **OW62 — adopt-not-start: the piece-open seam is where the ON
     execution model's "one starter per piece" has to land. POST-FLIP

--- a/packages/memory/test/v2-client-watch.test.ts
+++ b/packages/memory/test/v2-client-watch.test.ts
@@ -381,17 +381,29 @@ Deno.test("memory v2 resyncWatchSet re-ships the whole closure, and answers unde
     await writer.transact({
       localSeq: 1,
       reads: { confirmed: [], pending: [] },
-      operations: [{
-        op: "set",
-        id: "of:resync:1",
-        value: { value: { hello: "resync" } },
-      }],
+      operations: [
+        {
+          op: "set",
+          id: "of:resync:1",
+          value: {
+            value: {
+              hello: "resync",
+              child: { "/": { "link@1": { id: "of:resync:2", path: [] } } },
+            },
+          },
+        },
+        {
+          op: "set",
+          id: "of:resync:2",
+          value: { value: { hello: "descendant" } },
+        },
+      ],
     });
     await watcher.watchSet([{
       id: "root",
       kind: "graph",
       query: {
-        roots: [{ id: "of:resync:1", selector: { path: [], schema: false } }],
+        roots: [{ id: "of:resync:1", selector: { path: [], schema: true } }],
       },
     }]);
 
@@ -401,8 +413,8 @@ Deno.test("memory v2 resyncWatchSet re-ships the whole closure, and answers unde
     // document the cache wrongly believes a replica holds.
     const again = await watcher.resyncWatchSet();
     assertEquals(
-      again?.sync.upserts.map((upsert) => upsert.id),
-      ["of:resync:1"],
+      again?.sync.upserts.map((upsert) => upsert.id).sort(),
+      ["of:resync:1", "of:resync:2"],
     );
   } finally {
     await watcher.close();

--- a/packages/memory/test/v2-client-watch.test.ts
+++ b/packages/memory/test/v2-client-watch.test.ts
@@ -353,3 +353,62 @@ Deno.test("memory v2 session closed mid-watch-set arms no ack timer", async () =
     await server.close();
   }
 });
+
+Deno.test("memory v2 resyncWatchSet re-ships the whole closure, and answers undefined when there is no watch set", async () => {
+  const server = new Server({
+    ...testSessionOpenServerOptions,
+    store: new URL("memory://memory-v2-client-resync"),
+    subscriptionRefreshDelayMs: 0,
+  });
+  const writerClient = await connect({ transport: loopback(server) });
+  const watcherClient = await connect({ transport: loopback(server) });
+  const space = "did:key:z6Mk-memory-v2-client-resync";
+  const writer = await writerClient.mount(
+    space,
+    {},
+    testSessionOpenAuthFactory,
+  );
+  const watcher = await watcherClient.mount(
+    space,
+    {},
+    testSessionOpenAuthFactory,
+  );
+
+  try {
+    // No watch set yet: nothing to re-establish.
+    assertEquals(await watcher.resyncWatchSet(), undefined);
+
+    await writer.transact({
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: "of:resync:1",
+        value: { value: { hello: "resync" } },
+      }],
+    });
+    await watcher.watchSet([{
+      id: "root",
+      kind: "graph",
+      query: {
+        roots: [{ id: "of:resync:1", selector: { path: [], schema: false } }],
+      },
+    }]);
+
+    // A DIFFED answer would be empty here — the session cache already
+    // holds this entry from the watch.set above. The full evaluation
+    // re-ships it, which is what makes it the recovery path for a
+    // document the cache wrongly believes a replica holds.
+    const again = await watcher.resyncWatchSet();
+    assertEquals(
+      again?.sync.upserts.map((upsert) => upsert.id),
+      ["of:resync:1"],
+    );
+  } finally {
+    await watcher.close();
+    await writer.close();
+    await watcherClient.close();
+    await writerClient.close();
+    await server.close();
+  }
+});

--- a/packages/memory/test/v2-session-resume-watermark.test.ts
+++ b/packages/memory/test/v2-session-resume-watermark.test.ts
@@ -1,0 +1,54 @@
+import { assertEquals } from "@std/assert";
+import { SessionRegistry } from "../v2/session-registry.ts";
+
+// The sent-vs-held reconciliation on resume. `session.entities` records
+// what the server SENT, not what the client HOLDS, and it is committed
+// when a frame is built. A socket that dies mid-flight loses frames the
+// server counts as delivered — `rollbackUndeliveredSync` only repairs a
+// locally-throwing send — so the cache keeps claiming documents the
+// client never received, and the next diff elides exactly those. A
+// schema document elided that way is unobtainable: a watch.add answers
+// from the same cache, and no later frame re-stages it.
+//
+// The repair input is already on the wire: a resuming client reports the
+// highest server seq it actually received.
+Deno.test("a resume behind the last synced seq forces a full re-evaluation", () => {
+  const registry = new SessionRegistry();
+  const space = "did:key:z6Mk-resume-watermark";
+
+  const opened = registry.open(space, { sessionId: "s:1" }, 0);
+  assertEquals(registry.get(space, "s:1")?.forceFullResync, false);
+
+  // The server syncs this session out to seq 150.
+  const stored = registry.get(space, "s:1")!;
+  stored.lastSyncedSeq = 150;
+  stored.seenSeq = 150;
+
+  // The client comes back saying it only ever received through 100:
+  // frames 101..150 were sent and lost. The cache still claims them.
+  registry.open(
+    space,
+    { sessionId: "s:1", sessionToken: opened.sessionToken, seenSeq: 100 },
+    150,
+  );
+  assertEquals(registry.get(space, "s:1")?.forceFullResync, true);
+});
+
+Deno.test("a resume that is caught up does not force a re-evaluation", () => {
+  const registry = new SessionRegistry();
+  const space = "did:key:z6Mk-resume-watermark-caught-up";
+
+  const opened = registry.open(space, { sessionId: "s:2" }, 0);
+  const stored = registry.get(space, "s:2")!;
+  stored.lastSyncedSeq = 150;
+  stored.seenSeq = 150;
+
+  // The client reports exactly what the server sent it: nothing lost,
+  // so the incremental path stands and no closure is re-shipped.
+  registry.open(
+    space,
+    { sessionId: "s:2", sessionToken: opened.sessionToken, seenSeq: 150 },
+    150,
+  );
+  assertEquals(registry.get(space, "s:2")?.forceFullResync, false);
+});

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -861,6 +861,28 @@ export class SpaceSession {
     );
   }
 
+  /**
+   * Re-establish the CURRENT watch set as a FULL evaluation.
+   *
+   * `watch.add` answers from the session's delivery cache: an entry the
+   * cache already claims delivered is diffed out, even when the request
+   * names that document as a root. So a replica that does not hold a
+   * document the cache believes it has cannot obtain it by asking for
+   * it — the pull returns an empty frame. `watch.set` is the way back:
+   * the server rebuilds the assembled closure and ships all of it
+   * (`buildFullSync` maps every entry, diffing only removes), which is
+   * the "full evaluation" the arrival validator's quarantine
+   * diagnostic points at. Resolves undefined when there is no watch
+   * set to re-establish.
+   */
+  async resyncWatchSet(): Promise<WatchMutationResult | undefined> {
+    this.#assertOpen();
+    if (this.#watchSpecs.length === 0) {
+      return undefined;
+    }
+    return await this.watchSetSync([...this.#watchSpecs]);
+  }
+
   async watchAdd(watches: WatchSpec[]): Promise<WatchView> {
     this.#assertOpen();
     const hadView = this.#watchView !== null;

--- a/packages/memory/v2/session-registry.ts
+++ b/packages/memory/v2/session-registry.ts
@@ -118,10 +118,29 @@ export class SessionRegistry {
         `session ${sessionId} resume token is no longer valid`,
       );
     }
+    const clientSeenSeq = session.seenSeq ?? 0;
     const seenSeq = Math.max(
       existing?.seenSeq ?? 0,
-      session.seenSeq ?? 0,
+      clientSeenSeq,
     );
+    // A resuming client reports the highest server seq it actually
+    // RECEIVED. When that is behind what this session was last synced
+    // to, the frames in between were sent but never arrived — a socket
+    // that dies mid-flight loses "successfully sent" frames, and only a
+    // locally-throwing send is visible in-process for
+    // `rollbackUndeliveredSync` to repair. The delivery cache still
+    // records those documents as delivered, so the next diff would
+    // elide exactly the ones the client is missing, and a schema
+    // document elided that way is unobtainable: the client cannot ask
+    // for it (a watch.add answers from the same cache) and no later
+    // frame re-stages it.
+    //
+    // The client's report is the authority on what it holds, so trust
+    // it and route the next pass through a FULL evaluation, which
+    // re-ships the whole assembled state and puts sent back in step
+    // with held.
+    const missedDelivery = existing !== undefined &&
+      clientSeenSeq < existing.lastSyncedSeq;
     const sessionToken = nextSessionToken();
     const revokedConnectionId = existing?.ownerConnectionId !== undefined &&
         existing.ownerConnectionId !== null &&
@@ -141,7 +160,7 @@ export class SessionRegistry {
         trackedIdsFromEntries(existing?.entities?.values() ?? []),
       caughtUpLocalSeq: existing?.caughtUpLocalSeq ?? 0,
       pendingCaughtUpLocalSeq: existing?.pendingCaughtUpLocalSeq ?? 0,
-      forceFullResync: existing?.forceFullResync ?? false,
+      forceFullResync: (existing?.forceFullResync ?? false) || missedDelivery,
       ...(existing?.leaseHolderReads === true
         ? { leaseHolderReads: true }
         : {}),

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -5530,6 +5530,7 @@ class SpaceReplica implements ISpaceReplica {
             overlay.delete(referrer);
             changed = true;
             logger.error("schema-doc-quarantine", () => [
+              `[${this.#space}] ` +
               `Document ${referrer} names schema document cid:${dep}, ` +
               `which is not delivered and verified in this replica ` +
               `(docs/specs/content-addressed-schemas.md). The document ` +
@@ -5906,6 +5907,11 @@ class SpaceReplica implements ISpaceReplica {
           this.#parkedOnSchemaClosure.delete(key);
         }
         if (releasable.length === 0) break;
+        logger.error("schema-doc-released", () => [
+          `[${this.#space}] releasing ${releasable.length} held ` +
+          `document(s) whose schema refs now resolve: ` +
+          releasable.map((upsert) => String(upsert.id)).join(", "),
+        ]);
         this.applySessionSync({
           type: "sync",
           fromSeq: 0,

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -5530,15 +5530,19 @@ class SpaceReplica implements ISpaceReplica {
             overlay.delete(referrer);
             changed = true;
             logger.error("schema-doc-quarantine", () => [
-              `Document ${referrer} was delivered with a broken schema ` +
-              `ref: cid:${dep} is not delivered and verified in this ` +
-              `replica. Every delivered document's refs must resolve ` +
-              `within the delivered set ` +
+              `Document ${referrer} names schema document cid:${dep}, ` +
+              `which is not delivered and verified in this replica ` +
               `(docs/specs/content-addressed-schemas.md). The document ` +
-              `is quarantined — this replica keeps its previous state ` +
-              `for it until the next full evaluation (a watch.set or ` +
-              `reconnect) re-delivers it with its closure. This ` +
-              `indicates a client-side absorb/ordering defect ` +
+              `is HELD, not dropped: this replica keeps its previous ` +
+              `state for it, pulls the named schema document, and — if ` +
+              `the session's delivery cache answers that pull empty — ` +
+              `requests a full re-evaluation; the held document applies ` +
+              `as soon as the reference resolves. A line here is ` +
+              `therefore expected during recovery and is not by itself ` +
+              `a failure. It becomes one if it REPEATS for the same ` +
+              `pair, which means the recovery is not converging: either ` +
+              `a client-side absorb/ordering defect or a schema ` +
+              `document the producer never installed ` +
               `(verification-coverage.md OW61).`,
             ]);
           }
@@ -5708,12 +5712,20 @@ class SpaceReplica implements ISpaceReplica {
       // version, and treating it as one discards a park that is still
       // waiting (the sink's own pull for a not-yet-applied doc).
       if (upsert.seq > 0 && this.#parkedOnSchemaClosure.size > 0) {
-        this.#parkedOnSchemaClosure.delete(
-          docKey(
-            upsert.id as URI,
-            this.instanceKey(upsert.scope, undefined, upsert.scopeKey),
-          ),
+        const parkedKey = docKey(
+          upsert.id as URI,
+          this.instanceKey(upsert.scope, undefined, upsert.scopeKey),
         );
+        const parked = this.#parkedOnSchemaClosure.get(parkedKey);
+        // Supersede only with a revision at least as new as the parked
+        // one. A watch refresh can carry an OLDER seq than a revision
+        // already parked (the monotonicity guard above exists for
+        // exactly that), and dropping the park for it would discard the
+        // newer revision permanently — the schema's later arrival would
+        // then have nothing to release.
+        if (parked !== undefined && upsert.seq >= parked.upsert.seq) {
+          this.#parkedOnSchemaClosure.delete(parkedKey);
+        }
       }
       // The arrival wake fires on a FORWARD move — and on a same-seq
       // frame whose class arrives LATE (undefined -> defined): an entry

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -5621,14 +5621,6 @@ class SpaceReplica implements ISpaceReplica {
         ),
       };
     }
-    // An id this frame DID apply supersedes any older parked copy of it.
-    if (this.#parkedOnSchemaClosure.size > 0) {
-      for (const upsert of sync.upserts) {
-        if (typeof upsert.id === "string") {
-          this.#parkedOnSchemaClosure.delete(upsert.id);
-        }
-      }
-    }
 
     // A keyed frame (a lease-holder session's — server-execution v2 stage
     // A, OW17's wire leg) names each entry's instance; the replica keys
@@ -5694,6 +5686,15 @@ class SpaceReplica implements ISpaceReplica {
         coverClass,
       );
       record.materialized = undefined;
+      // A REAL delivery for this id supersedes any parked copy of it:
+      // the parked one is older, and resurrecting it later would move
+      // the doc backwards. A seq-0 absent-doc marker is exempt — it is
+      // the "no confirmed version" answer to a pull, not a newer
+      // version, and treating it as one discards a park that is still
+      // waiting (the sink's own pull for a not-yet-applied doc).
+      if (upsert.seq > 0 && this.#parkedOnSchemaClosure.size > 0) {
+        this.#parkedOnSchemaClosure.delete(upsert.id as string);
+      }
       // The arrival wake fires on a FORWARD move — and on a same-seq
       // frame whose class arrives LATE (undefined -> defined): an entry
       // failed CLOSED at its floor under an unknown class (a mixed-window
@@ -5766,6 +5767,7 @@ class SpaceReplica implements ISpaceReplica {
     }
     for (const remove of sync.removes) {
       const id = remove.id as URI;
+      this.#parkedOnSchemaClosure.delete(id);
       const record = this.record(id, remove.scope, undefined, remove.scopeKey);
       record.confirmed = confirmedVersion(0, undefined);
       record.materialized = undefined;
@@ -5900,16 +5902,21 @@ class SpaceReplica implements ISpaceReplica {
       this.#kickedSchemaClosurePulls.add(hash);
       queueMicrotask(() => {
         this.sync(`cid:${hash}` as URI)
-          .then((result) => {
-            if (
-              result.error !== undefined ||
-              !this.#isVerifiedSchemaDocDelivered(hash, EMPTY_OVERLAY)
-            ) {
+          .then(() => {
+            if (!this.#isVerifiedSchemaDocDelivered(hash, EMPTY_OVERLAY)) {
               // Not installed server-side yet, or the pull failed:
               // re-arm so a later frame retries instead of the window
-              // going permanent for the session.
+              // going permanent for the session. (The pull can report
+              // an error and still have delivered the document; the
+              // residency check is the authority, not the result.)
               this.#kickedSchemaClosurePulls.delete(hash);
+              return;
             }
+            // Release HERE rather than relying on the arrival hook: a
+            // pull installs its documents through `pull`, not through
+            // `applySessionSync`, so the frame-end release never sees
+            // this one.
+            this.releaseParkedSchemaClosures("integrate");
           }, () => {
             this.#kickedSchemaClosurePulls.delete(hash);
           });

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -5611,12 +5611,23 @@ class SpaceReplica implements ISpaceReplica {
       // so it can be applied once the schema document it names resolves.
       // Dropping it here would lose it for the session — the server
       // never re-sends an unchanged document (OW61's elision design).
+      // Keyed by the FULL document address, the same identity the
+      // record store uses — NOT the bare id. The quarantine unit is the
+      // id (branch- and instance-blind, by design), but a keyed frame
+      // may carry two instances of one (branch, id, scope), and an
+      // id-keyed park would drop one of them on the floor.
       for (const upsert of sync.upserts) {
         const id = upsert.id;
         if (typeof id !== "string") continue;
         const waitingOn = deferred.get(id);
         if (waitingOn === undefined) continue;
-        this.#parkedOnSchemaClosure.set(id, { upsert, waitingOn });
+        this.#parkedOnSchemaClosure.set(
+          docKey(
+            id as URI,
+            this.instanceKey(upsert.scope, undefined, upsert.scopeKey),
+          ),
+          { upsert, waitingOn },
+        );
       }
       sync = {
         ...sync,
@@ -5697,7 +5708,12 @@ class SpaceReplica implements ISpaceReplica {
       // version, and treating it as one discards a park that is still
       // waiting (the sink's own pull for a not-yet-applied doc).
       if (upsert.seq > 0 && this.#parkedOnSchemaClosure.size > 0) {
-        this.#parkedOnSchemaClosure.delete(upsert.id as string);
+        this.#parkedOnSchemaClosure.delete(
+          docKey(
+            upsert.id as URI,
+            this.instanceKey(upsert.scope, undefined, upsert.scopeKey),
+          ),
+        );
       }
       // The arrival wake fires on a FORWARD move — and on a same-seq
       // frame whose class arrives LATE (undefined -> defined): an entry
@@ -5771,7 +5787,11 @@ class SpaceReplica implements ISpaceReplica {
     }
     for (const remove of sync.removes) {
       const id = remove.id as URI;
-      this.#parkedOnSchemaClosure.delete(id);
+      // Same address identity as the record below: a deleted document
+      // must never be resurrected by a park that predates its remove.
+      this.#parkedOnSchemaClosure.delete(
+        docKey(id, this.instanceKey(remove.scope, undefined, remove.scopeKey)),
+      );
       const record = this.record(id, remove.scope, undefined, remove.scopeKey);
       record.confirmed = confirmedVersion(0, undefined);
       record.materialized = undefined;
@@ -5865,13 +5885,13 @@ class SpaceReplica implements ISpaceReplica {
     try {
       while (true) {
         const releasable: SessionSync["upserts"][number][] = [];
-        for (const [id, parked] of this.#parkedOnSchemaClosure) {
+        for (const [key, parked] of this.#parkedOnSchemaClosure) {
           const resolved = [...parked.waitingOn].every((hash) =>
             this.#isVerifiedSchemaDocDelivered(hash, EMPTY_OVERLAY)
           );
           if (!resolved) continue;
           releasable.push(parked.upsert);
-          this.#parkedOnSchemaClosure.delete(id);
+          this.#parkedOnSchemaClosure.delete(key);
         }
         if (releasable.length === 0) break;
         this.applySessionSync({

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -6035,7 +6035,20 @@ class SpaceReplica implements ISpaceReplica {
         const { session } = await this.activeSessionHandle();
         const result = await session.resyncWatchSet?.();
         if (result !== undefined && !this.#closed) {
-          this.applySessionSync(result.sync, "pull");
+          // UPSERTS ONLY. This resync is a REPAIR — it exists to obtain
+          // content the delivery cache wrongly believes this replica
+          // holds — and it must not also act as a watch-set authority.
+          // `buildFullSync` derives its removes by diffing the session
+          // cache against the freshly evaluated closure, so a closure
+          // that legitimately differs from the cache carries removes
+          // for documents a live consumer is still reading; applying
+          // them deletes state out from under it (watched on #6260's
+          // board 2: pattern shard 7, green on board 1, failed on
+          // `shopping-list.tsx` with `hasTags is not a function` and
+          // destructured-undefined errors — data vanishing mid-run).
+          // Removes belong to the ordinary watch path, which owns the
+          // watch set; this path only ever adds back what is missing.
+          this.applySessionSync({ ...result.sync, removes: [] }, "pull");
         }
       } catch (error) {
         logger.warn("schema-closure-resync-failed", () => [

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2548,6 +2548,10 @@ class SpaceReplica implements ISpaceReplica {
    * applySessionSync (the released entries' own frame) does not start a
    * second drain. */
   #releasingParkedClosure = false;
+  /** One full re-evaluation at a time for the park (see
+   * `escalateParkedSchemaClosure`); a resync is expensive and one
+   * covers every hash outstanding when it runs. */
+  #schemaClosureResyncInFlight = false;
   readonly #updatePromises = new Set<Promise<void>>();
   readonly #sinks = new Map<
     string,
@@ -5904,12 +5908,17 @@ class SpaceReplica implements ISpaceReplica {
         this.sync(`cid:${hash}` as URI)
           .then(() => {
             if (!this.#isVerifiedSchemaDocDelivered(hash, EMPTY_OVERLAY)) {
-              // Not installed server-side yet, or the pull failed:
-              // re-arm so a later frame retries instead of the window
-              // going permanent for the session. (The pull can report
-              // an error and still have delivered the document; the
-              // residency check is the authority, not the result.)
+              // The pull came back WITHOUT the document. Under the
+              // session's delivery cache that is the diagnostic
+              // signature of this defect, not an absent document: a
+              // `watch.add` — which is what a pull issues — diffs its
+              // answer against that cache, so a document the cache
+              // claims delivered is elided even when the request names
+              // it as a root. Asking again cannot help; only a full
+              // evaluation can. Re-arm (the document may genuinely be
+              // absent and arrive later) and escalate.
               this.#kickedSchemaClosurePulls.delete(hash);
+              this.escalateParkedSchemaClosure();
               return;
             }
             // Release HERE rather than relying on the arrival hook: a
@@ -5996,6 +6005,49 @@ class SpaceReplica implements ISpaceReplica {
           });
       });
     }
+  }
+
+  /**
+   * Re-establish the watch set as a FULL evaluation, so the server
+   * re-ships its whole assembled closure.
+   *
+   * The last resort behind the park, and the only one that works when
+   * the session's delivery cache and this replica disagree about a
+   * document: `watch.add` (a pull) answers from that cache and elides
+   * what it believes delivered, so the document is unobtainable by
+   * request. `watch.set` rebuilds and ships everything, which is the
+   * "full evaluation" the quarantine diagnostic names.
+   *
+   * Expensive, so it is single-flight: one resync covers every hash
+   * outstanding when it runs, and the release afterwards drains the
+   * whole park.
+   */
+  private escalateParkedSchemaClosure(): void {
+    if (
+      this.#schemaClosureResyncInFlight ||
+      this.#parkedOnSchemaClosure.size === 0 || this.#closed
+    ) {
+      return;
+    }
+    this.#schemaClosureResyncInFlight = true;
+    queueMicrotask(async () => {
+      try {
+        const { session } = await this.activeSessionHandle();
+        const result = await session.resyncWatchSet?.();
+        if (result !== undefined && !this.#closed) {
+          this.applySessionSync(result.sync, "pull");
+        }
+      } catch (error) {
+        logger.warn("schema-closure-resync-failed", () => [
+          "the parked-closure full re-evaluation failed; a later frame",
+          "carrying the reference re-kicks",
+          error,
+        ]);
+      } finally {
+        this.#schemaClosureResyncInFlight = false;
+      }
+      this.releaseParkedSchemaClosures("integrate");
+    });
   }
 
   // Mark every id this conflicted commit touched (reads + writes) stale until

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -188,6 +188,19 @@ const pendingPatchLogger = getLogger("storage.v2.pending-patch", {
 
 const EMPTY_OVERLAY: ReadonlyMap<string, unknown> = new Map();
 
+/**
+ * The arrival validator's verdict on one frame: which upserts must not
+ * apply, and which of those are merely WAITING on a schema document
+ * (keyed by the dependency hashes each still needs). A deferred entry is
+ * retained for release; a quarantined-but-not-deferred entry — a forged
+ * replacement for a content-addressed id — is dropped outright, because
+ * no later arrival can make it applicable.
+ */
+interface ArrivalValidation {
+  quarantined: Set<string>;
+  deferred: Map<string, Set<string>>;
+}
+
 function withCommitTiming<T>(
   keys: string[],
   fn: () => T,
@@ -2512,6 +2525,29 @@ class SpaceReplica implements ISpaceReplica {
   // whose cid: pull is in flight or has succeeded; a failed pull removes
   // its entry so a later frame can retry.
   readonly #kickedCfcSchemaPulls = new Set<string>();
+  /**
+   * Documents ABSORBED but not yet applicable: they arrived naming a
+   * `cid:` schema document this replica cannot resolve yet. The client's
+   * contract is to absorb every frame the server sends and never dismiss
+   * one (verification-coverage.md OW61, owner ruling 2026-08-24) — and
+   * the server, by design, never re-sends an unchanged document, so a
+   * dropped entry is lost for the session. Keyed by upsert id (one
+   * entry per id: a newer arrival supersedes an older park), each
+   * holding the upsert verbatim and the dependency hashes it waits on.
+   * Released — re-validated and applied — as soon as those hashes
+   * resolve, from any later frame or from #kickedSchemaClosurePulls.
+   */
+  readonly #parkedOnSchemaClosure = new Map<string, {
+    upsert: SessionSync["upserts"][number];
+    waitingOn: Set<string>;
+  }>();
+  /** Hydration dedupe for #parkedOnSchemaClosure's missing hashes; a
+   * failed pull removes its entry so a later frame can retry. */
+  readonly #kickedSchemaClosurePulls = new Set<string>();
+  /** Set while the release loop below is draining, so a nested
+   * applySessionSync (the released entries' own frame) does not start a
+   * second drain. */
+  #releasingParkedClosure = false;
   readonly #updatePromises = new Set<Promise<void>>();
   readonly #sinks = new Map<
     string,
@@ -5362,9 +5398,12 @@ class SpaceReplica implements ISpaceReplica {
    * and a forged local copy fails even when the realm registry holds a
    * valid twin from another space.
    *
-   * @returns the ids of the frame's upserts that must NOT apply.
+   * @returns the ids of the frame's upserts that must NOT apply, split
+   * into the ones DEFERRED on an unresolved schema ref (retained for
+   * release, keyed by the hashes they wait on) and the ones dropped
+   * outright.
    */
-  #validateArrivedSchemaDocuments(sync: SessionSync): Set<string> {
+  #validateArrivedSchemaDocuments(sync: SessionSync): ArrivalValidation {
     const registered: [string, JSONSchema][] = [];
     // Dependency hash → every delivered document id that embeds it: the
     // quarantine set on a violation, and the violation report.
@@ -5387,6 +5426,19 @@ class SpaceReplica implements ISpaceReplica {
     // in the same frame drops with the offender — strictly less damage
     // than the whole-frame rejection this replaces (review note S1).
     const quarantined = new Set<string>();
+    // Deferred entries and the dependency hashes each still waits on.
+    // A FORGED cid replacement below is a hard drop and never lands
+    // here: its content violates content addressing, so no later
+    // arrival can make it applicable.
+    const deferred = new Map<string, Set<string>>();
+    const defer = (id: string, hash: string) => {
+      let waiting = deferred.get(id);
+      if (waiting === undefined) {
+        waiting = new Set();
+        deferred.set(id, waiting);
+      }
+      waiting.add(hash);
+    };
     for (const remove of sync.removes) {
       if (typeof remove.id === "string") deletedInFrame.add(remove.id);
     }
@@ -5468,6 +5520,7 @@ class SpaceReplica implements ISpaceReplica {
           !this.#isVerifiedSchemaDocDelivered(dep, overlay)
         ) {
           for (const referrer of referrers) {
+            defer(referrer, dep);
             if (quarantined.has(referrer)) continue;
             quarantined.add(referrer);
             overlay.delete(referrer);
@@ -5488,7 +5541,7 @@ class SpaceReplica implements ISpaceReplica {
         }
       }
     }
-    return quarantined;
+    return { quarantined, deferred };
   }
 
   /**
@@ -5546,14 +5599,35 @@ class SpaceReplica implements ISpaceReplica {
     // loud diagnostic — never half-installed, never a process kill; see
     // #validateArrivedSchemaDocuments), and the rest of the frame
     // applies.
-    const quarantined = this.#validateArrivedSchemaDocuments(sync);
+    const { quarantined, deferred } = this.#validateArrivedSchemaDocuments(
+      sync,
+    );
     if (quarantined.size > 0) {
+      // Absorb before filtering: a DEFERRED entry is retained verbatim
+      // so it can be applied once the schema document it names resolves.
+      // Dropping it here would lose it for the session — the server
+      // never re-sends an unchanged document (OW61's elision design).
+      for (const upsert of sync.upserts) {
+        const id = upsert.id;
+        if (typeof id !== "string") continue;
+        const waitingOn = deferred.get(id);
+        if (waitingOn === undefined) continue;
+        this.#parkedOnSchemaClosure.set(id, { upsert, waitingOn });
+      }
       sync = {
         ...sync,
         upserts: sync.upserts.filter((upsert) =>
           typeof upsert.id !== "string" || !quarantined.has(upsert.id)
         ),
       };
+    }
+    // An id this frame DID apply supersedes any older parked copy of it.
+    if (this.#parkedOnSchemaClosure.size > 0) {
+      for (const upsert of sync.upserts) {
+        if (typeof upsert.id === "string") {
+          this.#parkedOnSchemaClosure.delete(upsert.id);
+        }
+      }
     }
 
     // A keyed frame (a lease-holder session's — server-execution v2 stage
@@ -5754,6 +5828,93 @@ class SpaceReplica implements ISpaceReplica {
       }
     }
     this.hydrateArrivedCfcSchemaRefs(sync);
+    this.releaseParkedSchemaClosures(type);
+  }
+
+  /**
+   * Apply every parked entry whose schema documents now resolve, and pull
+   * the ones still missing.
+   *
+   * The release is a real frame: the parked upserts re-enter
+   * `applySessionSync`, so they are re-validated (a stale park cannot
+   * install unverified content) and integrate through the same
+   * notification path a delivered frame does. Draining is iterative
+   * because a released entry may itself be a schema document that frees
+   * further parks; `#releasingParkedClosure` keeps the nested apply from
+   * starting a second drain, and each pass removes what it releases, so
+   * the loop is bounded by the park's size.
+   *
+   * Whatever stays parked is missing a document this replica has never
+   * seen. Pull it: under elision the server will not volunteer it again,
+   * so the pull is what turns "absorbed but not yet applicable" into
+   * applied without waiting for a full evaluation.
+   */
+  private releaseParkedSchemaClosures(type: "pull" | "integrate"): void {
+    if (
+      this.#releasingParkedClosure || this.#parkedOnSchemaClosure.size === 0
+    ) {
+      return;
+    }
+    this.#releasingParkedClosure = true;
+    try {
+      while (true) {
+        const releasable: SessionSync["upserts"][number][] = [];
+        for (const [id, parked] of this.#parkedOnSchemaClosure) {
+          const resolved = [...parked.waitingOn].every((hash) =>
+            this.#isVerifiedSchemaDocDelivered(hash, EMPTY_OVERLAY)
+          );
+          if (!resolved) continue;
+          releasable.push(parked.upsert);
+          this.#parkedOnSchemaClosure.delete(id);
+        }
+        if (releasable.length === 0) break;
+        this.applySessionSync({
+          type: "sync",
+          fromSeq: 0,
+          toSeq: 0,
+          upserts: releasable,
+          removes: [],
+        } as SessionSync, type);
+      }
+    } finally {
+      this.#releasingParkedClosure = false;
+    }
+    this.hydrateParkedSchemaClosures();
+  }
+
+  /** Pull the `cid:` documents the park is still waiting on. Deduped
+   * while a pull is in flight or has delivered; a failure or an empty
+   * completion re-arms the hash so the next arriving frame kicks
+   * again. Mirrors `hydrateArrivedCfcSchemaRefs`, whose refs are the
+   * metadata class this one's link-position refs sit beside. */
+  private hydrateParkedSchemaClosures(): void {
+    const missing = new Set<string>();
+    for (const parked of this.#parkedOnSchemaClosure.values()) {
+      for (const hash of parked.waitingOn) {
+        if (this.#isVerifiedSchemaDocDelivered(hash, EMPTY_OVERLAY)) continue;
+        if (this.#kickedSchemaClosurePulls.has(hash)) continue;
+        missing.add(hash);
+      }
+    }
+    for (const hash of missing) {
+      this.#kickedSchemaClosurePulls.add(hash);
+      queueMicrotask(() => {
+        this.sync(`cid:${hash}` as URI)
+          .then((result) => {
+            if (
+              result.error !== undefined ||
+              !this.#isVerifiedSchemaDocDelivered(hash, EMPTY_OVERLAY)
+            ) {
+              // Not installed server-side yet, or the pull failed:
+              // re-arm so a later frame retries instead of the window
+              // going permanent for the session.
+              this.#kickedSchemaClosurePulls.delete(hash);
+            }
+          }, () => {
+            this.#kickedSchemaClosurePulls.delete(hash);
+          });
+      });
+    }
   }
 
   /** Schema-hash hydration for arrived metadata (verification-coverage.md

--- a/packages/runner/test/schema-doc-sync.test.ts
+++ b/packages/runner/test/schema-doc-sync.test.ts
@@ -807,6 +807,89 @@ describe("schema-doc-sync", () => {
     );
   });
 
+  it("keeps a parked NEWER revision when an older refresh for the same doc applies", () => {
+    // A watch refresh can carry an older seq than a revision already
+    // parked — the monotonicity guard in the apply loop exists for
+    // exactly that. Superseding the park on any arrival would discard
+    // the newer revision permanently, and the schema's later arrival
+    // would have nothing to release. Found in review of this change.
+    const depSchema = { type: "string", title: "stale-refresh" } as const;
+    const depHash = internSchemaAsTaggedHashString(depSchema);
+    const provider = readerStorage.open(space);
+    const replica = provider.replica as unknown as {
+      applySessionSync(sync: unknown, type: string): void;
+      getDocument(uri: string): unknown;
+    };
+    const newer = {
+      value: {
+        revision: "newer",
+        linked: {
+          "/": {
+            [LINK_V1_TAG]: {
+              id: "of:stale-target",
+              path: [],
+              schema: { $ref: `cid:${depHash}` },
+            },
+          },
+        },
+      },
+    };
+    // seq 5, deferred on the missing schema.
+    replica.applySessionSync({
+      type: "sync",
+      fromSeq: 980_000,
+      toSeq: 980_001,
+      upserts: [
+        {
+          branch: "",
+          id: "of:stale-carrier",
+          scope: "space",
+          seq: 5,
+          doc: newer,
+        },
+      ],
+      removes: [],
+    }, "integrate");
+    expect(replica.getDocument("of:stale-carrier")).toBeUndefined();
+
+    // seq 3 — an OLDER refresh, no ref of its own, so it applies.
+    replica.applySessionSync({
+      type: "sync",
+      fromSeq: 980_001,
+      toSeq: 980_002,
+      upserts: [
+        {
+          branch: "",
+          id: "of:stale-carrier",
+          scope: "space",
+          seq: 3,
+          doc: { value: { revision: "older" } },
+        },
+      ],
+      removes: [],
+    }, "integrate");
+
+    // The schema lands; the parked seq-5 revision is still there and
+    // wins on seq. Superseding on the stale arrival would leave the
+    // replica pinned to "older" forever.
+    replica.applySessionSync({
+      type: "sync",
+      fromSeq: 980_002,
+      toSeq: 980_003,
+      upserts: [
+        {
+          branch: "",
+          id: `cid:${depHash}`,
+          scope: "space",
+          seq: 6,
+          doc: { value: depSchema },
+        },
+      ],
+      removes: [],
+    }, "integrate");
+    expect(replica.getDocument("of:stale-carrier")).toEqual(newer);
+  });
+
   it("PULLS the cid a parked doc waits on and applies it, with nothing re-delivered (the OW61 board's shape)", async () => {
     // #6248's ensure-ON board: the cid document IS installed in the
     // space — the server elides it because this session already

--- a/packages/runner/test/schema-doc-sync.test.ts
+++ b/packages/runner/test/schema-doc-sync.test.ts
@@ -731,6 +731,77 @@ describe("schema-doc-sync", () => {
     expect(replica.getDocument("of:absorb-carrier")).toEqual(carrierDoc);
   });
 
+  it("PULLS the cid a parked doc waits on and applies it, with nothing re-delivered (the OW61 board's shape)", async () => {
+    // #6248's ensure-ON board: the cid document IS installed in the
+    // space — the server elides it because this session already
+    // received it — and the replica that lacks it holds a mentioning
+    // doc it can never be re-sent. Absorbing is only half the answer;
+    // the client has to go GET what it is missing, or the parked doc
+    // waits for a full evaluation that never comes mid-session.
+    const depSchema: JSONSchemaObj = {
+      type: "object",
+      properties: { pulledLeaf: { type: "string" } },
+      title: "pulled-by-the-park",
+    };
+    const decomposed = decomposeSchema(depSchema);
+    await writeSchemaDocs(decomposed);
+    const depHash = parseExternalSchemaRef(decomposed.rootRef)!.taggedHash;
+
+    const provider = readerStorage.open(space);
+    const replica = provider.replica as unknown as {
+      applySessionSync(sync: unknown, type: string): void;
+      getDocument(uri: string): unknown;
+    };
+    const carrierDoc = {
+      value: {
+        linked: {
+          "/": {
+            [LINK_V1_TAG]: {
+              id: "of:pull-target",
+              path: [],
+              schema: { $ref: `cid:${depHash}` },
+            },
+          },
+        },
+      },
+    };
+    const released = defer<void>();
+    const cancel = (provider as unknown as {
+      sink: (uri: URI, callback: (doc: unknown) => void) => () => void;
+    }).sink("of:pull-carrier" as URI, (doc: unknown) => {
+      if (doc !== undefined) released.resolve();
+    });
+
+    // The elision shape: the mentioning doc alone, naming a cid this
+    // replica has never received. Nothing will re-deliver either one.
+    replica.applySessionSync({
+      type: "sync",
+      fromSeq: 950_000,
+      toSeq: 950_001,
+      upserts: [
+        {
+          branch: "",
+          id: "of:pull-carrier",
+          scope: "space",
+          seq: 1,
+          doc: carrierDoc,
+        },
+      ],
+      removes: [],
+    }, "integrate");
+    // Held, not visible — fail-closed survives.
+    expect(replica.getDocument("of:pull-carrier")).toBeUndefined();
+
+    // The park's own pull fetches the cid from the space and releases
+    // the carrier: absorbed, healed IN SESSION, no re-delivery. Waited
+    // on the release itself — the sink fires when the carrier becomes
+    // visible, which is the event under test.
+    await released.promise;
+    expect(replica.getDocument(`cid:${depHash}`)).toBeDefined();
+    expect(replica.getDocument("of:pull-carrier")).toEqual(carrierDoc);
+    cancel();
+  });
+
   it("the background consumer survives a frame that fails to apply and keeps consuming", async () => {
     const provider = readerStorage.open(space);
     const replica = provider.replica as unknown as {

--- a/packages/runner/test/schema-doc-sync.test.ts
+++ b/packages/runner/test/schema-doc-sync.test.ts
@@ -664,6 +664,73 @@ describe("schema-doc-sync", () => {
     expect(replica.getDocument("of:heal-carrier")).toEqual(carrierDoc);
   });
 
+  it("absorbs a doc whose cid arrives in a LATER frame, with no re-delivery of the doc (the elision shape)", () => {
+    const depSchema = {
+      type: "string",
+      title: "absorbs-late-cid",
+    } as const;
+    const depHash = internSchemaAsTaggedHashString(depSchema);
+    const provider = readerStorage.open(space);
+    const replica = provider.replica as unknown as {
+      applySessionSync(sync: unknown, type: string): void;
+      getDocument(uri: string): unknown;
+    };
+    const carrierDoc = {
+      value: {
+        linked: {
+          "/": {
+            [LINK_V1_TAG]: {
+              id: "of:absorb-target",
+              path: [],
+              schema: { $ref: `cid:${depHash}` },
+            },
+          },
+        },
+      },
+    };
+    // Frame 1: the mentioning doc arrives BEFORE the cid it names. The
+    // client's contract is to ABSORB every frame the server sends —
+    // never to dismiss one (OW61's owner ruling, 2026-08-24). Holding
+    // the doc back from the visible state is fail-closed and correct;
+    // DISCARDING it is the defect, because of what frame 2 cannot do.
+    replica.applySessionSync({
+      type: "sync",
+      fromSeq: 900_000,
+      toSeq: 900_001,
+      upserts: [
+        {
+          branch: "",
+          id: "of:absorb-carrier",
+          scope: "space",
+          seq: 1,
+          doc: carrierDoc,
+        },
+      ],
+      removes: [],
+    }, "integrate");
+    // Frame 2: the cid sibling ALONE. The server elides an already-
+    // delivered cid doc and never re-sends an unchanged carrier, so
+    // this is the only further information this session will ever
+    // carry about the pair — there is no full evaluation coming. The
+    // carrier must become resident off the client's own retained copy.
+    replica.applySessionSync({
+      type: "sync",
+      fromSeq: 900_001,
+      toSeq: 900_002,
+      upserts: [
+        {
+          branch: "",
+          id: `cid:${depHash}`,
+          scope: "space",
+          seq: 2,
+          doc: { value: depSchema },
+        },
+      ],
+      removes: [],
+    }, "integrate");
+    expect(replica.getDocument("of:absorb-carrier")).toEqual(carrierDoc);
+  });
+
   it("the background consumer survives a frame that fails to apply and keeps consuming", async () => {
     const provider = readerStorage.open(space);
     const replica = provider.replica as unknown as {

--- a/packages/runner/test/schema-doc-sync.test.ts
+++ b/packages/runner/test/schema-doc-sync.test.ts
@@ -731,6 +731,82 @@ describe("schema-doc-sync", () => {
     expect(replica.getDocument("of:absorb-carrier")).toEqual(carrierDoc);
   });
 
+  it("parks two instances of one id separately, so neither delivery is lost", () => {
+    // The park is keyed by the full document address, not the bare id:
+    // the quarantine unit IS the id (branch- and instance-blind, by
+    // design), but one frame may carry two instances of a single
+    // (branch, id, scope) and an id-keyed park would drop one of them
+    // on the floor. Found in review of this change.
+    const depSchema = { type: "string", title: "two-instances" } as const;
+    const depHash = internSchemaAsTaggedHashString(depSchema);
+    const provider = readerStorage.open(space);
+    const replica = provider.replica as unknown as {
+      applySessionSync(sync: unknown, type: string): void;
+      getDocument(uri: string, scope?: string): unknown;
+    };
+    const carrierFor = (marker: string) => ({
+      value: {
+        marker,
+        linked: {
+          "/": {
+            [LINK_V1_TAG]: {
+              id: "of:dual-target",
+              path: [],
+              schema: { $ref: `cid:${depHash}` },
+            },
+          },
+        },
+      },
+    });
+    replica.applySessionSync({
+      type: "sync",
+      fromSeq: 970_000,
+      toSeq: 970_001,
+      upserts: [
+        {
+          branch: "",
+          id: "of:dual-carrier",
+          scope: "space",
+          seq: 1,
+          doc: carrierFor("space-instance"),
+        },
+        {
+          branch: "",
+          id: "of:dual-carrier",
+          scope: "user",
+          seq: 1,
+          doc: carrierFor("user-instance"),
+        },
+      ],
+      removes: [],
+    }, "integrate");
+
+    replica.applySessionSync({
+      type: "sync",
+      fromSeq: 970_001,
+      toSeq: 970_002,
+      upserts: [
+        {
+          branch: "",
+          id: `cid:${depHash}`,
+          scope: "space",
+          seq: 2,
+          doc: { value: depSchema },
+        },
+      ],
+      removes: [],
+    }, "integrate");
+
+    // BOTH instances come back. An id-keyed park returns only the
+    // second, having overwritten the first.
+    expect(replica.getDocument("of:dual-carrier", "space")).toEqual(
+      carrierFor("space-instance"),
+    );
+    expect(replica.getDocument("of:dual-carrier", "user")).toEqual(
+      carrierFor("user-instance"),
+    );
+  });
+
   it("PULLS the cid a parked doc waits on and applies it, with nothing re-delivered (the OW61 board's shape)", async () => {
     // #6248's ensure-ON board: the cid document IS installed in the
     // space — the server elides it because this session already

--- a/packages/runner/test/schema-doc-sync.test.ts
+++ b/packages/runner/test/schema-doc-sync.test.ts
@@ -734,9 +734,12 @@ describe("schema-doc-sync", () => {
   it("parks two instances of one id separately, so neither delivery is lost", () => {
     // The park is keyed by the full document address, not the bare id:
     // the quarantine unit IS the id (branch- and instance-blind, by
-    // design), but one frame may carry two instances of a single
-    // (branch, id, scope) and an id-keyed park would drop one of them
-    // on the floor. Found in review of this change.
+    // design), but one frame may carry the same id under more than one
+    // address, and an id-keyed park drops all but the last on the
+    // floor. Exercised here with two SCOPES of one id; the keyed
+    // frame's `scopeKey` instances are the other shape the same park
+    // key covers and are not exercised. Found in review of this
+    // change.
     const depSchema = { type: "string", title: "two-instances" } as const;
     const depHash = internSchemaAsTaggedHashString(depSchema);
     const provider = readerStorage.open(space);

--- a/packages/runner/test/schema-doc-sync.test.ts
+++ b/packages/runner/test/schema-doc-sync.test.ts
@@ -802,6 +802,83 @@ describe("schema-doc-sync", () => {
     cancel();
   });
 
+  it("ESCALATES to a full evaluation when the session cache claims the cid was delivered and the pull comes back empty", async () => {
+    // The floor under OW61, found on #6260's board: a pull issues
+    // `session.watch.add`, and watchAdd DIFFS its answer against the
+    // session's delivery cache — so a document the cache already
+    // claims delivered is elided even when the request names it as a
+    // root. A replica that does not hold it therefore cannot get it by
+    // asking; the frame comes back empty every time (the board showed
+    // one cid missing 48 times in a single shard). Only a full
+    // evaluation re-ships it, because buildFullSync maps every entry.
+    const depSchema: JSONSchemaObj = {
+      type: "object",
+      properties: { escalatedLeaf: { type: "string" } },
+      title: "escalates-past-the-cache",
+    };
+    const decomposed = decomposeSchema(depSchema);
+    await writeSchemaDocs(decomposed);
+    const depHash = parseExternalSchemaRef(decomposed.rootRef)!.taggedHash;
+    const carrierValue = {
+      linked: {
+        "/": {
+          [LINK_V1_TAG]: {
+            id: "of:escalate-target",
+            path: [],
+            schema: { $ref: `cid:${depHash}` },
+          },
+        },
+      },
+    };
+    await writeDocs({ "of:escalate-carrier": carrierValue });
+
+    const provider = readerStorage.open(space);
+    const replica = provider.replica as unknown as {
+      applySessionSync(sync: unknown, type: string): void;
+      getDocument(uri: string): unknown;
+    };
+    // The absorb defect, transient: the FIRST frame loses its cid
+    // upserts, every later one is intact. The session cache on the
+    // server counts that first frame as delivered regardless — which is
+    // the disagreement this step exists to escape. (The register
+    // sanctions this instance-patch seam for standing in for whichever
+    // interleaving drops a delivery.)
+    let framesSeen = 0;
+    const originalApply = replica.applySessionSync.bind(replica);
+    replica.applySessionSync = (sync: unknown, type: string) => {
+      const frame = sync as { upserts?: Array<{ id?: unknown }> };
+      const upserts = Array.isArray(frame?.upserts) ? frame.upserts : [];
+      framesSeen += 1;
+      if (framesSeen > 1) return originalApply(sync, type);
+      const kept = upserts.filter((upsert) =>
+        typeof upsert?.id !== "string" || !upsert.id.startsWith("cid:")
+      );
+      return originalApply({ ...(sync as object), upserts: kept }, type);
+    };
+
+    const healed = defer<void>();
+    const cancel = (provider as unknown as {
+      sink: (uri: URI, callback: (doc: unknown) => void) => () => void;
+    }).sink("of:escalate-carrier" as URI, (doc: unknown) => {
+      if (doc !== undefined) healed.resolve();
+    });
+
+    await provider.sync("of:escalate-carrier" as URI, {
+      path: [],
+      schema: false,
+    });
+
+    // The pull for the missing cid is answered EMPTY by the cache, so
+    // re-asking is futile; the escalation's full evaluation re-ships
+    // the closure and the parked carrier applies.
+    await healed.promise;
+    expect(replica.getDocument(`cid:${depHash}`)).toBeDefined();
+    expect(replica.getDocument("of:escalate-carrier")).toEqual({
+      value: carrierValue,
+    });
+    cancel();
+  });
+
   it("the background consumer survives a frame that fails to apply and keeps consuming", async () => {
     const provider = readerStorage.open(space);
     const replica = provider.replica as unknown as {


### PR DESCRIPTION
Part of the **server-execution v2 optimize arc**. Please do **not** merge — the arc coordinator merges after independent adversarial review.

## Why

The owner's contract, ruled 2026-08-24 when the shipping-side fix in #6223 was reversed:

> "this change undermines why we added cids in the first place, to not retransmit the schemas all the time"

> "the client should absorb all information sent from the server, it shouldn't ever dismiss a frame. i don't think it even does so."

> "So if we saw this in CI - earlier frame delivered cid doc, later frame didn't see it - then that's the actual bug."

#6223 landed the containment (quarantine instead of a process-killing throw) and removed its per-frame resend, leaving the correctness fix to this investigation. OW61's row named the residual work: find the client-side absorb defect.

**It is not an interleaving, and no race is required.** The arrival validator met a document naming an unresolved `cid:` schema by **dropping it**, and the only heal on offer was a re-delivery *of that document* — the FULL evaluation shape (`watch.set`, reconnect). Under the elision the owner's reversal restored, an unchanged document is never re-sent mid-session. So the drop was permanent for the session: the client had dismissed information the server had sent and would never send again.

That is the contract broken on the plain path. Delivery-window timing only decided whether a mention ever *preceded* its cid — never whether the drop was *recoverable*. It explains the board exactly: CI hit the ordering consistently, one local run at the same head did not, and once hit, nothing healed it.

The two ref classes had opposite answers to one question. `hydrateArrivedCfcSchemaRefs` (OW47's re-close) already answers a missing `/cfc` metadata `schemaHash` by **pulling** it. Link-position refs — the class this validator checks — answered by **rejecting the document**. This aligns them.

## The reproduction

**#6248's ensure-ON board is this bug's real evidence**, and it supersedes the original 13-file crash board: **1069 `schema-doc-quarantine` lines across ten ON lanes, zero worker kills**, the quarantined pair byte-for-byte the original (`computed:fid1:7BycCyHc…` / `cid:fid1:zgJY1m9lR0…`). Every failure signature there is *downstream of a doc that never applied* — `Failed to create or find default pattern` (`pieces-controller.ts:1762`), `[alice] No data at cell`, the `/sourceMap` CFC abort, the shell lane's 30-minute hang. It separates OW61's two halves cleanly: the containment doing exactly what it shipped to do, and the dismissal costing the lanes their data.

Modelling that shape as a pin **caught two defects in this fix**, either of which would have left that board red (commit `eb3892796`):

1. **The release never ran after a pull.** `pull()` installs its documents directly, not through `applySessionSync`, so the frame-end release hook never saw the very delivery the park was waiting for — the pull succeeded, the cid went resident, and the parked doc sat there. The pull now releases on completion, and its *residency check* rather than its result decides whether to re-arm (a pull can report a connection error and still have delivered).
2. **The supersede rule discarded live parks.** A seq-0 absent-doc marker — the "no confirmed version" answer to a pull, not a newer version — counted as "a newer arrival for this id", so a sink's own pull for the not-yet-applied doc evicted the park waiting to supply it. Superseding now happens only where a real delivery lands (`seq > 0`), plus on a remove.

**Verification board: #6260** — this branch with #6248's four env-line flip cherry-picked on top, which is the coordinator's stated sequencing (absorb fix → re-run the flip). Note for reading it: **a `schema-doc-quarantine` line no longer means the doc was dropped** — it is held and healing — so lane colour, not quarantine count, is the health metric.

## Board evidence (four runs at the true topology)

| board | pattern shards green | package ON lanes green |
|---|---|---|
| #6248 — no fix | 2 of 10 | 1 of 3 |
| 1 — absorb fix | 2 of 10 | **3 of 3** |
| 2 — + escalation | 4 of 10 | 3 of 3 |
| 3 — + upserts-only resync | 8 of 10 | 3 of 3 |
| 4 — + resume watermark | **9 of 10** | 3 of 3 |

Board 2 caught this fix **harming** what it was meant to help: shard 7, green on board 1, failed inside `shopping-list.tsx` with `hasTags is not a function` and destructured-undefined — data vanishing under a live pattern. `buildFullSync` derives its removes by diffing the session cache against the freshly evaluated closure, so a legitimately different closure carries removes for documents a running consumer still reads. The resync is a **repair**, never a watch-set authority; it now applies upserts only, and shard 7 came back green with 4, 5 and 9.

Two of #6248's four signatures — `Failed to create or find default pattern` and `No data at cell` — are now **absent from every failing shard**.

### The last delivery-side mechanism

`session.entities` records what the server **sent**, not what the client **holds**, and it commits when a frame is *built*. A socket that dies mid-flight loses frames the server counts as delivered — `rollbackUndeliveredSync` repairs only a locally-throwing send, as its own comment concedes — so the cache goes on claiming documents the client never received, and the next diff elides exactly those. A schema document elided that way is unobtainable, which is what made this class terminal rather than transient.

The repair input was already on the wire and being discarded. A resuming client reports the highest server seq it actually received (`reopen` sends `seenSeq: this.#serverSeq`); the registry took `Math.max(existing.seenSeq, client.seenSeq)` — throwing away the one case that matters, a client admitting it is **behind**. When that report is below this session's `lastSyncedSeq`, the frames between were sent and lost, so the next pass routes through the full evaluation (`forceFullResync`, existing machinery). No new protocol, no retransmission to a client that holds the data, and the elision is untouched: a caught-up resume takes the incremental path exactly as before. Pinned both directions and mutation-checked.

**Shard 6 — the residual board 3 could not explain — went green on board 4.** That settles it: reconnects were live in those lanes and the lost-frame-on-resume class was its cause.

### The one remaining failure is not this defect

Shard 10's degradation gate dies on `PatternManager.writeBackCompileCache` ([pattern-manager.ts:2208](packages/runner/src/pattern-manager.ts:2208)) throwing the `/sourceMap` CFC prepare abort — #6248's third signature, outside the delivery path. `Failed to create or find default pattern` and `No data at cell` are both at **zero** across every lane. That is #6248's own scope decision, not OW61's.

### Superseded reading

- **Shard 6 is still this defect.** `cid:fid1:zgJY1m9lR0…` missing 64 times with **zero** `schema-closure-resync-failed`: the escalation fires and still does not obtain the document. Suspected floor beneath the floor is the **graph-level** closure staging ("stages a closure doc only while the tracked graph has never delivered it") — a second elision layer a full `watch.set` does not clear either, which would mean no request a client can make recovers the document. Unverified; it is the next thing to pin.
- **Shard 10 is not this defect.** Its degradation gate dies on `PatternManager.writeBackCompileCache` ([pattern-manager.ts:2208](packages/runner/src/pattern-manager.ts:2208)) throwing the `/sourceMap` CFC prepare abort — #6248's third signature, outside the delivery path.

## What Changed

`packages/runner/src/storage/v2.ts`, client side only. The server's cross-frame elision is untouched: nothing is re-sent.

- `#validateArrivedSchemaDocuments` now returns `{ quarantined, deferred }` — which upserts must not apply, and which of those are merely *waiting* on a schema document, keyed by the hashes each needs.
- **Park, don't dismiss.** An entry whose refs cannot resolve yet is retained verbatim in `#parkedOnSchemaClosure` against the hashes it waits on. A newer arrival for the same id supersedes an older park.
- **Release.** Parked entries re-enter `applySessionSync` as soon as their hashes resolve from any later frame — so they are **re-validated**, and a stale park can never install unverified content. The drain is iterative (a released entry may itself be the schema document that frees the next), guarded by `#releasingParkedClosure`, and bounded by the park's size.
- **Pull what is still missing.** `hydrateParkedSchemaClosures` fetches the `cid:` documents the park still waits on — deduped while in flight, re-armed on failure or empty completion. This is what turns "absorbed but not yet applicable" into applied without waiting for a full evaluation.
- A **forged** replacement for a content-addressed id stays a hard drop: its content violates content addressing, so no later arrival makes it applicable.

The park is keyed by upsert id, so it is bounded by the number of distinct documents waiting on an absent schema, and each entry clears on release or on a newer arrival for the same id. It is deliberately **not** capped: evicting a parked entry would be the dismissal this PR exists to remove, so a producer bug that grows it should surface as the `schema-doc-quarantine` diagnostic it already logs per document, not as a silent drop.

**Fail-closed is unchanged** — a parked document is not visible, and the `schema-doc-quarantine` diagnostic still fires.

**The containment is not retired, and should not be.** The row anticipated this fix would make it a never-fires net. It does not: the park makes the *compliant* path self-healing rather than dependent on perfect retention, which leaves the containment as the net under a genuinely absent document (a hash the server never installed) and under any future producer bug. Its ensure-driven pin passes unchanged, because that simulation drops cid upserts on *every* frame including the hydration pull's answer.

### Ruled out as the mechanism, with evidence

- `experimentalConcurrentWatchRefresh`'s deferred watch-response apply is a real ordering inversion, but the flag is **default off** and was off on the board.
- `handleEffect` with a null `#watchView` absorbs via `WatchView.fromSync` (`emit: false`), so the frame reaches no consumer — but both nulling sites set `#closed` first and `handleEffect` returns early on it. Unreachable while open.
- The runner's `#updatePromises.size === 0` consumer gate is harmless: `watchAddSync` **reuses** `#watchView` rather than handing back a fresh instance.
- **Retention examined, deliberately not patched.** No path was found by which a cid this replica applied later disappears from it: `applySessionSync`'s `upsert.seq < record.confirmed.seq` skip is harmless for content-addressed docs (the content cannot differ), and `reset()`'s `#docs.clear()` has one caller (`replaceProvisionalReplica`), which builds the replacement on a **fresh session** whose delivery cache re-ships the closure. Hardening it without a red pin would be speculative; park+pull makes it moot for correctness either way.

### Standing hazard — reported, not fixed

`refreshWatchSet`'s `view.close()` on a failed frame closes the **shared** `WatchView`. Its comment reasons about a per-refresh view that the client's reuse means does not exist, so this would silence every later push frame for the session — a much larger dismissal than the one fixed here. Quarantine plus the park mean `applySessionSync` no longer throws for the schema class, so the path is far less reachable. Left for the coordinator's call because `schema-doc-sync.test.ts`'s "closes the staged watch view when a frame fails validation" pins the current behavior on purpose.

## Test plan

**Red-first.** The new pin in `packages/runner/test/schema-doc-sync.test.ts` — *"absorbs a doc whose cid arrives in a LATER frame, with no re-delivery of the doc (the elision shape)"* — was watched failing at `4ac3b2e70`:

```
schema-doc-quarantine Document of:absorb-carrier was delivered with a broken
schema ref: cid:fid1:HAuq1U… is not delivered and verified in this replica.
```
```
AssertionError: Values are not equal.  Actual: undefined
```

Frame one carries the mentioning doc; frame two carries **only** the cid — the elision shape, the sole further information the session ever gets. The doc stayed absent. Green at head.

Also run:

- `packages/runner/test/schema-doc-sync.test.ts` — 20 steps green, including the existing quarantine and full-evaluation-heal pins (fail-closed posture preserved: `of:frame-carrier` still not visible on arrival).
- `packages/runner/test/executor-space-root-ensure.test.ts` — 9 steps green, including OW61's ensure-driven containment pin, unchanged.
- `PULLS the cid a parked doc waits on and applies it, with nothing re-delivered (the OW61 board's shape)` — a real loopback server, the cid resident in the space and never re-delivered; waits on the release event itself (a sink on the carrier) rather than a poll.
- The full `packages/runner` suite.
- `deno fmt`, `deno lint`, `deno check` on the touched files.

An end-to-end reproduction against the live producer (server ensure + a plain `PiecesController`-shape space-cell subscriber) was built and run first; it is green on the happy path — the ensure delivers the cid docs and the computed doc in **one** frame — which is what sent the investigation to the second-frame case rather than the first.

## Coverage

`resyncWatchSet` is pinned directly (`memory/test/v2-client-watch.test.ts`), and the park, release, pull and escalation paths are all exercised by the four `schema-doc-sync` steps. What remains uncovered is the recovery's error arms — the session refusing to answer, the resync rejecting — which are reachable only by breaking the session handle mid-flight, and a test that does so hangs the suite's teardown rather than asserting anything. Declaring the residual rather than shipping a test that fights the machinery:

ACCEPT_COVERAGE_DEBT: packages/runner +9 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
