### PR TITLE
DIAGNOSTIC (do not merge): why the client cannot verify OW61's cascade-root hash

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -21,9 +21,6 @@ concurrency:
 # variables holding the numbers are how a workflow declares a value an anchor
 # can name; nothing reads them.
 env:
-  # GitHub's Ubuntu image includes Chrome. Astral uses it directly instead of
-  # downloading another browser when the first browser test starts.
-  ASTRAL_BIN_PATH: /usr/bin/google-chrome
   WORK_TIMEOUT_MINUTES: &work-timeout 30
   JOB_TIMEOUT_MINUTES: &job-timeout 40
   CLI_WORK_TIMEOUT_MINUTES: &cli-work-timeout 10
@@ -1370,7 +1367,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        shard: [1]
         total: [10]
     steps:
       - name: 📥 Checkout repository
@@ -1406,12 +1403,12 @@ jobs:
           chmod +x ./common-binaries/toolshed
           # --background waits until the server has bound its port before it
           # returns, so the test steps never race a not-yet-listening server.
-          # Space-root ensure OFF for test lanes (see the package ON
-          # lane's note; RULED 2026-08-24).
+          # DIAGNOSTIC BRANCH: ensure ON (the production posture) and the
+          # OW61 per-session delivery probe armed.
           CFTS_AI_GATEWAY_URL="" \
           CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
           EXPERIMENTAL_SERVER_EXECUTION=true \
-          SERVER_EXECUTION_ENSURE_SPACE_ROOTS=false \
+          OW61_PROBE=1 \
           ./common-binaries/toolshed \
             --background --log-file="$RUNNER_TEMP/toolshed.log"
 
@@ -1476,6 +1473,20 @@ jobs:
           deno test --no-check --v8-flags=--max-old-space-size=4096 --trace-leaks -A \
             --junit-path=../../test-results/patterns-server-execution-on-${{ matrix.shard }}.xml \
             "${TEST_FILES[@]}"
+
+      - name: 🔬 OW61 delivery probe verdict
+        if: always()
+        run: |
+          LOG="$RUNNER_TEMP/toolshed.log"
+          echo "=== ow61 probe totals ==="
+          echo "ok frames:   $(grep -c 'ow61-ok' "$LOG" || true)"
+          echo "VIOLATIONS:  $(grep -c 'ow61-VIOLATION' "$LOG" || true)"
+          echo "held cid:    $(grep -c 'ow61-held' "$LOG" || true)"
+          echo "=== violations (first 40) ==="
+          grep 'ow61-VIOLATION' "$LOG" | head -40 || true
+          echo "=== obligation timing (same frame vs earlier) ==="
+          grep -o 'sameFrame=[0-9]* earlierFrame=[0-9]* worstLagFrames=[0-9]*' "$LOG" \
+            | sort | uniq -c | sort -rn | head -20 || true
 
       - name: 📤 Upload test timing data
         if: always()

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -165,7 +165,12 @@ const runWithAbortSignal = async <T>(
 // saw it" when the question is "did THIS replica's socket see it". The
 // per-connection sets are published on globalThis only so the arrival
 // validator in runner/src/storage/v2.ts can read them back.
-type Ow61Conn = { seen: Set<string>; frames: number; label: string };
+type Ow61Conn = {
+  seen: Set<string>;
+  frames: number;
+  label: string;
+  sessions: Set<string>;
+};
 type Ow61State = { conns: Ow61Conn[]; seq: number };
 const ow61State = (): Ow61State => {
   const g = globalThis as unknown as { __ow61?: Ow61State };
@@ -178,11 +183,19 @@ const ow61NewConn = (): Ow61Conn => {
     seen: new Set(),
     frames: 0,
     label: `c${++state.seq}`,
+    sessions: new Set(),
   };
   state.conns.push(conn);
   return conn;
 };
+const OW61_SESSION = /"sessionId":"([^"]+)"/g;
 const ow61Socket = (conn: Ow61Conn, payload: string): void => {
+  // The session a connection speaks for: a StorageManager keeps one
+  // sessionId across socket reconnects, so a hash delivered on an EARLIER
+  // connection of the same session is one the server will never re-offer.
+  for (const match of payload.matchAll(OW61_SESSION)) {
+    conn.sessions.add(match[1]);
+  }
   if (!payload.includes("cid:")) return;
   conn.frames += 1;
   const mentioned = new Set<string>();
@@ -197,7 +210,9 @@ const ow61Socket = (conn: Ow61Conn, payload: string): void => {
     }
   }
   console.error(
-    `[ow61-S1-socket] conn=${conn.label} frame=${conn.frames}` +
+    `[ow61-S1-socket] conn=${conn.label}` +
+      `/${[...conn.sessions].map((id) => id.slice(0, 8)).join("|")}` +
+      ` frame=${conn.frames}` +
       ` delivered=${delivered.map((h) => h.slice(5, 12)).join(",")}` +
       ` mentioned=${[...mentioned].map((h) => h.slice(5, 12)).join(",")}`,
   );

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -166,7 +166,7 @@ const runWithAbortSignal = async <T>(
 // per-connection sets are published on globalThis only so the arrival
 // validator in runner/src/storage/v2.ts can read them back.
 type Ow61Conn = {
-  seen: Set<string>;
+  seen: Map<string, number>;
   frames: number;
   label: string;
   sessions: Set<string>;
@@ -180,7 +180,7 @@ const OW61_CID = /cid:(fid1:[A-Za-z0-9_-]+)/g;
 const ow61NewConn = (): Ow61Conn => {
   const state = ow61State();
   const conn: Ow61Conn = {
-    seen: new Set(),
+    seen: new Map(),
     frames: 0,
     label: `c${++state.seq}`,
     sessions: new Set(),
@@ -206,7 +206,7 @@ const ow61Socket = (conn: Ow61Conn, payload: string): void => {
   for (const hash of mentioned) {
     if (payload.includes(`"id":"cid:${hash}"`)) {
       delivered.push(hash);
-      conn.seen.add(hash);
+      if (!conn.seen.has(hash)) conn.seen.set(hash, conn.frames);
     }
   }
   console.error(

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -155,6 +155,55 @@ const runWithAbortSignal = async <T>(
   }
 };
 
+// ---- OW61 TEMPORARY DIAGNOSTIC (not for commit) ----
+// Stage S1: what physically arrived, read off the raw payload text before
+// any decode, so a loss inside parsing, schema expansion, or dispatch is
+// separable from a frame that never came.
+//
+// Keyed PER CONNECTION, not on globalThis: the pattern lanes run every
+// replica in one browser realm, so a realm-wide set answers "some socket
+// saw it" when the question is "did THIS replica's socket see it". The
+// per-connection sets are published on globalThis only so the arrival
+// validator in runner/src/storage/v2.ts can read them back.
+type Ow61Conn = { seen: Set<string>; frames: number; label: string };
+type Ow61State = { conns: Ow61Conn[]; seq: number };
+const ow61State = (): Ow61State => {
+  const g = globalThis as unknown as { __ow61?: Ow61State };
+  return (g.__ow61 ??= { conns: [], seq: 0 });
+};
+const OW61_CID = /cid:(fid1:[A-Za-z0-9_-]+)/g;
+const ow61NewConn = (): Ow61Conn => {
+  const state = ow61State();
+  const conn: Ow61Conn = {
+    seen: new Set(),
+    frames: 0,
+    label: `c${++state.seq}`,
+  };
+  state.conns.push(conn);
+  return conn;
+};
+const ow61Socket = (conn: Ow61Conn, payload: string): void => {
+  if (!payload.includes("cid:")) return;
+  conn.frames += 1;
+  const mentioned = new Set<string>();
+  for (const match of payload.matchAll(OW61_CID)) mentioned.add(match[1]);
+  // An id appearing as an UPSERT id is a delivered schema document; a bare
+  // mention inside a `$ref` is only a demand.
+  const delivered: string[] = [];
+  for (const hash of mentioned) {
+    if (payload.includes(`"id":"cid:${hash}"`)) {
+      delivered.push(hash);
+      conn.seen.add(hash);
+    }
+  }
+  console.error(
+    `[ow61-S1-socket] conn=${conn.label} frame=${conn.frames}` +
+      ` delivered=${delivered.map((h) => h.slice(5, 12)).join(",")}` +
+      ` mentioned=${[...mentioned].map((h) => h.slice(5, 12)).join(",")}`,
+  );
+};
+// ---- end OW61 TEMPORARY DIAGNOSTIC ----
+
 export class Client {
   #pending = new Map<string, PromiseWithResolvers<unknown>>();
   #spaces = new Set<SpaceSession>();
@@ -370,7 +419,10 @@ export class Client {
     }
   }
 
+  readonly #ow61Conn = ow61NewConn();
+
   private onMessage(payload: string): void {
+    ow61Socket(this.#ow61Conn, payload);
     let message: unknown;
     try {
       message = decodeMemoryBoundary(payload);

--- a/packages/memory/v2/server-sync.ts
+++ b/packages/memory/v2/server-sync.ts
@@ -13,6 +13,99 @@ import {
 } from "../v2.ts";
 import { toDirtyKey } from "./query.ts";
 
+// ---- OW61 TEMPORARY DIAGNOSTIC (not for commit) ----
+import { collectExternalSchemaRefHashes } from "../../runner/src/schema-decompose.ts";
+import { isSubschema } from "../../runner/src/schema-walk.ts";
+import { mapLinkSchemas } from "./schema-table-links.ts";
+import { isObjectNotArray } from "@commonfabric/utils/types";
+import type { JSONSchema } from "@commonfabric/api";
+
+// Per session: hash -> the ordinal of the frame that first carried it, so
+// an obligation can be reported as met in the SAME frame, met by an
+// EARLIER frame (and how many back), or never met at all.
+const ow61Sent = new Map<string, Map<string, number>>();
+const ow61FrameNo = new Map<string, number>();
+const ow61On = () => {
+  try {
+    return Deno.env.get("OW61_PROBE") === "1";
+  } catch {
+    return false;
+  }
+};
+export const ow61Frame = (
+  where: string,
+  sessionId: string,
+  upserts: readonly SessionCacheEntry[],
+): void => {
+  if (!ow61On()) return;
+  let sent = ow61Sent.get(sessionId);
+  if (sent === undefined) {
+    sent = new Map();
+    ow61Sent.set(sessionId, sent);
+  }
+  const frameNo = (ow61FrameNo.get(sessionId) ?? 0) + 1;
+  ow61FrameNo.set(sessionId, frameNo);
+
+  const inFrame: string[] = [];
+  for (const entry of upserts) {
+    if (entry.id.startsWith("cid:")) {
+      const hash = entry.id.slice(4);
+      inFrame.push(hash);
+      if (!sent.has(hash)) sent.set(hash, frameNo);
+    }
+  }
+  const need: Array<[string, string]> = [];
+  for (const entry of upserts) {
+    const doc = entry.doc;
+    if (!isObjectNotArray(doc)) continue;
+    if (entry.id.startsWith("cid:")) {
+      const inner = (doc as { value?: unknown }).value;
+      if (isSubschema(inner)) {
+        for (const h of collectExternalSchemaRefHashes(inner as JSONSchema)) {
+          need.push([entry.id, h]);
+        }
+      }
+      continue;
+    }
+    mapLinkSchemas(doc as never, (schema) => {
+      for (const h of collectExternalSchemaRefHashes(schema as JSONSchema)) {
+        need.push([entry.id, h]);
+      }
+      return schema;
+    });
+  }
+  if (need.length === 0) return;
+
+  let sameFrame = 0;
+  let earlier = 0;
+  let worstLag = 0;
+  const missing: string[] = [];
+  for (const [id, hash] of need) {
+    const carried = sent.get(hash);
+    if (carried === undefined) {
+      missing.push(`${id}->cid:${hash}`);
+    } else if (carried === frameNo) {
+      sameFrame += 1;
+    } else {
+      earlier += 1;
+      worstLag = Math.max(worstLag, frameNo - carried);
+    }
+  }
+  if (missing.length > 0) {
+    console.error(
+      `[ow61-VIOLATION] ${where} session=${sessionId.slice(0, 10)} ` +
+        `frame=${frameNo} missing=${missing.join(" ")}`,
+    );
+    return;
+  }
+  console.error(
+    `[ow61-ok] ${where} session=${sessionId.slice(0, 10)} frame=${frameNo} ` +
+      `refs=${need.length} sameFrame=${sameFrame} earlierFrame=${earlier} ` +
+      `worstLagFrames=${worstLag}`,
+  );
+};
+// ---- end OW61 TEMPORARY DIAGNOSTIC ----
+
 /**
  * A session's cached snapshot of one tracked doc INSTANCE. `scopeKey` is
  * server-internal (the wire upsert keeps the scope NAME — a client's

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -104,6 +104,7 @@ import {
   groupedQueries,
   isEmptySync,
   mergeWatchesById,
+  ow61Frame,
   sameSnapshot,
   sameWatchSpec,
   type SessionCacheEntry,
@@ -3426,6 +3427,7 @@ export class Server {
           sessionId: message.sessionId,
         },
       );
+      ow61Frame("watch.set", message.sessionId, [...entities.values()]);
       const sync = buildFullSync(
         session.entities,
         entities,
@@ -3655,6 +3657,7 @@ export class Server {
         session.trackedIds.add(toDirtyKey(entry.id, entry.scopeKey));
       }
 
+      ow61Frame("watch.add", message.sessionId, upserts);
       const serverSeq = Engine.serverSeq(engine);
       const fromSeq = session.lastSyncedSeq;
       session.graphs = graphs;
@@ -4173,6 +4176,13 @@ export class Server {
                   origin.sessionId === sessionId &&
                   origin.seq === entry.seq &&
                   (origin.op !== "patch" || !getOwnWriteEchoConfig());
+                if (held && entry.id.startsWith("cid:")) {
+                  console.error(
+                    `[ow61-held] cid elided as own-write session=${sessionId} ` +
+                      `principal=${session.principal} originOp=${origin?.op} ` +
+                      `seq=${entry.seq} id=${entry.id}`,
+                  );
+                }
                 if (!held) {
                   upserts.push(entry);
                 }
@@ -4232,6 +4242,7 @@ export class Server {
             recordSlowQueryDuration("session.watch.refresh", space, startedAt, {
               watches: session.watches.length,
             });
+            ow61Frame("push", sessionId, upserts);
             const message = finishCatchUp({
               type: "sync",
               fromSeq,
@@ -4299,6 +4310,7 @@ export class Server {
             delivered,
             keyed,
           );
+          ow61Frame("full-reeval", sessionId, delivered.upserts);
           // As above: commit the re-evaluated watch state only once the
           // frame is built, so a throw leaves the diff recomputable. The
           // empty-sync branch commits first — its frame carries no doc

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2449,6 +2449,114 @@ const docKey = (id: URI, instance: string): string => `${instance}\0${id}`;
  * caller knows it, the explicit instance key. */
 type LocalDocAddress = { id: URI; scope?: CellScope; scopeKey?: ScopeKey };
 
+// ---- OW61 TEMPORARY DIAGNOSTIC (not for commit) ----
+// Stages S2/S3/S4 of the arrival path, paired with stage S1 in
+// memory/v2/client.ts. S1 records what the socket saw; these say what the
+// frame carried on entry to apply, what the store held before and after,
+// and — at a quarantine — how far the missing document actually got.
+type Ow61Conn = { seen: Set<string>; frames: number; label: string };
+type Ow61State = { conns: Ow61Conn[]; seq: number };
+const ow61State = (): Ow61State => {
+  const g = globalThis as unknown as { __ow61?: Ow61State };
+  return (g.__ow61 ??= { conns: [], seq: 0 });
+};
+/** Which connections' sockets saw `hash` delivered — by label, so a
+ *  realm-wide hit is no longer reported as this replica's. */
+const ow61ConnsSeeing = (hash: string): string[] =>
+  ow61State().conns.filter((conn) => conn.seen.has(hash)).map((c) => c.label);
+
+const ow61CidsOf = (sync: SessionSync): string[] => {
+  const ids: string[] = [];
+  for (const upsert of sync.upserts) {
+    if (typeof upsert.id === "string" && upsert.id.startsWith("cid:")) {
+      ids.push(upsert.id.slice("cid:".length));
+    }
+  }
+  return ids;
+};
+
+const ow61Apply = (
+  replica: SpaceReplica,
+  sync: SessionSync,
+  type: string,
+): void => {
+  const carried = ow61CidsOf(sync);
+  if (carried.length === 0) return;
+  const held = carried.filter((hash) =>
+    (replica as unknown as { isSchemaDocPersisted(h: string): boolean })
+      .isSchemaDocPersisted(hash)
+  );
+  logger.error("ow61-S2-apply", () => [
+    `type=${type} toSeq=${sync.toSeq} carried=${
+      carried.map((h) => h.slice(5, 12)).join(",")
+    } alreadyHeld=${held.length}/${carried.length}`,
+  ]);
+  // S3: the same question after this frame has applied.
+  queueMicrotask(() => {
+    const after = carried.filter((hash) =>
+      (replica as unknown as { isSchemaDocPersisted(h: string): boolean })
+        .isSchemaDocPersisted(hash)
+    );
+    logger.error("ow61-S3-stored", () => [
+      `toSeq=${sync.toSeq} storedAfterApply=${after.length}/${carried.length}` +
+      ` missing=${
+        carried.filter((h) => !after.includes(h)).map((h) => h.slice(5, 12))
+          .join(",")
+      }`,
+    ]);
+  });
+};
+
+/**
+ * Why `#isVerifiedSchemaDocDelivered` said no, for one hash, at the moment
+ * the fixpoint asked. The three answers are different bugs: `absent` means
+ * the document never reached this replica (transport, ordering, or a frame
+ * addressed to another replica); `value-not-subschema` means it arrived
+ * with the wrong shape; `HASH-MISMATCH` means it arrived and something
+ * between the wire and here rewrote it, which would make the schema
+ * expansion in the memory client the suspect.
+ */
+const ow61Describe = (doc: unknown, hash: string): string => {
+  if (doc === undefined) return "absent";
+  if (!isObjectNotArray(doc)) return `not-an-object(${typeof doc})`;
+  const value = (doc as { value?: unknown }).value;
+  if (value === undefined) return "no-value-member";
+  if (!isSubschema(value)) {
+    return `value-not-subschema(${
+      Array.isArray(value) ? "array" : typeof value
+    })`;
+  }
+  const actual = internSchemaAsTaggedHashString(value as JSONSchema);
+  return actual === hash
+    ? "verified"
+    : `HASH-MISMATCH actual=${actual.slice(0, 20)}`;
+};
+
+const ow61Why = (
+  replica: SpaceReplica,
+  hash: string,
+  overlay: ReadonlyMap<string, unknown>,
+): string => {
+  const store = replica as unknown as { getDocument(uri: string): unknown };
+  return `overlay=${ow61Describe(overlay.get(`cid:${hash}`), hash)}` +
+    ` store=${ow61Describe(store.getDocument(`cid:${hash}`), hash)}` +
+    ` inFrameOverlay=${overlay.has(`cid:${hash}`)}`;
+};
+
+const ow61Stages = (replica: SpaceReplica, hash: string): string => {
+  const state = ow61State();
+  const store = replica as unknown as {
+    isSchemaDocPersisted(h: string): boolean;
+    getDocument(uri: string): unknown;
+  };
+  const seenBy = ow61ConnsSeeing(hash);
+  const inStore = store.getDocument(`cid:${hash}`) !== undefined;
+  const confirmed = store.isSchemaDocPersisted(hash);
+  return `cid:${hash.slice(5, 12)} socketConns=[${seenBy.join(",")}]` +
+    ` ofConns=${state.conns.length} store=${inStore} confirmed=${confirmed}`;
+};
+// ---- end OW61 TEMPORARY DIAGNOSTIC ----
+
 class SpaceReplica implements ISpaceReplica {
   readonly #space: MemorySpace;
   readonly #subscription: IStorageSubscription;
@@ -5472,6 +5580,9 @@ class SpaceReplica implements ISpaceReplica {
             quarantined.add(referrer);
             overlay.delete(referrer);
             changed = true;
+            logger.error("schema-doc-quarantine-stages", () => [
+              `${ow61Stages(this, dep)} ${ow61Why(this, dep, overlay)}`,
+            ]);
             logger.error("schema-doc-quarantine", () => [
               `Document ${referrer} was delivered with a broken schema ` +
               `ref: cid:${dep} is not delivered and verified in this ` +
@@ -5541,6 +5652,7 @@ class SpaceReplica implements ISpaceReplica {
       return;
     }
 
+    ow61Apply(this, sync, type);
     // Validation precedes every record mutation: an entry that fails the
     // delivery guarantee is QUARANTINED (dropped from this frame with a
     // loud diagnostic — never half-installed, never a process kill; see

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2454,7 +2454,12 @@ type LocalDocAddress = { id: URI; scope?: CellScope; scopeKey?: ScopeKey };
 // memory/v2/client.ts. S1 records what the socket saw; these say what the
 // frame carried on entry to apply, what the store held before and after,
 // and — at a quarantine — how far the missing document actually got.
-type Ow61Conn = { seen: Set<string>; frames: number; label: string };
+type Ow61Conn = {
+  seen: Set<string>;
+  frames: number;
+  label: string;
+  sessions: Set<string>;
+};
 type Ow61State = { conns: Ow61Conn[]; seq: number };
 const ow61State = (): Ow61State => {
   const g = globalThis as unknown as { __ow61?: Ow61State };
@@ -2462,8 +2467,8 @@ const ow61State = (): Ow61State => {
 };
 /** Which connections' sockets saw `hash` delivered — by label, so a
  *  realm-wide hit is no longer reported as this replica's. */
-const ow61ConnsSeeing = (hash: string): string[] =>
-  ow61State().conns.filter((conn) => conn.seen.has(hash)).map((c) => c.label);
+const ow61ConnsSeeing = (hash: string): Ow61Conn[] =>
+  ow61State().conns.filter((conn) => conn.seen.has(hash));
 
 const ow61CidsOf = (sync: SessionSync): string[] => {
   const ids: string[] = [];
@@ -2549,11 +2554,30 @@ const ow61Stages = (replica: SpaceReplica, hash: string): string => {
     isSchemaDocPersisted(h: string): boolean;
     getDocument(uri: string): unknown;
   };
+  const mySession = ow61MySession(replica);
   const seenBy = ow61ConnsSeeing(hash);
-  const inStore = store.getDocument(`cid:${hash}`) !== undefined;
-  const confirmed = store.isSchemaDocPersisted(hash);
-  return `cid:${hash.slice(5, 12)} socketConns=[${seenBy.join(",")}]` +
-    ` ofConns=${state.conns.length} store=${inStore} confirmed=${confirmed}`;
+  // The discriminator: a connection of MY OWN session saw this hash
+  // delivered, and my store no longer holds it — the server will never
+  // re-offer it, because for that session it counts as delivered.
+  const sameSession = seenBy.filter((conn) =>
+    mySession !== undefined && conn.sessions.has(mySession)
+  );
+  return `cid:${hash.slice(5, 12)} mySession=${mySession?.slice(0, 8)}` +
+    ` seenByConns=[${seenBy.map((c) => c.label).join(",")}]` +
+    ` seenBySAMEsession=[${sameSession.map((c) => c.label).join(",")}]` +
+    ` ofConns=${state.conns.length}` +
+    ` store=${store.getDocument(`cid:${hash}`) !== undefined}` +
+    ` confirmed=${store.isSchemaDocPersisted(hash)}`;
+};
+
+const ow61MySession = (replica: SpaceReplica): string | undefined => {
+  try {
+    return (replica as unknown as {
+      ow61Identity(): { sessionId?: string };
+    }).ow61Identity().sessionId;
+  } catch {
+    return undefined;
+  }
 };
 // ---- end OW61 TEMPORARY DIAGNOSTIC ----
 
@@ -2786,6 +2810,9 @@ class SpaceReplica implements ISpaceReplica {
     this.#space = options.space;
     this.#subscription = options.subscription;
     this.#scopeKeyIdentity = options.scopeKeyIdentity;
+    // OW61 TEMPORARY: the probe needs this replica's session identity.
+    (this as unknown as { ow61Identity: () => ScopeKeyIdentity }).ow61Identity =
+      () => this.#scopeKeyIdentity();
     this.#createSession = options.createSession;
     this.#getTelemetry = options.getTelemetry ?? (() => undefined);
     this.#settings = options.settings;

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -5585,7 +5585,22 @@ class SpaceReplica implements ISpaceReplica {
         continue;
       }
       const doc = upsert.doc;
-      if (!isObjectNotArray(doc)) continue;
+      if (!isObjectNotArray(doc)) {
+        // OW61 TEMPORARY: a carried upsert that never enters the overlay is
+        // invisible to every later resolution in this frame.
+        if (id.startsWith("cid:")) {
+          logger.error("ow61-OVERLAY-SKIP", () => [
+            `id=${id.slice(0, 20)} docType=${
+              doc === undefined
+                ? "undefined"
+                : Array.isArray(doc)
+                ? "array"
+                : typeof doc
+            } deleted=${upsert.deleted} keys=${Object.keys(upsert).join(",")}`,
+          ]);
+        }
+        continue;
+      }
       overlay.set(id, doc);
       deletedInFrame.delete(id);
       if (id.startsWith("cid:")) {
@@ -5611,6 +5626,13 @@ class SpaceReplica implements ISpaceReplica {
         // check is a forged replacement, not another document class.
         // Quarantine the ARRIVING copy; the stored verified one stays,
         // so refs to this hash keep resolving.
+        logger.error("ow61-CID-NOT-IDENTITY", () => [
+          `id=${id.slice(0, 20)} isSubschema=${isSubschema(value)} actual=${
+            isSubschema(value)
+              ? internSchemaAsTaggedHashString(value as JSONSchema).slice(0, 20)
+              : "n/a"
+          }`,
+        ]);
         if (this.#isVerifiedSchemaDocDelivered(hash, EMPTY_OVERLAY)) {
           quarantined.add(id);
           overlay.delete(id);

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2813,6 +2813,13 @@ class SpaceReplica implements ISpaceReplica {
     // OW61 TEMPORARY: the probe needs this replica's session identity.
     (this as unknown as { ow61Identity: () => ScopeKeyIdentity }).ow61Identity =
       () => this.#scopeKeyIdentity();
+    queueMicrotask(() => {
+      logger.error("ow61-replica-new", () => [
+        `space=${this.#space.slice(-8)} session=${
+          this.#scopeKeyIdentity().sessionId?.slice(0, 8)
+        }`,
+      ]);
+    });
     this.#createSession = options.createSession;
     this.#getTelemetry = options.getTelemetry ?? (() => undefined);
     this.#settings = options.settings;
@@ -4154,6 +4161,13 @@ class SpaceReplica implements ISpaceReplica {
         this.makeLocalRejection(entry.commit, "memory replica reset"),
       );
     }
+    logger.error("ow61-replica-RESET", () => [
+      `space=${this.#space.slice(-8)} session=${
+        this.#scopeKeyIdentity().sessionId?.slice(0, 8)
+      } docsWiped=${this.#docs.size} cidsWiped=${
+        [...this.#docs.keys()].filter((k) => k.includes("cid:")).length
+      }`,
+    ]);
     this.#docs.clear();
     this.#watchedIds.clear();
     this.resetConflictAdmissionState();

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2455,7 +2455,7 @@ type LocalDocAddress = { id: URI; scope?: CellScope; scopeKey?: ScopeKey };
 // frame carried on entry to apply, what the store held before and after,
 // and — at a quarantine — how far the missing document actually got.
 type Ow61Conn = {
-  seen: Set<string>;
+  seen: Map<string, number>;
   frames: number;
   label: string;
   sessions: Set<string>;
@@ -2469,6 +2469,12 @@ const ow61State = (): Ow61State => {
  *  realm-wide hit is no longer reported as this replica's. */
 const ow61ConnsSeeing = (hash: string): Ow61Conn[] =>
   ow61State().conns.filter((conn) => conn.seen.has(hash));
+
+// Only the FIRST quarantine on a replica characterises the trigger. Every
+// one after it is cascade: a quarantine drops correctly delivered schema
+// documents, the server never re-offers them, and they become the next
+// frame's missing deps. Counting quarantines counts the cascade.
+const ow61FirstFire = new WeakSet<object>();
 
 const ow61CidsOf = (sync: SessionSync): string[] => {
   const ids: string[] = [];
@@ -2546,6 +2552,38 @@ const ow61Why = (
   return `overlay=${ow61Describe(overlay.get(`cid:${hash}`), hash)}` +
     ` store=${ow61Describe(store.getDocument(`cid:${hash}`), hash)}` +
     ` inFrameOverlay=${overlay.has(`cid:${hash}`)}`;
+};
+
+/**
+ * The state at a replica's FIRST quarantine — the only one that describes
+ * the trigger rather than the cascade it starts.
+ */
+const ow61First = (
+  replica: SpaceReplica,
+  hash: string,
+  sync: SessionSync,
+): string => {
+  const store = replica as unknown as { getDocument(uri: string): unknown };
+  const mySession = ow61MySession(replica);
+  const carried = ow61CidsOf(sync);
+  const seenAt = ow61State().conns
+    .filter((conn) =>
+      mySession !== undefined && conn.sessions.has(mySession) &&
+      conn.seen.has(hash)
+    )
+    .map((conn) =>
+      `${conn.label}@frame${conn.seen.get(hash)}/of${conn.frames}`
+    );
+  const heldCids = ow61State().conns.length;
+  return `missing=cid:${hash.slice(5, 12)} session=${mySession?.slice(0, 8)}` +
+    ` frameType=${(sync as { type?: string }).type ?? "?"}` +
+    ` fromSeq=${(sync as { fromSeq?: number }).fromSeq}` +
+    ` toSeq=${sync.toSeq}` +
+    ` frameCarriedCids=${carried.length}` +
+    ` frameCarriesMissing=${carried.includes(hash)}` +
+    ` storeHasMissing=${store.getDocument(`cid:${hash}`) !== undefined}` +
+    ` mySessionSawItAt=[${seenAt.join(",")}]` +
+    ` connsInRealm=${heldCids}`;
 };
 
 const ow61Stages = (replica: SpaceReplica, hash: string): string => {
@@ -5621,6 +5659,13 @@ class SpaceReplica implements ISpaceReplica {
             quarantined.add(referrer);
             overlay.delete(referrer);
             changed = true;
+            if (!ow61FirstFire.has(this)) {
+              ow61FirstFire.add(this);
+              logger.error(
+                "ow61-FIRST-FIRE",
+                () => [ow61First(this, dep, sync)],
+              );
+            }
             logger.error("schema-doc-quarantine-stages", () => [
               `${ow61Stages(this, dep)} ${ow61Why(this, dep, overlay)}`,
             ]);

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -5681,6 +5681,15 @@ class SpaceReplica implements ISpaceReplica {
             quarantined.add(referrer);
             overlay.delete(referrer);
             changed = true;
+            logger.error("ow61-FRAME-FAIL", () => [
+              `dep=cid:${dep.slice(5, 12)} frameCarried=${
+                ow61CidsOf(sync).length
+              } depIsInThisFrame=${ow61CidsOf(sync).includes(dep)} ` +
+              `referrer=${referrer.slice(0, 24)} ` +
+              `carried=${
+                ow61CidsOf(sync).map((h) => h.slice(5, 12)).join(",")
+              }`,
+            ]);
             if (!ow61FirstFire.has(this)) {
               ow61FirstFire.add(this);
               logger.error(


### PR DESCRIPTION
**Throwaway diagnostic. Do not merge, do not review.** Closed once it produces
its measurement. Third in a series after #6276 and #6277.

## Where the investigation is

#6276 established the server ships every referenced `cid:` (0 delivery
violations against 103 client quarantines in one run). #6277 staged the client
arrival path and found the shape of the loss: in one frame at `toSeq=4`,
**19 `cid:` documents delivered, 7 stored**. The 12 that vanished were
themselves quarantined on the *"broken schema ref"* branch, all naming one
dependency — `cid:fid1:ayhc5ov…` — which was itself never quarantined. One
fixpoint cascade from a single hash the validator could not verify.

## The two questions this closes

**Why could it not verify it?** `#isVerifiedSchemaDocDelivered` returns true
only when the overlay or the store holds content under `cid:<hash>` that is a
subschema whose `internSchemaAsTaggedHashString` equals the hash. Three ways to
fail, three different bugs. The probe now reports which, at the moment the
fixpoint asks:

- `absent` — never reached this replica (transport, ordering, or a frame for
  another replica)
- `value-not-subschema(...)` — arrived with the wrong shape
- `HASH-MISMATCH actual=…` — arrived and was **rewritten between the wire and
  the validator**, which would put `expandServerMessageSchemas`
  (`memory/v2/sync-schema-table.ts`, called from `client.ts onMessage`
  whenever the raw payload carries a reserved schema-ref substring) squarely in
  the frame

**Did it reach THIS replica?** The socket stage was keyed on `globalThis`, and
the pattern lanes run every replica in one browser realm — so it answered "some
socket saw it" when the question is "did this replica's socket see it". That
was a real weakness in the previous run's verdict and is called out as such.
S1 is now per connection, and the quarantine site names which connections saw
the hash delivered.

## Positive control

Against this repository's own containment pin — whose interceptor deliberately
drops `cid:` upserts between socket and store — the verdict reads
`overlay=absent store=absent inFrameOverlay=false`. The instrument names the
injected loss at exactly the stage that injects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/6284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

