### PR TITLE
[ablation — do not merge] OW61: resume-watermark fix ALONE under the ensure-ON lanes

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -901,15 +901,20 @@ jobs:
           # then returns, so the test steps never race a not-yet-listening
           # server. The server logs to --log-file, which the launcher prints on
           # success and dumps if the server exits before binding.
-          # Space-root ensure OFF for test lanes (OW45 arm-B stage 1,
-          # RULED 2026-08-24: production spaces always get a default
-          # pattern; tests may switch it off — the ensured root's
-          # content-addressed computed cells otherwise land in every
-          # fixture space's subscriptions).
+          # Space-root ensure ON — the production default (unset knob).
+          # The lanes opted out while OW61's crash class was open (the
+          # ensured root's content-addressed computed cells landed in
+          # fixture spaces' plain subscriptions and the arrival throw
+          # killed the consumers); with the arrival containment merged
+          # the lanes run the production posture again, and these ON
+          # lanes ARE the CI coverage of the ensure at the true
+          # topology (the OW45/OW61 rows' flagged gap). A
+          # `schema-doc-quarantine` log line here is non-fatal evidence
+          # for the client-side absorb investigation (OW61), not a
+          # failure.
           CFTS_AI_GATEWAY_URL="" \
           CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
           EXPERIMENTAL_SERVER_EXECUTION=true \
-          SERVER_EXECUTION_ENSURE_SPACE_ROOTS=false \
           ./common-binaries/toolshed --port="$TOOLSHED_PORT" \
             --background --log-file="$RUNNER_TEMP/toolshed.log"
 
@@ -966,7 +971,6 @@ jobs:
           SX_ON_IGNORE=$(deno run --allow-read ../../tasks/server-execution-on-skips.ts ${{ matrix.suite_name }})
           API_URL="http://localhost:${TOOLSHED_PORT}/" \
           EXPERIMENTAL_SERVER_EXECUTION=true \
-          SERVER_EXECUTION_ENSURE_SPACE_ROOTS=false \
           INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml ${SX_ON_IGNORE}" \
           deno task integration
 
@@ -1403,12 +1407,12 @@ jobs:
           chmod +x ./common-binaries/toolshed
           # --background waits until the server has bound its port before it
           # returns, so the test steps never race a not-yet-listening server.
-          # Space-root ensure OFF for test lanes (see the package ON
-          # lane's note; RULED 2026-08-24).
+          # Space-root ensure ON — the production default (see the
+          # package ON lane's note: the opt-out retired with OW61's
+          # arrival containment).
           CFTS_AI_GATEWAY_URL="" \
           CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
           EXPERIMENTAL_SERVER_EXECUTION=true \
-          SERVER_EXECUTION_ENSURE_SPACE_ROOTS=false \
           ./common-binaries/toolshed \
             --background --log-file="$RUNNER_TEMP/toolshed.log"
 
@@ -1467,7 +1471,6 @@ jobs:
           HEADLESS=1 \
           API_URL=http://localhost:8000/ \
           EXPERIMENTAL_SERVER_EXECUTION=true \
-          SERVER_EXECUTION_ENSURE_SPACE_ROOTS=false \
           PATTERN_INTEGRATION_SHARD="${{ matrix.shard }}/${{ matrix.total }}" \
           CF_COMPILE_CACHE_FILE="${{ github.workspace }}/.compile-cache/pattern-integration-${{ matrix.shard }}.json" \
           deno test --no-check --v8-flags=--max-old-space-size=4096 --trace-leaks -A \

--- a/packages/memory/test/v2-session-resume-watermark.test.ts
+++ b/packages/memory/test/v2-session-resume-watermark.test.ts
@@ -1,0 +1,54 @@
+import { assertEquals } from "@std/assert";
+import { SessionRegistry } from "../v2/session-registry.ts";
+
+// The sent-vs-held reconciliation on resume. `session.entities` records
+// what the server SENT, not what the client HOLDS, and it is committed
+// when a frame is built. A socket that dies mid-flight loses frames the
+// server counts as delivered — `rollbackUndeliveredSync` only repairs a
+// locally-throwing send — so the cache keeps claiming documents the
+// client never received, and the next diff elides exactly those. A
+// schema document elided that way is unobtainable: a watch.add answers
+// from the same cache, and no later frame re-stages it.
+//
+// The repair input is already on the wire: a resuming client reports the
+// highest server seq it actually received.
+Deno.test("a resume behind the last synced seq forces a full re-evaluation", () => {
+  const registry = new SessionRegistry();
+  const space = "did:key:z6Mk-resume-watermark";
+
+  const opened = registry.open(space, { sessionId: "s:1" }, 0);
+  assertEquals(registry.get(space, "s:1")?.forceFullResync, false);
+
+  // The server syncs this session out to seq 150.
+  const stored = registry.get(space, "s:1")!;
+  stored.lastSyncedSeq = 150;
+  stored.seenSeq = 150;
+
+  // The client comes back saying it only ever received through 100:
+  // frames 101..150 were sent and lost. The cache still claims them.
+  registry.open(
+    space,
+    { sessionId: "s:1", sessionToken: opened.sessionToken, seenSeq: 100 },
+    150,
+  );
+  assertEquals(registry.get(space, "s:1")?.forceFullResync, true);
+});
+
+Deno.test("a resume that is caught up does not force a re-evaluation", () => {
+  const registry = new SessionRegistry();
+  const space = "did:key:z6Mk-resume-watermark-caught-up";
+
+  const opened = registry.open(space, { sessionId: "s:2" }, 0);
+  const stored = registry.get(space, "s:2")!;
+  stored.lastSyncedSeq = 150;
+  stored.seenSeq = 150;
+
+  // The client reports exactly what the server sent it: nothing lost,
+  // so the incremental path stands and no closure is re-shipped.
+  registry.open(
+    space,
+    { sessionId: "s:2", sessionToken: opened.sessionToken, seenSeq: 150 },
+    150,
+  );
+  assertEquals(registry.get(space, "s:2")?.forceFullResync, false);
+});

--- a/packages/memory/v2/session-registry.ts
+++ b/packages/memory/v2/session-registry.ts
@@ -118,10 +118,29 @@ export class SessionRegistry {
         `session ${sessionId} resume token is no longer valid`,
       );
     }
+    const clientSeenSeq = session.seenSeq ?? 0;
     const seenSeq = Math.max(
       existing?.seenSeq ?? 0,
-      session.seenSeq ?? 0,
+      clientSeenSeq,
     );
+    // A resuming client reports the highest server seq it actually
+    // RECEIVED. When that is behind what this session was last synced
+    // to, the frames in between were sent but never arrived — a socket
+    // that dies mid-flight loses "successfully sent" frames, and only a
+    // locally-throwing send is visible in-process for
+    // `rollbackUndeliveredSync` to repair. The delivery cache still
+    // records those documents as delivered, so the next diff would
+    // elide exactly the ones the client is missing, and a schema
+    // document elided that way is unobtainable: the client cannot ask
+    // for it (a watch.add answers from the same cache) and no later
+    // frame re-stages it.
+    //
+    // The client's report is the authority on what it holds, so trust
+    // it and route the next pass through a FULL evaluation, which
+    // re-ships the whole assembled state and puts sent back in step
+    // with held.
+    const missedDelivery = existing !== undefined &&
+      clientSeenSeq < existing.lastSyncedSeq;
     const sessionToken = nextSessionToken();
     const revokedConnectionId = existing?.ownerConnectionId !== undefined &&
         existing.ownerConnectionId !== null &&
@@ -141,7 +160,7 @@ export class SessionRegistry {
         trackedIdsFromEntries(existing?.entities?.values() ?? []),
       caughtUpLocalSeq: existing?.caughtUpLocalSeq ?? 0,
       pendingCaughtUpLocalSeq: existing?.pendingCaughtUpLocalSeq ?? 0,
-      forceFullResync: existing?.forceFullResync ?? false,
+      forceFullResync: (existing?.forceFullResync ?? false) || missedDelivery,
       ...(existing?.leaseHolderReads === true
         ? { leaseHolderReads: true }
         : {}),


### PR DESCRIPTION
**Ablation board — do not merge, do not review the diff.** Exists to answer one question.

## The question

[#6258](https://github.com/commontoolsinc/labs/pull/6258) carries four fixes for OW61, and every board so far was **cumulative** — each added a fix on top of the last, so none of them isolate anything:

| board | contents | shards green |
|---|---|---|
| 1 | client absorb (park, don't dismiss) | 2 of 10 |
| 2 | + escalation to full evaluation | 4 of 10 |
| 3 | + upserts-only resync | 8 of 10 |
| 4 | + resume watermark | 9 of 10 |

Board 4's resume-watermark fix looks like the actual root cause: the session cache records what the server **sent**, not what the client **holds**, and the resuming client's own report of being behind was discarded by a `Math.max`.

If that's the cause, the client-side machinery in #6258 may now be redundant. The argument for redundancy is decent — frame loss requires a socket death, a death forces a reconnect, and the reconnect now re-ships the whole assembled state, so the client may never need to park anything.

## This board

`main` + **only** the resume-watermark fix (`session-registry.ts` + its pin) + #6248's four env-line lane flip. No park, no pull, no escalation — `grep parkedOnSchemaClosure` returns nothing.

- **9 of 10 shards** → the client-side machinery is redundant and #6258 should shrink to this one change.
- **Materially worse** → the client-side fixes carry independent weight and #6258 stays as it is, with this board as the evidence for why.

Either answer is worth the run; #6258 should not merge until it's read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

