### PR TITLE
Repair transaction dependencies outside graph watches

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -71,6 +71,10 @@ a record: archive it to `docs/history/plans/` following the procedure in
   and packing rules, and the two things a subset breaks and this replaces:
   coverage becomes a trend rather than a gate, and a regression that only
   `main` catches is reported back to the change that introduced it.
+- [Transaction conflict repair](transaction-conflict-repair.md) proposes
+  transaction-owned repair coverage, applied-repair receipts, reconnect and
+  cancellation ownership, and a staged implementation for dependencies outside
+  ordinary graph watches.
 - [Memory `apply-op`](memory-apply-op.md) sequences the editor-neutral
   collaborative-field substrate, the first CodeMirror codec and editor
   integration, and the checkpoints and review gates required before a future

--- a/docs/plans/transaction-conflict-repair.md
+++ b/docs/plans/transaction-conflict-repair.md
@@ -72,10 +72,10 @@ The document footprint is the deduplicated union of:
 3. document operation targets.
 
 Each internal address contains space, branch, entity ID, scope, and resolved
-scope instance. Reads use their explicitly named branch or the commit branch;
-operation targets use the commit branch. Scope resolution must share the
-transaction validator's rules. An unresolvable scope is a failure to repair, not
-permission to substitute a different instance.
+scope instance. Confirmed reads use their explicitly named branch or the commit
+branch; pending reads and operation targets use the commit branch. Scope
+resolution must share the transaction validator's rules. An unresolvable scope
+is a failure to repair, not permission to substitute a different instance.
 
 The wire uses the ordinary recipient's scope vocabulary. Explicit foreign
 instance keys remain subject to the existing lease-holder read authorization.
@@ -436,10 +436,15 @@ criteria.
 Implement in the following stages. Intermediate work can be reviewed with the
 capability inactive; do not enable a partial lifecycle in deployed clients.
 
-1. [ ] Define the protocol types, shared footprint builder, recovery ownership
-       interface, and failure classification. Update memory specs for explicit
-       repair coverage, receipts, and release. Pin branch/scope resolution and
-       exact membership in focused tests.
+1. [ ] Define the protocol types, recovery ownership interface, and failure
+       classification. Update memory specs for explicit repair coverage,
+       receipts, and release. The shared footprint builder and its branch/scope
+       membership tests are implemented in
+       [transaction-repair.ts](../../packages/memory/v2/transaction-repair.ts)
+       and
+       [its unit tests](../../packages/memory/test/v2-transaction-repair.test.ts).
+       Server conflict staging uses that builder; it still repairs through graph
+       watches until the following stages supply independent coverage.
 2. [ ] Implement the server repair component and shared snapshot/schema
        assembly. Compose it into incremental/full/no-watch sync paths and
        separate execution demand from delivery holdings. Verify a direct

--- a/docs/plans/transaction-conflict-repair.md
+++ b/docs/plans/transaction-conflict-repair.md
@@ -1,6 +1,6 @@
 # Transaction conflict repair
 
-Status: proposed design; implementation pending.
+Status: implementation in progress; protocol activation pending.
 
 ## Decision
 
@@ -43,9 +43,10 @@ Holding a document does not by itself make that document application demand.
 
 These distinctions have concrete implementation consequences:
 
-- `SessionState.entities` can remain the delivery diff base for the union of
-  graph and repair coverage. Execution demand must then be derived from graph
-  provenance rather than from every entry in that delivery map.
+- `SessionState.entities` remains the graph delivery diff base and graph
+  provenance. `RepairCoverage` keeps a separate delivery map for retained repair
+  documents. The frame composer unions their delivery at the boundary; execution
+  demand continues to derive from the graph state alone.
 - A document remains covered while either an ordinary watch or any active
   recovery owns it. Removing one owner cannot evict another owner's basis.
 - `session.watch.set` replaces ordinary watches only. A request prepared before
@@ -153,8 +154,9 @@ silently discard an owned basis.
 
 ## 4. Protocol changes
 
-Use a negotiated capability, provisionally `transactionRepairV1`. The names
-below are proposed wire fields, not existing exports.
+Use a negotiated capability, provisionally `transactionRepairV1`. The receipt,
+failure, conflict identity, and release types are defined; session admission
+does not enable them yet. The reconnect declaration remains to be implemented.
 
 | Surface           | Proposed addition | Meaning                                                                                                                                                       |
 | ----------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -443,12 +445,18 @@ capability inactive; do not enable a partial lifecycle in deployed clients.
        [transaction-repair.ts](../../packages/memory/v2/transaction-repair.ts)
        and
        [its unit tests](../../packages/memory/test/v2-transaction-repair.test.ts).
-       Server conflict staging uses that builder; it still repairs through graph
-       watches until the following stages supply independent coverage.
-2. [ ] Implement the server repair component and shared snapshot/schema
-       assembly. Compose it into incremental/full/no-watch sync paths and
-       separate execution demand from delivery holdings. Verify a direct
-       memory-client conflict on an unwatched document.
+       Server conflict staging uses that builder. Ordinary sessions retain
+       graph-watch recovery until the complete lifecycle can be negotiated.
+2. [ ] Finish the server lifecycle around the implemented
+       [repair component](../../packages/memory/v2/repair-coverage.ts) and
+       shared raw snapshot/schema assembly. Push fan-out, watch
+       replacement/addition, send failure, and explicit release compose repair
+       delivery independently of graph demand. The
+       [server transport tests](../../packages/memory/test/v2-server-repair.test.ts)
+       install coverage through the internal session registry and verify an
+       unwatched scoped conflict, successful fresh retry, and cleanup.
+       Negotiated admission, complete reconnect declarations, authorization
+       lifecycle tests, and resource bounds remain before activation.
 3. [ ] Implement receipt validation, explicit release, and reconnect
        declarations in the memory client and runner replica. Exercise lost
        frames, unknown verdicts, changed logical identity, and unchanged
@@ -470,7 +478,7 @@ Principal implementation seams:
 | File                                                                                                                                                                                                                                           | Responsibility                                                                                                          |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | [memory/v2.ts](../../packages/memory/v2.ts) and [memory/interface.ts](../../packages/memory/interface.ts)                                                                                                                                      | Protocol shapes, scope vocabulary, rejection/recovery interface.                                                        |
-| [memory/v2/session-registry.ts](../../packages/memory/v2/session-registry.ts)                                                                                                                                                                  | Per-session repair ownership and restoration.                                                                           |
+| [memory/v2/repair-coverage.ts](../../packages/memory/v2/repair-coverage.ts) and [session-registry.ts](../../packages/memory/v2/session-registry.ts)                                                                                            | Per-session repair ownership and restoration.                                                                           |
 | [memory/v2/server.ts](../../packages/memory/v2/server.ts)                                                                                                                                                                                      | Rejection staging, publication ordering, coverage composition, release, authorization, and execution-demand provenance. |
 | [memory/v2/query.ts](../../packages/memory/v2/query.ts) and [server-sync.ts](../../packages/memory/v2/server-sync.ts)                                                                                                                          | Shared snapshot/schema assembly and union delivery differences.                                                         |
 | [memory/v2/client.ts](../../packages/memory/v2/client.ts)                                                                                                                                                                                      | Recovery handles, receipts, release batching, and reconnect declarations.                                               |

--- a/docs/plans/transaction-conflict-repair.md
+++ b/docs/plans/transaction-conflict-repair.md
@@ -1,0 +1,535 @@
+# Transaction conflict repair
+
+Status: proposed design; implementation pending.
+
+## Decision
+
+Memory conflict recovery must deliver a rejected transaction's document
+dependencies even when the application's graph watches cannot reach them.
+Successful writes retain their optimistic path. Recovery creates temporary,
+explicit document coverage owned by the operation that will consume the repair.
+
+The correctness contract is:
+
+> Successful repair readiness means that the receiving replica has installed
+> authoritative bases for the rejected transaction's document footprint, sampled
+> at a server cut at or after rejection, and that recovery keeps those bases
+> covered until its owner finishes or cancels.
+
+A transaction must be rebuilt against those bases. Repair does not change the
+read versions of a transaction computed from stale data.
+
+The acceptance fixture seeds a space output pointing to another space document
+and an existing user instance of the output. A fresh runtime loads the space
+output, then attempts to write the computed result into its user instance and
+restore the space-to-user redirect atomically. The unseen user instance produces
+a stale sequence-0 read. Awaited conflict repair must make the next freshly
+computed transaction succeed without an explicit user sync.
+
+The fixture belongs in `packages/runner/test/scoped-output-restoration.test.ts`
+when the recovery implementation is added. This plan proposes behavior; it does
+not report a passing implementation or a measured performance improvement.
+
+## 1. Separate the three kinds of state
+
+| State             | Purpose                                                             | Owner and lifetime                                         |
+| ----------------- | ------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Graph watches     | Select live application data and establish execution demand.        | Application subscriptions.                                 |
+| Repair coverage   | Keep the authoritative document bases needed by recovery available. | A recovery operation, through consumption or cancellation. |
+| Delivery holdings | Describe the document versions the replica actually absorbed.       | The replica; declared when reconnecting.                   |
+
+Repair coverage contributes to synchronization, but not to execution demand.
+Holding a document does not by itself make that document application demand.
+
+These distinctions have concrete implementation consequences:
+
+- `SessionState.entities` can remain the delivery diff base for the union of
+  graph and repair coverage. Execution demand must then be derived from graph
+  provenance rather than from every entry in that delivery map.
+- A document remains covered while either an ordinary watch or any active
+  recovery owns it. Removing one owner cannot evict another owner's basis.
+- `session.watch.set` replaces ordinary watches only. A request prepared before
+  a conflict must not erase the conflict's independently owned repair coverage.
+- Repair coverage uses direct document snapshots. Naming a normal graph root
+  entails loading its metadata family; that is an execution-oriented contract
+  and is too broad for repairing a transaction's previous-value reads.
+
+The memory query specification's
+[metadata-family rules](../specs/memory-v2/05-queries.md) and the server's
+`demandedInstancesForSpace()` are the places to preserve this separation.
+
+## 2. Addresses and the repair footprint
+
+One repair belongs to one memory session and one rejected `localSeq`. Its
+identity is the pair `(sessionId, localSeq)`; it is not a server-log sequence.
+Repeated delivery or replay of the same rejected submission identifies the same
+repair. Distinct rejected attempts have distinct repair identities.
+
+The document footprint is the deduplicated union of:
+
+1. `reads.confirmed` addresses;
+2. `reads.pending` addresses;
+3. document operation targets.
+
+Each internal address contains space, branch, entity ID, scope, and resolved
+scope instance. Reads use their explicitly named branch or the commit branch;
+operation targets use the commit branch. Scope resolution must share the
+transaction validator's rules. An unresolvable scope is a failure to repair, not
+permission to substitute a different instance.
+
+The wire uses the ordinary recipient's scope vocabulary. Explicit foreign
+instance keys remain subject to the existing lease-holder read authorization.
+The acting principal used for delegated READ authority must not replace the
+envelope identity used to resolve a transaction's user or session instance.
+
+Paths determine conflict validation, but repair installs full document bases.
+Deduplicate paths to document addresses only after validating their address
+fields. Reads of outputs marked `ignoreReadForScheduling` remain in this
+footprint: scheduling and commit validation have different dependency sets.
+
+A SQLite operation has no JSON document target to manufacture. Its declared
+document dependencies still participate. A conflict requiring non-document
+repair needs an explicit recovery mechanism for that dependency kind; an empty
+JSON footprint must not be called a successful repair of such a conflict.
+
+A shared, browser-safe footprint builder belongs with memory's protocol types.
+Both server staging and client reconnect declarations must use it. Recovery must
+not parse an entity ID out of an error message.
+
+The memory protocol's branch support does not require adding general branch
+support to the runner's default-branch replica in this change. Receipt
+validation must reject an address that its consumer cannot represent, rather
+than allowing a same-ID default-branch record to satisfy it. Cross-branch
+coverage is tested at the memory layer as well as at any consumer that supports
+those branches.
+
+## 3. Recovery ownership
+
+The local recovery handle has two operations: await readiness, and release
+ownership. Release is idempotent. The handle is attached to a server conflict
+and propagated through the storage rejection adapter. `readyToRetry()` can
+delegate to its readiness operation while callers migrate.
+
+The runtime, rather than pattern authors, owns these handles. Low-level memory
+callers that manage their own retries must explicitly release a recovery after
+using it or deciding not to retry. Their documented helper should bracket the
+recovery callback with release on every exit. Session close is the final cleanup
+boundary, not the routine way to release a completed recovery.
+
+| State     | Transition and obligations                                                                                                                                         |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Waiting   | The verdict is a conflict. The server owes a complete repair; the client retains its footprint and waits for application of the repair.                            |
+| Ready     | The replica has applied a complete repair at a sufficiently recent cut. Its owner may rebuild the operation; coverage stays live.                                  |
+| Consuming | The rebuilt operation is running or settling. Keep the coverage through its completion, including a vacuous successful transaction.                                |
+| Replaced  | A further conflict supplies another handle. Keep the earlier coverage until the next repair is installed and ownership transfers, then release the earlier handle. |
+| Released  | The operation succeeded, gave up, was superseded, or was canceled. Remove this ownership and eventually retract documents with no remaining owner.                 |
+| Failed    | Repair cannot satisfy its contract. Surface a typed failure, release ownership, and do not report successful readiness.                                            |
+
+Transport disconnection suspends Waiting, Ready, or Consuming; it does not
+release ownership. A change of logical scope identity invalidates the handle
+instead of remapping its addresses to another user's or session's documents.
+
+Readiness is a check of the current replica generation, not one permanently
+resolved promise. If the replica loses its installed bases, invalidate the
+receipt and return the handle to Waiting. A consuming transaction from the
+discarded generation must abort and rebuild after rehydration. An ordinary
+disconnect that preserves the replica does not discard its authoritative bases.
+
+Cancellation can precede the verdict. Retain the cancellation disposition with
+the outstanding submission until the verdict is processed; if a conflict then
+arrives, release its repair instead of reviving a canceled operation. A late
+receipt for a released repair may carry useful ordinary data, but cannot revive
+the handle or schedule a retry.
+
+If dependent local rejections share a repair, local handles share ownership with
+reference counting. One consumer cannot release a basis another consumer still
+needs. Purely local inconsistency or preemption does not create a new server
+repair merely because it uses the same rejection classification.
+
+No timer determines successful readiness or ownership expiry. Pending repairs
+remain bounded by active recovery operations, with explicit resource failure if
+the implementation's memory limit is exceeded. Resource pressure must not
+silently discard an owned basis.
+
+## 4. Protocol changes
+
+Use a negotiated capability, provisionally `transactionRepairV1`. The names
+below are proposed wire fields, not existing exports.
+
+| Surface           | Proposed addition | Meaning                                                                                                                                                       |
+| ----------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Conflict response | `repair.localSeq` | Identifies the repair staged from this rejected submission. Carries no document values.                                                                       |
+| `SessionSync`     | `repairs`         | Complete repair receipts, each naming a `localSeq`, a server cut `atSeq`, and document address/version requirements. Values travel in the ordinary `upserts`. |
+| `SessionSync`     | `repairFailures`  | Typed, per-repair failures when the server cannot assemble a valid repair.                                                                                    |
+| `session.ack`     | `releaseRepairs`  | An explicit array of completed or canceled repair identities to release. This is independent of `seenSeq`.                                                    |
+| `session.open`    | `repairs`         | The client's complete active recovery declarations, including the footprints of submissions whose verdicts remain unknown.                                    |
+
+### Complete repair receipt
+
+Each receipt lists the full document footprint and the authoritative version of
+each address at `atSeq`, including a deletion marker when applicable. A
+never-created document is represented explicitly with sequence 0 and absence; an
+existing tombstone carries its actual revision. Membership is exact: a receipt
+that omits a required scope instance cannot complete readiness.
+
+The client already has the failed submission, so it validates membership against
+the shared footprint builder. The receipt carries version requirements so the
+replica can distinguish actually installed data from a transport-level marker.
+Schema documents required to interpret delivered snapshots must also be verified
+and available before the receipt completes.
+
+For the first delivery of a repair, send authoritative snapshots for its whole
+footprint, deduplicated with the same frame's ordinary upserts. Do not elide
+them solely because the server's delivery cache says they were sent. Reconnect
+may elide a snapshot against declared, actually absorbed holdings, provided the
+client can still satisfy the receipt from those holdings.
+
+A newer authoritative local base can satisfy an older version requirement. A
+pending optimistic overlay or a sequence number without its corresponding
+authoritative value cannot. Exact accepted writes may qualify through the
+existing accepted-write promotion rules; speculative values do not.
+
+### Two completion conditions, without a second acknowledgement clock
+
+`caughtUpLocalSeq` continues to order verdict application and accepted-write
+promotion. It must not by itself complete a negotiated conflict repair. Conflict
+readiness additionally requires the matching receipt to have been applied by the
+replica, with `atSeq >= retryAfterSeq` for that rejection. Both values in that
+comparison are server-log sequences from the same store epoch.
+
+Explicit release discharges ownership after consumption; a separate cumulative
+"repair acknowledged through" clock is unnecessary. Releases name exact repairs
+because unrelated recoveries can finish out of order.
+
+An acknowledgement containing releases must be sent even when `seenSeq` has not
+advanced. A lost acknowledgement is harmless: retrying release is idempotent,
+and the complete declaration on the next open omits locally released repairs.
+Release is cleanup; it need not add an awaited round trip to a successful retry.
+
+Ordinary watch mutations do not carry replacement repair declarations. This
+avoids an in-flight watch request canceling a repair it could not yet know
+about.
+
+### Failure receipt
+
+An unreadable branch, revoked authorization, corrupt schema closure, or
+unrepresentable required instance produces an explicit failure for the repair.
+Do not send a partial receipt claiming success. Unrelated valid sync work may
+continue under its own contract.
+
+The client preserves the original conflict as the cause of a typed recovery
+failure. A rejected readiness promise is not converted into unconditional
+resubmission. Connection recovery waits for the session's actual restoration
+event; terminal failure stops that attempt until an appropriate external change
+or explicit retry.
+
+All wire parsers, response-error adapters, schema-table encoding, and session
+frame forwarding must preserve these additions. `isEmptySync()` must treat a
+receipt-only or failure-only frame as nonempty. A test must exercise this
+through the actual transport and the runner's frame consumer, not only a
+constructed receipt passed directly to the validator.
+
+## 5. Server synchronization
+
+Introduce a small repair component rather than adding separate ad hoc branches
+to every early return in `syncSessionForConnection()`.
+
+Its responsibilities are footprint ownership, direct snapshot assembly, receipt
+construction, release, and reconnect declaration. It has no access to the
+scheduler or pattern-binding machinery.
+
+On a server conflict, while holding the existing per-space publication lock:
+
+1. Register the repair footprint under the rejected session and `localSeq`.
+2. Stage its receipt obligation and the existing verdict catch-up obligation.
+3. Publish the conflict response before the corresponding live repair frame.
+4. Let the existing batched fan-out deliver the repair.
+
+For each fan-out pass:
+
+1. Evaluate ordinary watched updates and any required repair snapshots at the
+   same server cut, with the existing authorization and session-ownership
+   checks.
+2. Assemble the union once. A repair-only document uses `Engine.readState()` or
+   the shared snapshot assembler, preserving its actual version and tombstone.
+3. Add and validate the transitive schema-document closure. Reuse the closure
+   assembly used by query delivery; do not duplicate schema interpretation.
+4. Build ordinary upserts/removes and complete repair receipts. A remove is
+   permitted only when neither watch nor repair ownership retains the address.
+5. Commit delivery bookkeeping only when the complete frame is constructible.
+
+Repair assembly does not recursively load ordinary value links, a piece's
+pattern/argument/internal metadata family, or a whole space. It delivers the
+explicit footprint and the schema closure needed to interpret it. If rebuilding
+the transaction discovers another ordinary data dependency, the normal read
+machinery handles that dependency. Further conflicts on newly discovered
+dependencies do not violate the contract.
+
+Coverage remains live until release, so dirty changes to a retained repair
+document can update its basis during recovery. Maintain repair wake keys
+separately from graph demand keys. Ordinary execution-demand enumerators and
+callbacks must use graph provenance; they must not infer demand from the union
+delivery map.
+
+Both the incremental and full-evaluation paths, including no-watch sessions,
+must compose through the same repair assembly. A full refresh cannot retract a
+repair-only document. Failed-send rollback restages receipt delivery without
+dropping coverage. Replay of a rejected submission restages its complete receipt
+idempotently, even if the server remembers sending it already.
+
+Release itself schedules the coverage diff, including when there are no normal
+watches or subsequent commits. It must not require unrelated traffic to reclaim
+repair-only state. Resume and release composition use the same per-space
+publication ordering as fan-out; any awaited authorization or engine-open step
+precedes the snapshot cut and is followed by the ordinary session-owner check.
+
+Multiple repairs share document snapshots and schema closure in one frame. They
+retain separate completion identities and ownership. Processing a later repair
+cannot declare an earlier incomplete repair complete through a maximum counter.
+
+## 6. Replica application and reconnect
+
+The storage replica applies a repair-bearing frame in this order:
+
+1. Decode and validate the frame and its schema closure.
+2. Apply authoritative upserts/removes under the normal monotonic-version and
+   optimistic-overlay rules.
+3. Check each repair receipt against its expected footprint and installed
+   authoritative bases.
+4. Complete only the satisfied repair waiters. Apply ordinary verdict markers
+   according to their existing accepted-write semantics.
+5. Finalize rejection rollback and schedule the owning operation's fresh run.
+
+In particular, the replica must not quarantine a required document and then
+complete the repair from the frame's marker. A receipt also must not reach the
+memory client and release a runner waiter before the runner consumes the frame.
+The two existing readiness layers must share the explicit repair identity.
+
+On reconnect, retain active repair descriptors on the client and include them
+with its declared holdings. Also declare the footprints of all submissions whose
+outcomes remain unknown. Such a submission may have been rejected just before
+disconnection, without its verdict reaching the client.
+
+The server reinstalls this coverage before calculating resume differences. It
+may authorize a redeclared footprint as a scoped read without proving that its
+original conflict is durably recorded: the declaration grants no write or
+verdict authority. It must not advance `caughtUpLocalSeq` merely because a
+client declares a repair. Outstanding submissions still obtain their verdicts
+through ordinary replay.
+
+The client only completes a conflict's readiness once it knows that conflict's
+verdict and has a sufficiently recent applied receipt. A snapshot obtained
+before a replayed rejection is insufficient if the rejection names a newer
+server cut. Replay restages the repair in that case.
+
+This also covers a server restart or expired server-side session with the same
+logical session identity: the client supplies coverage and holdings afresh.
+Rejection waiters cannot depend on vanished server-side marker counters. If the
+logical session identity changes, invalidate the old recovery and let the owner
+reestablish its operation under the new identity; never reuse a session-scoped
+basis under a different identity.
+
+An ordinary server restart preserves the underlying store and its sequence
+history. Restoring an older database or replacing the store is a different
+operation: receipts from the retired history cannot establish freshness in the
+replacement. This plan does not treat a maximum remembered sequence as evidence
+that two different store histories are continuous.
+
+Within one server session, coverage pins repair data through watch replacement
+and reconnect. A release removes only the named owner. The next diff retracts
+repair-only data after its last owner releases it; ordinary graph ownership
+keeps overlapping documents live.
+
+## 7. Runtime integration
+
+| Owner                     | Required handling                                                                                                                                                                                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Reactive scheduler        | Keep the handle with the action while waiting and while its fresh transaction runs. Release on successful settlement, terminal failure, action removal, or supersession; transfer ownership on a further conflict. |
+| `Runtime.editWithRetry()` | Bracket the recursive fresh attempt with repair ownership. A consumed retry budget or teardown releases the handle. A failed readiness outcome must not become a successful wait.                                  |
+| UI writes                 | Use the same `editWithRetry()` ownership; preserve newest-value lane semantics and the non-retry behavior of already-resolved CAS updates.                                                                         |
+| Queued events             | Carry ownership with the queued event through any existing pacing, and release on completion, cancellation, opt-out, or convergence failure. A delay is not proof of repair.                                       |
+| Piece startup             | Keep coverage through the permitted re-instantiation or load-from-served-state operation, using the existing cancellation/registration owner. Do not introduce a new permission to retry a terminal start failure. |
+| Local dependent rejection | Borrow relevant recovery ownership from the failed dependency, or await local state repair for a purely local rejection; do not manufacture a server repair.                                                       |
+
+`Runtime.awaitCommitRetryReadiness()` currently combines a readiness wait with a
+pull of `conflict.of` using the default scope. The implementation should replace
+this ad hoc recovery with the shared typed mechanism for negotiated peers.
+`toRejectedError()` must carry the recovery handle through without reducing its
+identity to the error message's document ID.
+
+Keep `ignoreReadForScheduling` for output diff reads. Do not add an eager sync
+to every output write or expand `loadUnexaminedAbsences()` to probe every new
+document creation. Those changes are not prerequisites for this recovery
+contract.
+
+The API migration must include low-level callers that intentionally decline to
+retry. A recovery handle is a resource even when its error is simply returned.
+Use explicit ownership and `finally` cleanup rather than garbage collection or
+session expiry as routine cleanup. The reduced test may add cleanup for this
+handle, but its behavioral assertion remains unchanged: after awaited repair, a
+fresh second transaction succeeds without a manual scoped sync.
+
+## 8. Performance and observability
+
+For the scoped-output regression, the expected sequence is:
+
+1. The space output points elsewhere; its earlier user instance exists. The
+   replica reads that unseen user instance as absent and submits an output
+   update plus the redirect restoration.
+2. The server rejects the absence claim and creates repair coverage for both
+   scoped addresses, regardless of the stored space link.
+3. One frame delivers the user instance's actual value and revision along with a
+   complete receipt. The replica installs it and completes readiness.
+4. The fresh transaction recomputes the update. If the user value is already
+   correct, it only needs to restore the redirect. Otherwise it writes the
+   appropriate update against the actual previous value.
+5. After that operation settles, it releases the repair. The restored graph's
+   ordinary watch retains the user document if its selector reaches it.
+
+With no intervening writer and no newly discovered dependency, there is one
+initial conflict and one successful fresh attempt. Further identical conflicts
+against the same repaired footprint indicate failed recovery, not contention.
+
+The success path allocates no repair map entry, enumerates no additional
+footprint, and sends no repair-specific field or request. An outstanding
+commit's existing payload is enough to derive a repair declaration if reconnect
+makes it necessary.
+
+For a conflict batch, work is proportional to the unique document footprint plus
+its required schema closure and the ordinary watch refresh. Group by branch,
+deduplicate identical addresses and closure documents, reuse authoritative
+snapshots already assembled for the frame, and avoid one RPC per dependency.
+
+Keep temporary coverage through the current recovery sequence rather than
+accumulating it for every rejected attempt. On repeated conflict, install the
+replacement coverage before releasing superseded coverage. Distinct active
+operations can share snapshots while retaining independent ownership.
+
+Record aggregate counters for active repairs, unique repair-only addresses,
+repair snapshot bytes, repair wait duration, receipts that fail validation,
+reconnect redelivery, and coverage released. Diagnostic details may include
+space/session/localSeq, scoped address, rejected basis, conflicting version, and
+installed version; document values and identities' private material do not
+belong in those diagnostics.
+
+Measure both the normal path and conflicts. The acceptance target is no added
+repair reads or round trips for uncontended successful transactions, one batched
+repair for the reduced stale footprint, and return to zero temporary ownership
+after the workload completes. Wall-clock performance must be measured rather
+than inferred from those counts.
+
+## 9. Compatibility and implementation sequence
+
+The complete guarantee requires both peers to negotiate it. A server must not
+create indefinitely retained repairs for a peer that cannot release them. An
+updated client must not label an older peer's bare catch-up marker as complete
+transaction repair.
+
+Deploy the server capability before enabling it in clients. For a peer without
+the capability, preserve normal successful transactions and surface an explicit
+unsupported-recovery outcome when this automatic recovery would be required. Do
+not hide the capability gap with an unbounded retry or add a second, permanently
+maintained recovery implementation. Existing legacy behavior may remain for
+legacy peers during rollout, but it does not satisfy this plan's acceptance
+criteria.
+
+Implement in the following stages. Intermediate work can be reviewed with the
+capability inactive; do not enable a partial lifecycle in deployed clients.
+
+1. [ ] Define the protocol types, shared footprint builder, recovery ownership
+       interface, and failure classification. Update memory specs for explicit
+       repair coverage, receipts, and release. Pin branch/scope resolution and
+       exact membership in focused tests.
+2. [ ] Implement the server repair component and shared snapshot/schema
+       assembly. Compose it into incremental/full/no-watch sync paths and
+       separate execution demand from delivery holdings. Verify a direct
+       memory-client conflict on an unwatched document.
+3. [ ] Implement receipt validation, explicit release, and reconnect
+       declarations in the memory client and runner replica. Exercise lost
+       frames, unknown verdicts, changed logical identity, and unchanged
+       server-sequence release.
+4. [ ] Migrate every runtime recovery owner and every non-retry exit. Remove
+       scope-losing recovery pulls for negotiated peers. Verify cancellation,
+       supersession, local dependents, and cleanup without session close.
+5. [ ] Make the runner regression and all relevant protocol, storage,
+       scheduling, event, UI-write, and startup tests pass. Measure normal-path
+       cost and batched conflict cost. Exercise server execution OFF and ON
+       independently.
+6. [ ] Rehearse the six-step source round trip in a throwaway empty space,
+       review the full change, and enable the negotiated capability after the
+       lifecycle and performance gates pass. Archive this plan when
+       implementation ships.
+
+Principal implementation seams:
+
+| File                                                                                                                                                                                                                                           | Responsibility                                                                                                          |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| [memory/v2.ts](../../packages/memory/v2.ts) and [memory/interface.ts](../../packages/memory/interface.ts)                                                                                                                                      | Protocol shapes, scope vocabulary, rejection/recovery interface.                                                        |
+| [memory/v2/session-registry.ts](../../packages/memory/v2/session-registry.ts)                                                                                                                                                                  | Per-session repair ownership and restoration.                                                                           |
+| [memory/v2/server.ts](../../packages/memory/v2/server.ts)                                                                                                                                                                                      | Rejection staging, publication ordering, coverage composition, release, authorization, and execution-demand provenance. |
+| [memory/v2/query.ts](../../packages/memory/v2/query.ts) and [server-sync.ts](../../packages/memory/v2/server-sync.ts)                                                                                                                          | Shared snapshot/schema assembly and union delivery differences.                                                         |
+| [memory/v2/client.ts](../../packages/memory/v2/client.ts)                                                                                                                                                                                      | Recovery handles, receipts, release batching, and reconnect declarations.                                               |
+| [runner storage/v2.ts](../../packages/runner/src/storage/v2.ts)                                                                                                                                                                                | Applied-repair gate, rejection rollback, handle propagation, and holdings.                                              |
+| [runtime.ts](../../packages/runner/src/runtime.ts), [scheduler/run.ts](../../packages/runner/src/scheduler/run.ts), [scheduler/events.ts](../../packages/runner/src/scheduler/events.ts), and [runner.ts](../../packages/runner/src/runner.ts) | Recovery consumption and cancellation ownership.                                                                        |
+
+## 10. Acceptance tests
+
+Use the real in-process memory server with manual fan-out and explicit verdict,
+receipt, disconnect, and cancellation barriers. Tests must not depend on sleeps,
+polling, or a large retry count.
+
+| Case                                                                        | Required assertion                                                                                                            |
+| --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Existing hidden user output, desired value already `null`                   | Initial conflict; applied repair; next fresh transaction succeeds without explicit user sync.                                 |
+| Existing hidden output differs from desired result                          | The rebuilt diff uses the stored value and produces the desired result without losing unrelated preserved fields.             |
+| General stale computation                                                   | A result derived from an absent input is recomputed from the repaired value; changing only the exported sequence cannot pass. |
+| Truly new output                                                            | First attempt succeeds; zero repair reads, requests, and ownership entries.                                                   |
+| Read-only stale dependency, separate write target                           | Both the input and output bases are covered, including when neither has a normal watch.                                       |
+| Existing nonzero stale version                                              | Repair is not restricted to sequence-0 reads.                                                                                 |
+| Tombstone and never-created document                                        | Their versions remain distinguishable after repair.                                                                           |
+| Same ID across branches, user instances, and sessions                       | Only the rejected transaction's authorized addresses satisfy the receipt.                                                     |
+| Output diff read ignored for scheduling                                     | It remains a commit-repair dependency without establishing an output-triggered computation.                                   |
+| Required document or schema quarantined                                     | Readiness fails explicitly; an empty/partial frame marker cannot release the retry.                                           |
+| Receipt-only or failure-only frame                                          | The real wire and replica-consumer paths forward it and settle only the correct handle.                                       |
+| Foreign write after rejection                                               | The receipt covers a cut at or after rejection; a further genuinely newer conflict remains valid.                             |
+| Several coalesced rejected submissions                                      | Shared snapshots are sent once; each repair has complete membership and independent completion.                               |
+| Delivery throws or socket loses a sent frame                                | Replay or resume delivers missing bases before readiness.                                                                     |
+| Server remembers sending data the replica never installed                   | Declared holdings and receipt validation cause redelivery.                                                                    |
+| Disconnect before the verdict                                               | The outstanding submission's footprint survives; replay determines its outcome.                                               |
+| Server restart or expired session with stable logical identity              | Client declarations reconstruct coverage and readiness without old server marker state.                                       |
+| Logical session identity changes                                            | Old session-scoped recovery is invalidated, never silently remapped.                                                          |
+| Local replica loses installed data                                          | A previously completed receipt cannot make the replacement replica ready without rehydration.                                 |
+| Watch replacement between repair and retry                                  | It cannot retract the owned repair basis.                                                                                     |
+| Two recoveries share a document                                             | Releasing either one leaves the other's coverage intact.                                                                      |
+| Further conflict during recovery                                            | Replacement coverage installs before old ownership releases; completed sequences do not accumulate.                           |
+| No-op retry, cancellation, supersession, non-retry exit, or thrown callback | Ownership is released without requiring session close.                                                                        |
+| Cancellation precedes the conflict verdict                                  | The late verdict or receipt cannot resurrect the canceled recovery or leak ownership.                                         |
+| Release with unchanged `seenSeq`                                            | Cleanup is transmitted and applied; duplicate or lost release is safe.                                                        |
+| Release followed by no other traffic                                        | Its scheduled diff reclaims repair-only delivery state.                                                                       |
+| Repair-only computed document under server execution ON                     | Delivery introduces no graph execution demand or whole metadata-family load.                                                  |
+| Ordinary subscriptions overlap repair                                       | Last-owner release preserves normal delivery and ordinary execution demand.                                                   |
+| Mixed accepted and rejected transactions                                    | Accepted-write parking, optimistic overlays, and exact accepted-write promotion retain their semantics.                       |
+| Unsupported peer                                                            | Successful writes still work; automatic repair does not claim readiness from an unsupported contract.                         |
+
+Run the existing conflict-reconciliation, stacked-commit, memory subscription,
+effect-conflict-recovery, event-disposition, edit-with-retry, UI-write, and
+piece-start tests alongside the focused additions. Run the repository's required
+format, lint, type, documentation, and package test gates before publishing a
+changeset. Browser rehearsal follows the repository's sandbox and local-server
+instructions.
+
+## 11. Scope and remaining verification
+
+This design changes generic transaction recovery. Compiler node identities,
+source migration, persisted graph cleanup, the shell debug helper's scope
+option, and classification of the CLI `piece-start-commit-failed` observation
+are separate work. A passing recovery test does not establish a universal claim
+about how many source applies are safe.
+
+Before enabling the capability, implementation must demonstrate the exact
+resource accounting and release paths, schema-closure reuse without execution
+metadata traversal, and serving-runtime demand separation. Those are acceptance
+gates with the tests above, not assumptions that a successful lunch-poll reload
+can substitute for. Capability field names and internal module boundaries may be
+refined during implementation while preserving the explicit ownership, complete
+receipt, and unchanged successful-write path specified here.

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -1239,3 +1239,46 @@ view — so no frame stream to order against) also applies immediately.
 | Per-subscription routing                   | Watch-set union + session cache                           | Overlap is deduped at the session layer                   |
 | Re-subscribe each live query independently | Restore one watch set                                     | The client still restores interests after reconnect       |
 | Hash-centric semantic commit identity      | `(sessionId, localSeq)` before accept, `seq` after accept | UCAN envelope refs remain content-addressed               |
+
+## Transaction repair integration (inactive)
+
+Transaction repair is being implemented under
+[the transaction conflict repair plan](../../plans/transaction-conflict-repair.md).
+Session admission does not yet negotiate or instantiate repair coverage, so
+ordinary peers retain their existing behavior. The complete capability must not
+be advertised until reconnect declarations, replica validation, and ownership
+release are implemented together.
+
+The server integration defines these additions:
+
+- A conflict's `repair.localSeq` names its rejected submission.
+- A sync's `repairs` contains complete receipts. Each receipt names `localSeq`,
+  the global store cut `atSeq`, exact `documents`, and additional `schemas`.
+  Each required version contains `branch`, `id`, `scope`, `seq`, and optional
+  `deleted: true`. A never-created document has sequence 0 and is deleted; a
+  durable tombstone retains its stored sequence. Each branch is sampled at its
+  head at the captured global cut.
+- Values travel through ordinary `upserts`. Initial receipt delivery forces
+  every required document and schema snapshot, even when the server's graph
+  cache remembers sending it. Shared addresses appear once per frame.
+- `repairFailures` names each failed `localSeq` with an `unresolvable-address`,
+  `invalid-schema`, or `unsupported-dependency` reason. A failure contributes no
+  partial successful receipt. Additional terminal lifecycle failures belong to
+  the complete protocol before activation.
+- `session.ack.releaseRepairs` releases exact owners independently of `seenSeq`.
+  Release is idempotent and schedules cleanup without requiring another commit.
+  A session without enabled repair coverage rejects this field.
+
+A receipt is a requirement to verify after installing the authoritative bases,
+not proof that the receiving replica has installed them. The client and runner
+readiness gates remain to be implemented. Schema-table framing and watch-view
+forwarding preserve receipt and failure fields, including frames with no upserts
+or removes.
+
+The server keeps repair delivery state separate from graph delivery state.
+Repair ownership cannot be removed by replacing graph watches and does not
+create execution demand. Preparing a frame leaves repair delivery staged;
+successful transport send commits it. A failed send leaves the complete receipt
+and snapshots available for redelivery. Tests install the component through the
+internal session registry to exercise these paths while protocol activation is
+incomplete.

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -53,6 +53,9 @@ entity's value hashes to a specific value.
   tracking, watch sets, and catch-up sync.
 - `v2/transaction-repair.ts` — document dependencies of a rejected commit,
   preserving branch and scope for conflict recovery.
+- `v2/repair-coverage.ts` — independent repair ownership and frame composition;
+  integrated server paths remain inactive until session admission negotiates the
+  complete repair lifecycle.
 - `v2/client.ts` — the client half: session open and resume, optimistic commits,
   and watch subscriptions.
 - `v2/message-compression.ts` — the negotiated binary gzip envelope used by

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -51,6 +51,8 @@ entity's value hashes to a specific value.
   and commit validation.
 - `v2/server.ts` and `v2/server-sync.ts` — the WebSocket server, session
   tracking, watch sets, and catch-up sync.
+- `v2/transaction-repair.ts` — document dependencies of a rejected commit,
+  preserving branch and scope for conflict recovery.
 - `v2/client.ts` — the client half: session open and resume, optimistic commits,
   and watch subscriptions.
 - `v2/message-compression.ts` — the negotiated binary gzip envelope used by

--- a/packages/memory/deno.jsonc
+++ b/packages/memory/deno.jsonc
@@ -40,6 +40,7 @@
     "./v2/standalone": "./v2/standalone.ts",
     "./v2/session-open-auth": "./v2/session-open-auth.ts",
     "./v2/storage-path": "./v2/storage-path.ts",
+    "./v2/transaction-repair": "./v2/transaction-repair.ts",
     "./v2/schema-table-links": "./v2/schema-table-links.ts",
     "./v2/dump": "./v2/dump.ts",
     "./sqlite": "./v2/sqlite/mod.ts",

--- a/packages/memory/test/v2-repair-coverage.test.ts
+++ b/packages/memory/test/v2-repair-coverage.test.ts
@@ -1,0 +1,479 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { internSchemaAsTaggedHashString } from "@commonfabric/data-model-schema";
+
+import {
+  type ClientCommit,
+  type EntityDocument,
+  type Operation,
+  ProtocolError,
+  type SessionSync,
+  toDocumentPath,
+} from "../v2.ts";
+import * as Engine from "../v2/engine.ts";
+import { WatchView } from "../v2/client.ts";
+import { createDocumentSnapshotReader, toDirtyKey } from "../v2/query.ts";
+import { RepairCoverage } from "../v2/repair-coverage.ts";
+import {
+  cacheKeyForEntity,
+  isEmptySync,
+  type SessionCacheEntry,
+} from "../v2/server-sync.ts";
+import {
+  compressSessionSyncSchemas,
+  expandSessionSyncSchemas,
+} from "../v2/sync-schema-table.ts";
+
+const SPACE = "did:key:repair-space";
+const IDENTITY = {
+  principal: "did:key:repair-user",
+  sessionId: "repair-session",
+};
+
+function commitFor(
+  localSeq: number,
+  ids: string[],
+  scope: "space" | "user" | "session" = "space",
+): ClientCommit {
+  return {
+    localSeq,
+    reads: {
+      confirmed: ids.map((id) => ({
+        id,
+        scope,
+        path: toDocumentPath([]),
+        seq: 0,
+      })),
+      pending: [],
+    },
+    operations: [],
+  };
+}
+
+describe("transaction repair coverage", () => {
+  let engine: Engine.Engine;
+  let coverage: RepairCoverage;
+  let seedSeq: number;
+
+  beforeEach(async () => {
+    engine = await Engine.open({ url: new URL("memory://repair-coverage") });
+    coverage = new RepairCoverage(SPACE, IDENTITY);
+    seedSeq = 0;
+  });
+
+  afterEach(() => Engine.close(engine));
+
+  function write(operations: Operation[], branch = "") {
+    return Engine.applyCommit(engine, {
+      sessionId: IDENTITY.sessionId,
+      principal: IDENTITY.principal,
+      commit: {
+        localSeq: ++seedSeq,
+        branch,
+        reads: { confirmed: [], pending: [] },
+        operations,
+      },
+    });
+  }
+
+  function emptySync(): SessionSync {
+    return {
+      type: "sync",
+      fromSeq: 0,
+      toSeq: Engine.serverSeq(engine),
+      upserts: [],
+      removes: [],
+    };
+  }
+
+  function prepare(
+    sync = emptySync(),
+    graphs = new Map<string, SessionCacheEntry>(),
+  ) {
+    return coverage.prepare(
+      createDocumentSnapshotReader(SPACE, engine, IDENTITY),
+      sync,
+      graphs,
+    );
+  }
+
+  function set(
+    id: string,
+    value: EntityDocument["value"],
+    scope: "space" | "user" | "session" = "space",
+  ): Operation {
+    return { op: "set", id, scope, value: { value } };
+  }
+
+  it("delivers an unwatched user instance despite a space link pointing elsewhere", () => {
+    write([
+      set("of:output", { "/": { "link@1": { id: "of:alternate", path: [] } } }),
+      set("of:output", null, "user"),
+      set("of:alternate", "alternate value"),
+    ]);
+    const rejected = commitFor(10, ["of:output"], "user");
+    rejected.operations.push(set("of:output", null));
+    coverage.register(rejected, 1);
+    const frame = prepare();
+    expect(frame.sync.upserts.map((doc) => [doc.id, doc.scope])).toEqual([
+      ["of:output", "space"],
+      ["of:output", "user"],
+    ]);
+    expect(frame.sync.repairs).toEqual([{
+      localSeq: 10,
+      atSeq: 1,
+      documents: [
+        { branch: "", id: "of:output", scope: "space", seq: 1 },
+        { branch: "", id: "of:output", scope: "user", seq: 1 },
+      ],
+      schemas: [],
+    }]);
+    expect(frame.sync.upserts.find((doc) => doc.scope === "user")?.doc).toEqual(
+      { value: null },
+    );
+    expect(coverage.size).toBe(1);
+  });
+
+  it("distinguishes never-created absence from a durable tombstone", () => {
+    write([set("of:deleted", "old")]);
+    write([{ op: "delete", id: "of:deleted" }]);
+    coverage.register(commitFor(10, ["of:absent", "of:deleted"]), 2);
+    const sync = prepare().sync;
+    expect(sync.repairs?.[0].documents).toEqual([
+      { branch: "", id: "of:absent", scope: "space", seq: 0, deleted: true },
+      { branch: "", id: "of:deleted", scope: "space", seq: 2, deleted: true },
+    ]);
+    expect(sync.upserts.every((entry) => entry.deleted)).toBe(true);
+  });
+
+  it("keeps document versions from different branches distinct", () => {
+    write([set("of:shared", "main")]);
+    Engine.createBranch(engine, "other");
+    write([set("of:shared", "other")], "other");
+    const commit = commitFor(10, ["of:shared"]);
+    commit.reads.confirmed.push({
+      id: "of:shared",
+      branch: "other",
+      path: toDocumentPath([]),
+      seq: 0,
+    });
+    coverage.register(commit, 2);
+    expect(prepare().sync.upserts.map((doc) => [doc.branch, doc.doc?.value]))
+      .toEqual([
+        ["", "main"],
+        ["other", "other"],
+      ]);
+  });
+
+  it("pins document and schema reads to one captured server cut", () => {
+    write([set("of:doc", "before")]);
+    const reader = createDocumentSnapshotReader(SPACE, engine, IDENTITY);
+    write([set("of:doc", "after")]);
+    const result = reader.read([{ branch: "", id: "of:doc" }]);
+    expect(reader.atSeq).toBe(1);
+    expect(result.documents[0].document).toEqual({ value: "before" });
+    expect(result.documents[0].seq).toBe(1);
+  });
+
+  it("includes the verified transitive schema closure without following its value target", () => {
+    const leaf = { type: "string", title: "repair-leaf" } as const;
+    const leafHash = internSchemaAsTaggedHashString(leaf);
+    const root = {
+      type: "object",
+      properties: { x: { $ref: `cid:${leafHash}` } },
+    } as const;
+    const rootHash = internSchemaAsTaggedHashString(root);
+    write([
+      set(`cid:${leafHash}`, leaf),
+      set(`cid:${rootHash}`, root),
+      set("of:carrier", {
+        "/": {
+          "link@1": {
+            id: "of:target",
+            path: [],
+            schema: { $ref: `cid:${rootHash}` },
+          },
+        },
+      }),
+      set("of:target", "unread"),
+    ]);
+    coverage.register(commitFor(10, ["of:carrier"]), 1);
+    const sync = prepare().sync;
+    expect(sync.repairs?.[0].documents.map((entry) => entry.id)).toEqual([
+      "of:carrier",
+    ]);
+    expect(sync.repairs?.[0].schemas.map((entry) => entry.id).sort()).toEqual(
+      [`cid:${leafHash}`, `cid:${rootHash}`].sort(),
+    );
+    expect(sync.upserts.map((entry) => entry.id).sort()).toEqual(
+      ["of:carrier", `cid:${leafHash}`, `cid:${rootHash}`].sort(),
+    );
+  });
+
+  it("isolates a corrupt schema closure without publishing a partial repair", () => {
+    const schema = { type: "string", title: "repair-corruption" } as const;
+    const hash = internSchemaAsTaggedHashString(schema);
+    write([
+      set(`cid:${hash}`, schema),
+      set("of:carrier", {
+        "/": {
+          "link@1": {
+            id: "of:target",
+            path: [],
+            schema: { $ref: `cid:${hash}` },
+          },
+        },
+      }),
+      set("of:valid", "valid"),
+    ]);
+    // The commit API preserves schema closures. Removing the stored head
+    // directly models corruption despite a warm process schema registry.
+    engine.database.prepare("DELETE FROM head WHERE id = :id").run({
+      id: `cid:${hash}`,
+    });
+    coverage.register(commitFor(10, ["of:carrier"]), 1);
+    coverage.register(commitFor(11, ["of:valid"]), 1);
+    const frame = prepare();
+    expect(frame.sync.repairFailures).toEqual([{
+      localSeq: 10,
+      reason: "invalid-schema",
+    }]);
+    expect(frame.sync.repairs?.map((receipt) => receipt.localSeq)).toEqual([
+      11,
+    ]);
+    expect(frame.sync.upserts.map((entry) => entry.id)).toEqual(["of:valid"]);
+    frame.commit();
+    expect(coverage.size).toBe(1);
+  });
+
+  it("rejects readers for another space or logical identity", () => {
+    coverage.register(commitFor(10, ["of:doc"]), 0);
+    for (
+      const reader of [
+        createDocumentSnapshotReader("did:key:other-space", engine, IDENTITY),
+        createDocumentSnapshotReader(SPACE, engine, {
+          ...IDENTITY,
+          sessionId: "other-session",
+        }),
+        createDocumentSnapshotReader(SPACE, engine, {
+          ...IDENTITY,
+          principal: "did:key:other-user",
+        }),
+      ]
+    ) {
+      expect(() => coverage.prepare(reader, emptySync(), new Map())).toThrow(
+        ProtocolError,
+      );
+    }
+  });
+
+  it("delivers shared bases once while retaining separate receipt identities", () => {
+    write([set("of:shared", "value")]);
+    coverage.register(commitFor(10, ["of:shared"]), 1);
+    coverage.register(commitFor(12, ["of:shared"]), 1);
+    const frame = prepare();
+    expect(frame.sync.upserts).toHaveLength(1);
+    expect(frame.sync.repairs?.map((receipt) => receipt.localSeq)).toEqual([
+      10,
+      12,
+    ]);
+    frame.commit();
+    coverage.release(10);
+    expect(coverage.needsSync(new Set())).toBe(true);
+    const retained = prepare();
+    expect(retained.sync.removes).toEqual([]);
+    retained.commit();
+    expect(coverage.size).toBe(1);
+    coverage.release(12);
+    const released = prepare();
+    expect(released.sync.removes).toEqual([{
+      branch: "",
+      id: "of:shared",
+      scope: "space",
+    }]);
+    released.commit();
+    expect(coverage.size).toBe(0);
+    expect(coverage.needsSync(new Set())).toBe(false);
+  });
+
+  it("forces first-delivery snapshots even when the graph cache remembers them", () => {
+    write([set("of:shared", "value")]);
+    const entry: SessionCacheEntry = {
+      branch: "",
+      id: "of:shared",
+      scope: "space",
+      scopeKey: "space",
+      seq: 1,
+      doc: { value: "value" },
+    };
+    const graphs = new Map([[cacheKeyForEntity("", entry.id), entry]]);
+    coverage.register(commitFor(10, [entry.id]), 1);
+    const frame = prepare(emptySync(), graphs);
+    expect(frame.sync.upserts).toHaveLength(1);
+    expect(graphs.size).toBe(1);
+    frame.commit();
+    coverage.release(10);
+    expect(prepare(emptySync(), graphs).sync.removes).toEqual([]);
+  });
+
+  it("preserves repair ownership across ordinary watch removal", () => {
+    write([set("of:shared", "value")]);
+    coverage.register(commitFor(10, ["of:shared"]), 1);
+    prepare().commit();
+    const sync = emptySync();
+    sync.removes.push({ branch: "", id: "of:shared", scope: "space" });
+    expect(prepare(sync).sync.removes).toEqual([]);
+    expect(coverage.size).toBe(1);
+  });
+
+  it("retains live wake coverage after delivering its receipt", () => {
+    write([set("of:shared", "before")]);
+    coverage.register(commitFor(10, ["of:shared"]), 1);
+    prepare().commit();
+    expect(coverage.needsSync(new Set([toDirtyKey("of:unrelated")]))).toBe(
+      false,
+    );
+    expect(coverage.needsSync(new Set([toDirtyKey("of:shared")]))).toBe(true);
+    write([set("of:shared", "after")]);
+    const frame = prepare();
+    expect(frame.sync.upserts[0].doc).toEqual({ value: "after" });
+    expect(frame.sync.repairs).toBeUndefined();
+    expect(coverage.size).toBe(1);
+  });
+
+  it("restages complete delivery when a rejected submission is replayed", () => {
+    write([set("of:shared", "value")]);
+    const commit = commitFor(10, ["of:shared"]);
+    coverage.register(commit, 1);
+    prepare().commit();
+    expect(prepare().sync.upserts).toEqual([]);
+    coverage.register(commit, 1);
+    const replay = prepare();
+    expect(replay.sync.upserts).toHaveLength(1);
+    expect(replay.sync.repairs?.[0].localSeq).toBe(10);
+  });
+
+  it("retries a discarded frame with its complete receipts and bases", () => {
+    write([set("of:shared", "value")]);
+    coverage.register(commitFor(10, ["of:shared"]), 1);
+    const dropped = prepare();
+    const retry = prepare();
+    expect(retry.sync).toEqual(dropped.sync);
+    retry.commit();
+    retry.commit();
+    expect(prepare().sync.repairs).toBeUndefined();
+  });
+
+  it("refuses to commit a prepared frame after its ownership changes", () => {
+    coverage.register(commitFor(10, ["of:absent"]), 0);
+    const frame = prepare();
+    coverage.release(10);
+    expect(() => frame.commit()).toThrow(ProtocolError);
+    expect(coverage.size).toBe(0);
+  });
+
+  it("refuses reused rejection identities with different dependencies", () => {
+    coverage.register(commitFor(10, ["of:first"]), 0);
+    expect(() => coverage.register(commitFor(10, ["of:second"]), 0)).toThrow(
+      ProtocolError,
+    );
+  });
+
+  it("rejects a cut older than rejection and mismatched graph cuts", () => {
+    coverage.register(commitFor(10, ["of:absent"]), 1);
+    expect(() => prepare()).toThrow(ProtocolError);
+    write([set("of:doc", null)]);
+    const sync = emptySync();
+    sync.toSeq = 0;
+    expect(() => prepare(sync)).toThrow(ProtocolError);
+  });
+
+  it("reports an unreadable branch without claiming the other repair failed", () => {
+    const invalid = commitFor(10, ["of:missing"]);
+    invalid.branch = "missing-branch";
+    coverage.register(invalid, 0);
+    coverage.register(commitFor(11, ["of:absent"]), 0);
+    const frame = prepare();
+    expect(frame.sync.repairFailures).toEqual([{
+      localSeq: 10,
+      reason: "unresolvable-address",
+    }]);
+    expect(frame.sync.repairs?.map((receipt) => receipt.localSeq)).toEqual([
+      11,
+    ]);
+    frame.commit();
+    expect(coverage.size).toBe(1);
+  });
+
+  it("reports an unresolvable user instance instead of substituting space data", () => {
+    const anonymous = new RepairCoverage(SPACE, {});
+    anonymous.register(commitFor(10, ["of:doc"], "user"), 0);
+    const frame = anonymous.prepare(
+      createDocumentSnapshotReader(SPACE, engine, {}),
+      emptySync(),
+      new Map(),
+    );
+    expect(frame.sync.repairFailures).toEqual([{
+      localSeq: 10,
+      reason: "unresolvable-address",
+    }]);
+    expect(frame.sync.repairs).toBeUndefined();
+    expect(frame.sync.upserts).toEqual([]);
+  });
+
+  it("reports unsupported non-document recovery instead of an empty successful receipt", () => {
+    coverage.register(commitFor(10, []), 0);
+    const frame = prepare();
+    expect(frame.sync.repairFailures).toEqual([{
+      localSeq: 10,
+      reason: "unsupported-dependency",
+    }]);
+    expect(frame.sync.repairs).toBeUndefined();
+    expect(isEmptySync(frame.sync)).toBe(false);
+    frame.commit();
+    expect(coverage.size).toBe(0);
+  });
+
+  it("preserves receipt and failure fields through schema-table and watch-view delivery", async () => {
+    const sync: SessionSync = {
+      ...emptySync(),
+      repairs: [{
+        localSeq: 10,
+        atSeq: 0,
+        documents: [{
+          branch: "",
+          id: "of:absent",
+          scope: "space",
+          seq: 0,
+          deleted: true,
+        }],
+        schemas: [],
+      }],
+      repairFailures: [{ localSeq: 11, reason: "unsupported-dependency" }],
+    };
+    expect(isEmptySync({ ...emptySync(), repairs: sync.repairs })).toBe(false);
+    sync.upserts.push({
+      branch: "",
+      id: "of:watched",
+      seq: 0,
+      doc: {
+        value: {
+          "/": {
+            "link@1": { id: "of:target", path: [], schema: { type: "string" } },
+          },
+        },
+      },
+    });
+    const compressed = compressSessionSyncSchemas(sync);
+    expect(compressed).not.toBe(sync);
+    const roundTrip = expandSessionSyncSchemas(compressed);
+    expect(roundTrip).toEqual(sync);
+    expect(isEmptySync(roundTrip)).toBe(false);
+    const view = WatchView.fromSync(emptySync());
+    const subscription = view.subscribeSync();
+    const delivered = subscription.next();
+    view.applySync(roundTrip, true);
+    expect((await delivered).value).toEqual(sync);
+    await subscription.return?.();
+  });
+});

--- a/packages/memory/test/v2-server-repair.test.ts
+++ b/packages/memory/test/v2-server-repair.test.ts
@@ -1,0 +1,372 @@
+import { expect } from "@std/expect";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { FakeTime } from "@std/testing/time";
+import type { FabricValue } from "@commonfabric/data-model";
+
+import {
+  type ClientCommit,
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+  type ResponseMessage,
+  type ServerMessage,
+  type SessionSync,
+  toDocumentPath,
+} from "../v2.ts";
+import { RepairCoverage } from "../v2/repair-coverage.ts";
+import { parseClientMessage, Server, SessionRegistry } from "../v2/server.ts";
+import {
+  TEST_SESSION_OPEN_PRINCIPAL,
+  testSessionOpenServerOptions,
+} from "./v2-auth-test-helpers.ts";
+
+const SPACE = "did:key:repair-server-space";
+const SESSION = "repair-session";
+
+function staleCommit(localSeq: number): ClientCommit {
+  return {
+    localSeq,
+    reads: {
+      confirmed: [{
+        id: "of:output",
+        scope: "user",
+        path: toDocumentPath(["value"]),
+        seq: 0,
+      }],
+      pending: [],
+    },
+    operations: [
+      { op: "set", id: "of:output", scope: "user", value: { value: null } },
+      {
+        op: "set",
+        id: "of:output",
+        value: {
+          value: {
+            "/": { "link@1": { id: "of:output", scope: "user", path: [] } },
+          },
+        },
+      },
+    ],
+  };
+}
+
+describe("server transaction repair delivery", () => {
+  let time: FakeTime;
+  let server: Server;
+  let sessions: SessionRegistry;
+  let connection: ReturnType<Server["connect"]>;
+  let messages: ServerMessage[];
+  let failNextEffect: boolean;
+
+  beforeEach(async () => {
+    time = new FakeTime();
+    sessions = new SessionRegistry();
+    server = new Server({
+      store: new URL("memory://server-repair"),
+      sessions,
+      subscriptionRefreshDelayMs: 100,
+      ...testSessionOpenServerOptions,
+    });
+    messages = [];
+    failNextEffect = false;
+    connection = server.connect((message) => {
+      if (failNextEffect && message.type === "session/effect") {
+        failNextEffect = false;
+        throw new Error("test transport refused the frame");
+      }
+      messages.push(message);
+    });
+    await send({
+      type: "hello",
+      protocol: MEMORY_PROTOCOL,
+      flags: getMemoryProtocolFlags(),
+    });
+    const hello = messages.shift();
+    if (hello?.type !== "hello.ok" || hello.sessionOpen === undefined) {
+      throw new Error("Expected hello.ok");
+    }
+    await send({
+      type: "session.open",
+      requestId: "open",
+      space: SPACE,
+      session: { sessionId: SESSION },
+      invocation: {
+        aud: hello.sessionOpen.audience,
+        challenge: hello.sessionOpen.challenge.value,
+      },
+    });
+    expect(response().error).toBeUndefined();
+    await transact({
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [
+        { op: "set", id: "of:output", scope: "user", value: { value: null } },
+        {
+          op: "set",
+          id: "of:output",
+          value: {
+            value: { "/": { "link@1": { id: "of:alternate", path: [] } } },
+          },
+        },
+        { op: "set", id: "of:alternate", value: { value: "alternate value" } },
+      ],
+    });
+    expect(response().error).toBeUndefined();
+    await server.flushSessions([SPACE]);
+    effect();
+    expect(messages).toEqual([]);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    time.restore();
+  });
+
+  async function send(value: FabricValue): Promise<void> {
+    await connection.receive(encodeMemoryBoundary(value));
+  }
+
+  async function transact(commit: ClientCommit): Promise<void> {
+    await send({
+      type: "transact",
+      requestId: `tx-${commit.localSeq}`,
+      space: SPACE,
+      sessionId: SESSION,
+      commit,
+    });
+  }
+
+  function response(): ResponseMessage<unknown> {
+    const message = messages.shift();
+    if (message?.type !== "response") throw new Error("Expected response");
+    return message;
+  }
+
+  function effect(): SessionSync {
+    const message = messages.shift();
+    if (message?.type !== "session/effect") {
+      throw new Error("Expected session effect");
+    }
+    return message.effect;
+  }
+
+  function enableCoverage(): RepairCoverage {
+    const session = sessions.get(SPACE, SESSION);
+    if (session === null) throw new Error("Expected an open session");
+    // Session admission does not negotiate repairs yet. Install the component
+    // through the registry to exercise its actual server/transport integration.
+    session.repairs = new RepairCoverage(SPACE, {
+      principal: TEST_SESSION_OPEN_PRINCIPAL,
+      sessionId: SESSION,
+    });
+    return session.repairs;
+  }
+
+  async function release(ids: number[]): Promise<void> {
+    await send({
+      type: "session.ack",
+      requestId: "release",
+      space: SPACE,
+      sessionId: SESSION,
+      seenSeq: 0,
+      releaseRepairs: ids,
+    });
+    expect(response().error).toBeUndefined();
+  }
+
+  it("delivers the unwatched scoped basis after the conflict and permits a fresh retry", async () => {
+    const coverage = enableCoverage();
+    await transact(staleCommit(2));
+    const rejected = response();
+    expect(rejected.error?.name).toBe("ConflictError");
+    expect(rejected.error?.repair).toEqual({ localSeq: 2 });
+    expect(messages).toEqual([]);
+    await server.flushSessions([SPACE]);
+    const repaired = effect();
+    expect(repaired.caughtUpLocalSeq).toBe(2);
+    expect(repaired.repairs?.[0].atSeq).toBe(rejected.error?.retryAfterSeq);
+    expect(repaired.upserts.map((doc) => [doc.id, doc.scope])).toEqual([[
+      "of:output",
+      "space",
+    ], ["of:output", "user"]]);
+    expect(sessions.get(SPACE, SESSION)?.entities.size).toBe(0);
+    expect(server.demandedInstancesForSpace(SPACE)).toEqual([]);
+    const retry = staleCommit(3);
+    const basis = repaired.repairs?.[0].documents.find((doc) =>
+      doc.scope === "user"
+    );
+    expect(basis).toBeDefined();
+    retry.reads.confirmed[0].seq = basis!.seq;
+    await transact(retry);
+    expect(response().error).toBeUndefined();
+    await server.flushSessions([SPACE]);
+    effect();
+    await release([2]);
+    await server.accessForTestingOnly.flushScheduledSessions();
+    expect(effect().removes.map((doc) => [doc.id, doc.scope])).toEqual([[
+      "of:output",
+      "space",
+    ], ["of:output", "user"]]);
+    expect(coverage.size).toBe(0);
+    expect(server.demandedInstancesForSpace(SPACE)).toEqual([]);
+  });
+
+  it("answers changed dependencies under one rejection identity with a protocol error", async () => {
+    const coverage = enableCoverage();
+    await transact(staleCommit(2));
+    expect(response().error?.name).toBe("ConflictError");
+    const changed = staleCommit(2);
+    changed.reads.confirmed.push({
+      id: "of:alternate",
+      path: toDocumentPath([]),
+      seq: 0,
+    });
+    await transact(changed);
+    expect(response().error?.name).toBe("ProtocolError");
+    expect(coverage.size).toBe(1);
+  });
+
+  it("leaves ordinary sessions on the inactive protocol path", async () => {
+    await transact(staleCommit(2));
+    expect(response().error?.repair).toBeUndefined();
+    await server.flushSessions([SPACE]);
+    const sync = effect();
+    expect(sync.repairs).toBeUndefined();
+    expect(sync.upserts).toEqual([]);
+    expect(sessions.get(SPACE, SESSION)?.repairs).toBeUndefined();
+    await send({
+      type: "session.ack",
+      requestId: "release",
+      space: SPACE,
+      sessionId: SESSION,
+      seenSeq: 0,
+      releaseRepairs: [2],
+    });
+    expect(response().error?.name).toBe("ProtocolError");
+  });
+
+  it("keeps repair coverage through full watch replacement and removal", async () => {
+    const coverage = enableCoverage();
+    await transact(staleCommit(2));
+    response();
+    await server.flushSessions([SPACE]);
+    effect();
+    await send({
+      type: "session.watch.set",
+      requestId: "watch",
+      space: SPACE,
+      sessionId: SESSION,
+      watches: [{
+        id: "output",
+        kind: "graph",
+        query: {
+          roots: [{ id: "of:output", selector: { path: [], schema: false } }],
+        },
+      }],
+    });
+    expect(response().error).toBeUndefined();
+    await send({
+      type: "session.watch.set",
+      requestId: "unwatch",
+      space: SPACE,
+      sessionId: SESSION,
+      watches: [],
+    });
+    const removed = response().ok as { sync: SessionSync };
+    expect(removed.sync.removes.some((doc) => doc.id === "of:output")).toBe(
+      false,
+    );
+    expect(coverage.size).toBe(1);
+    expect(server.demandedInstancesForSpace(SPACE)).toEqual([]);
+    await release([2]);
+    await server.accessForTestingOnly.flushScheduledSessions();
+    expect(effect().removes).toHaveLength(2);
+  });
+
+  it("redelivers complete repair after a failed send without adding graph demand", async () => {
+    const coverage = enableCoverage();
+    await transact(staleCommit(2));
+    response();
+    failNextEffect = true;
+    await server.flushSessions([SPACE]);
+    expect(messages).toEqual([]);
+    expect(coverage.needsSync(new Set())).toBe(true);
+    expect(sessions.get(SPACE, SESSION)?.entities.size).toBe(0);
+    await server.accessForTestingOnly.flushScheduledSessions();
+    const retried = effect();
+    expect(retried.repairs?.[0].localSeq).toBe(2);
+    expect(retried.upserts).toHaveLength(2);
+    expect(server.demandedInstancesForSpace(SPACE)).toEqual([]);
+  });
+
+  it("updates a retained repair document during an otherwise untouched graph pass", async () => {
+    enableCoverage();
+    await transact(staleCommit(2));
+    response();
+    await server.flushSessions([SPACE]);
+    effect();
+    await transact({
+      localSeq: 3,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: "of:output",
+        scope: "user",
+        value: { value: "changed" },
+      }],
+    });
+    expect(response().error).toBeUndefined();
+    await server.flushSessions([SPACE]);
+    const sync = effect();
+    expect(sync.upserts).toHaveLength(1);
+    expect(sync.upserts[0].doc).toEqual({ value: "changed" });
+    expect(sync.repairs).toBeUndefined();
+    expect(server.demandedInstancesForSpace(SPACE)).toEqual([]);
+  });
+
+  it("releases shared coverage only after its final owner finishes", async () => {
+    const coverage = enableCoverage();
+    await transact(staleCommit(2));
+    response();
+    await transact(staleCommit(3));
+    response();
+    await server.flushSessions([SPACE]);
+    const sync = effect();
+    expect(sync.repairs?.map((receipt) => receipt.localSeq)).toEqual([2, 3]);
+    expect(sync.upserts).toHaveLength(2);
+    await release([3]);
+    await server.accessForTestingOnly.flushScheduledSessions();
+    expect(messages).toEqual([]);
+    expect(coverage.size).toBe(1);
+    await release([2]);
+    await server.accessForTestingOnly.flushScheduledSessions();
+    expect(effect().removes).toHaveLength(2);
+    expect(coverage.size).toBe(0);
+  });
+
+  it("validates explicit release identities at the wire boundary", () => {
+    const ack = {
+      type: "session.ack",
+      requestId: "release",
+      space: SPACE,
+      sessionId: SESSION,
+      seenSeq: 0,
+    };
+    expect(
+      parseClientMessage(
+        encodeMemoryBoundary({ ...ack, releaseRepairs: [3, 1] }),
+      ),
+    ).toEqual({
+      ...ack,
+      releaseRepairs: [3, 1],
+    });
+    for (const invalid of [[-1], [0.5], ["3"], null, 1]) {
+      expect(
+        parseClientMessage(
+          encodeMemoryBoundary({ ...ack, releaseRepairs: invalid }),
+        ),
+      )
+        .toBeNull();
+    }
+  });
+});

--- a/packages/memory/test/v2-transaction-repair.test.ts
+++ b/packages/memory/test/v2-transaction-repair.test.ts
@@ -1,0 +1,268 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import {
+  type ClientCommit,
+  type Operation,
+  ProtocolError,
+  resolveScopeKey,
+  toDocumentPath,
+  toValuePath,
+} from "../v2.ts";
+import {
+  type CommitRepairAddress,
+  getCommitRepairFootprint,
+  resolveCommitRepairAddress,
+} from "../v2/transaction-repair.ts";
+
+describe("transaction repair addresses", () => {
+  describe("getCommitRepairFootprint()", () => {
+    it("returns an empty footprint for an empty transaction", () => {
+      expect(getCommitRepairFootprint({
+        reads: { confirmed: [], pending: [] },
+        operations: [],
+      })).toEqual([]);
+    });
+
+    it("includes all document operation kinds and excludes the SQLite target", () => {
+      const operations = {
+        set: { op: "set", id: "of:set", value: { value: null } },
+        patch: { op: "patch", id: "of:patch", patches: [] },
+        delete: { op: "delete", id: "of:delete" },
+        "apply-op": {
+          op: "apply-op",
+          id: "of:apply",
+          path: toValuePath(["body"]),
+          codec: "test-codec",
+          submissionId: "edit",
+          base: null,
+          payload: null,
+        },
+        "release-op-field": {
+          op: "release-op-field",
+          id: "of:release",
+          path: toValuePath(["body"]),
+          codec: "test-codec",
+          cursor: { epoch: 1, version: 1 },
+        },
+        sqlite: {
+          op: "sqlite",
+          db: { id: "of:database", scope: "user" },
+          sql: "INSERT INTO entries VALUES (1)",
+        },
+      } satisfies Record<Operation["op"], Operation>;
+
+      expect(getCommitRepairFootprint({
+        branch: "working",
+        operations: Object.values(operations),
+        reads: {
+          confirmed: [{ id: "of:schema", path: toDocumentPath([]), seq: 4 }],
+          pending: [],
+        },
+      })).toEqual([
+        { branch: "working", id: "of:set", scope: "space" },
+        { branch: "working", id: "of:patch", scope: "space" },
+        { branch: "working", id: "of:delete", scope: "space" },
+        { branch: "working", id: "of:apply", scope: "space" },
+        { branch: "working", id: "of:release", scope: "space" },
+        { branch: "working", id: "of:schema", scope: "space" },
+      ]);
+    });
+
+    it("deduplicates paths and versions across writes and both read sets", () => {
+      expect(getCommitRepairFootprint({
+        operations: [
+          { op: "set", id: "of:output", value: { value: null } },
+          { op: "delete", id: "of:output", scope: "space" },
+        ],
+        reads: {
+          confirmed: [
+            { id: "of:output", path: toDocumentPath(["value"]), seq: 0 },
+            { id: "of:input", path: toDocumentPath(["value", "a"]), seq: 3 },
+            {
+              id: "of:input",
+              path: toDocumentPath(["value"]),
+              seq: 4,
+              nonRecursive: true,
+            },
+          ],
+          pending: [
+            { id: "of:input", path: toDocumentPath([]), localSeq: 1 },
+            {
+              id: "of:pending",
+              path: toDocumentPath(["value"]),
+              localSeq: [1, 2],
+            },
+          ],
+        },
+      })).toEqual([
+        { branch: "", id: "of:output", scope: "space" },
+        { branch: "", id: "of:input", scope: "space" },
+        { branch: "", id: "of:pending", scope: "space" },
+      ]);
+    });
+
+    it("retains the same output ID separately in space, user, and session scope", () => {
+      expect(getCommitRepairFootprint({
+        operations: [
+          { op: "patch", id: "of:output", patches: [] },
+          {
+            op: "set",
+            id: "of:output",
+            scope: "user",
+            value: { value: null },
+          },
+        ],
+        reads: {
+          confirmed: [
+            {
+              id: "of:output",
+              scope: "user",
+              path: toDocumentPath(["value"]),
+              seq: 0,
+            },
+          ],
+          pending: [
+            {
+              id: "of:output",
+              scope: "session",
+              path: toDocumentPath([]),
+              localSeq: 2,
+            },
+          ],
+        },
+      })).toEqual([
+        { branch: "", id: "of:output", scope: "space" },
+        { branch: "", id: "of:output", scope: "user" },
+        { branch: "", id: "of:output", scope: "session" },
+      ]);
+    });
+
+    it("preserves explicit read branches including the default branch", () => {
+      expect(getCommitRepairFootprint({
+        branch: "target",
+        operations: [{ op: "delete", id: "of:shared", scope: "user" }],
+        reads: {
+          confirmed: [
+            {
+              id: "of:shared",
+              scope: "user",
+              path: toDocumentPath([]),
+              seq: 1,
+            },
+            {
+              id: "of:shared",
+              scope: "user",
+              branch: "source",
+              path: toDocumentPath([]),
+              seq: 2,
+            },
+            {
+              id: "of:shared",
+              scope: "user",
+              branch: "",
+              path: toDocumentPath([]),
+              seq: 3,
+            },
+          ],
+          pending: [
+            {
+              id: "of:shared",
+              scope: "user",
+              path: toDocumentPath([]),
+              localSeq: 1,
+            },
+          ],
+        },
+      })).toEqual([
+        { branch: "target", id: "of:shared", scope: "user" },
+        { branch: "source", id: "of:shared", scope: "user" },
+        { branch: "", id: "of:shared", scope: "user" },
+      ]);
+    });
+
+    it("does not discover dependencies by traversing a proposed document value", () => {
+      const commit: ClientCommit = {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "of:output",
+          value: {
+            value: { "/": { "link@1": { id: "of:unread", path: [] } } },
+          },
+        }],
+      };
+      expect(getCommitRepairFootprint(commit)).toEqual([
+        { branch: "", id: "of:output", scope: "space" },
+      ]);
+    });
+  });
+
+  describe("resolveCommitRepairAddress()", () => {
+    it("resolves a space address without a principal", () => {
+      expect(resolveCommitRepairAddress({
+        branch: "source",
+        id: "of:shared",
+        scope: "space",
+      }, {})).toEqual({
+        branch: "source",
+        id: "of:shared",
+        scope: "space",
+        scopeKey: "space",
+      });
+    });
+
+    it("resolves distinct user instances using the supplied principal", () => {
+      const address: CommitRepairAddress = {
+        branch: "",
+        id: "of:output",
+        scope: "user",
+      };
+      const first = { principal: "did:key:first", sessionId: "session" };
+      const second = { principal: "did:key:second", sessionId: "session" };
+      const a = resolveCommitRepairAddress(address, first);
+      const b = resolveCommitRepairAddress(address, second);
+      expect(a.scopeKey).toBe(resolveScopeKey("user", first));
+      expect(b.scopeKey).toBe(resolveScopeKey("user", second));
+      expect(a.scopeKey).not.toBe(b.scopeKey);
+      expect(a.id).toBe(address.id);
+      expect(a.branch).toBe(address.branch);
+    });
+
+    it("resolves distinct session instances for the same principal", () => {
+      const address: CommitRepairAddress = {
+        branch: "",
+        id: "of:output",
+        scope: "session",
+      };
+      const first = { principal: "did:key:first", sessionId: "one" };
+      const second = { principal: "did:key:first", sessionId: "two" };
+      const a = resolveCommitRepairAddress(address, first);
+      const b = resolveCommitRepairAddress(address, second);
+      expect(a.scopeKey).toBe(resolveScopeKey("session", first));
+      expect(b.scopeKey).toBe(resolveScopeKey("session", second));
+      expect(a.scopeKey).not.toBe(b.scopeKey);
+    });
+
+    it("throws when a user address has no principal", () => {
+      expect(() =>
+        resolveCommitRepairAddress({
+          branch: "",
+          id: "of:output",
+          scope: "user",
+        }, { sessionId: "one" })
+      ).toThrow(ProtocolError);
+    });
+
+    it("throws when a session address has no session identity", () => {
+      expect(() =>
+        resolveCommitRepairAddress({
+          branch: "",
+          id: "of:output",
+          scope: "session",
+        }, { principal: "did:key:first" })
+      ).toThrow(ProtocolError);
+    });
+  });
+});

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1424,6 +1424,39 @@ export type SessionSyncRemove = {
   scopeKey?: ScopeKey;
 };
 
+/** A document in one transaction's space, resolved under its session identity. */
+export type CommitRepairAddress = {
+  readonly branch: BranchName;
+  readonly id: EntityId;
+  readonly scope: CellScope;
+};
+
+/** An authoritative document version required by a transaction repair. */
+export type CommitRepairVersion = CommitRepairAddress & {
+  readonly seq: number;
+  readonly deleted?: true;
+};
+
+/**
+ * Complete document and schema requirements at one server cut. Values travel
+ * in ordinary upserts; receipt delivery alone does not establish readiness.
+ */
+export type CommitRepairReceipt = {
+  readonly localSeq: number;
+  readonly atSeq: number;
+  readonly documents: readonly CommitRepairVersion[];
+  readonly schemas: readonly CommitRepairVersion[];
+};
+
+/** A repair that cannot supply a complete, authoritative document basis. */
+export type CommitRepairFailure = {
+  readonly localSeq: number;
+  readonly reason:
+    | "unresolvable-address"
+    | "invalid-schema"
+    | "unsupported-dependency";
+};
+
 export type SessionSync = {
   type: "sync";
   fromSeq: number;
@@ -1432,6 +1465,12 @@ export type SessionSync = {
   upserts: SessionSyncUpsert[];
   removes: SessionSyncRemove[];
   operationFields?: OperationFieldDelivery[];
+
+  /** Complete receipts for sessions negotiating transaction repair. */
+  repairs?: CommitRepairReceipt[];
+
+  /** Per-repair failures; none of these identities has a successful receipt. */
+  repairFailures?: CommitRepairFailure[];
 };
 
 export type WatchSetResult = {
@@ -1690,6 +1729,9 @@ export type SessionAckRequest = {
   space: string;
   sessionId: SessionId;
   seenSeq: number;
+
+  /** Exact repair owners to release, independent of the acknowledged sequence. */
+  releaseRepairs?: number[];
 };
 
 export type EventAttentionResolveRequest = {
@@ -1734,6 +1776,9 @@ export type V2Error = {
   message: string;
   precondition?: string;
   retryAfterSeq?: number;
+
+  /** The rejected submission whose independent repair coverage was staged. */
+  repair?: { localSeq: number };
 
   /**
    * Present on an `AuthorizationError` that a fresh handshake can heal — the

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -2287,7 +2287,9 @@ const isResponse = (message: unknown): message is ResponseMessage<unknown> => {
 
 const isEmptySync = (sync: SessionSync): boolean =>
   sync.upserts.length === 0 && sync.removes.length === 0 &&
-  (sync.operationFields?.length ?? 0) === 0;
+  (sync.operationFields?.length ?? 0) === 0 &&
+  (sync.repairs?.length ?? 0) === 0 &&
+  (sync.repairFailures?.length ?? 0) === 0;
 
 const isSessionRevokedError = (error: unknown): boolean =>
   error instanceof Error && error.name === "SessionRevokedError";

--- a/packages/memory/v2/query.ts
+++ b/packages/memory/v2/query.ts
@@ -37,6 +37,7 @@ import {
   type GraphQuery,
   type GraphQueryRoot,
   isScopeKey,
+  ProtocolError,
   resolveScopeKey,
   type ScopeKey,
   type ScopeKeyIdentity,
@@ -1242,6 +1243,115 @@ const assembleSchemaDocClosures = (
     }
   }
   return { trackerAdds, additions };
+};
+
+/** Direct document snapshots and the additional schemas needed to decode them. */
+export type DocumentSnapshotBatch = {
+  documents: EntitySnapshot[];
+  schemas: EntitySnapshot[];
+};
+
+/** A reusable reader pinned to one store cut and one authenticated identity. */
+export type DocumentSnapshotReader = {
+  readonly space: string;
+  readonly identity: Readonly<ScopeKeyIdentity>;
+  readonly atSeq: number;
+  read(
+    addresses: readonly Pick<EntitySnapshot, "branch" | "id" | "scope">[],
+  ): DocumentSnapshotBatch;
+};
+
+/**
+ * Assembles raw document bases and verified schema closures without traversing
+ * value links or metadata families. Reads share managers within the batch and
+ * stay pinned to the captured server cut. Callers authorize the space before
+ * creating the reader and keep publication ordered through frame assembly.
+ */
+export const createDocumentSnapshotReader = (
+  space: string,
+  engine: Engine.Engine,
+  identity: ScopeKeyIdentity,
+): DocumentSnapshotReader => {
+  const atSeq = Engine.serverSeq(engine);
+  const principal = identity.principal;
+  const sessionId = identity.sessionId;
+  const branches = new Map(
+    Engine.listBranches(engine).map((branch) => [branch.name, branch.headSeq]),
+  );
+  const managers = new Map<string, EngineObjectManager>();
+  const snapshots = new Map<string, Map<QueryDocKey, EntitySnapshot>>();
+  const scans = new Map<string, SchemaRefScans>();
+  return {
+    space,
+    identity: Object.freeze({ principal, sessionId }),
+    atSeq,
+    read(addresses) {
+      const grouped = new Map<string, Map<QueryDocKey, EntitySnapshot>>();
+      for (const address of addresses) {
+        if (!branches.has(address.branch)) {
+          throw new ProtocolError("Snapshot requires an unreadable branch");
+        }
+        const key = toDocKey(
+          space,
+          address.id,
+          address.scope ?? DEFAULT_SCOPE,
+          { principal, sessionId },
+        );
+        let manager = managers.get(address.branch);
+        if (manager === undefined) {
+          manager = new EngineObjectManager(
+            engine,
+            address.branch,
+            principal,
+            sessionId,
+            branches.get(address.branch)!,
+          );
+          managers.set(address.branch, manager);
+        }
+        let cached = snapshots.get(address.branch);
+        if (cached === undefined) {
+          cached = new Map();
+          snapshots.set(address.branch, cached);
+        }
+        let snapshot = cached.get(key);
+        if (snapshot === undefined) {
+          snapshot = snapshotForDocKey(space, manager, address.branch, key) ??
+            undefined;
+          if (snapshot === undefined) {
+            throw new ProtocolError("Invalid document address");
+          }
+          cached.set(key, snapshot);
+        }
+        let documents = grouped.get(address.branch);
+        if (documents === undefined) {
+          documents = new Map();
+          grouped.set(address.branch, documents);
+        }
+        documents.set(key, snapshot);
+      }
+      const result: DocumentSnapshotBatch = { documents: [], schemas: [] };
+      for (const [branch, documents] of grouped) {
+        let branchScans = scans.get(branch);
+        if (branchScans === undefined) {
+          branchScans = new Map();
+          scans.set(branch, branchScans);
+        }
+        const closure = assembleSchemaDocClosures(
+          space,
+          engine,
+          managers.get(branch)!,
+          branch,
+          new MapSetStringToPathSelectors(true),
+          documents,
+          branchScans,
+          createQueryTraversalStats(),
+        );
+        result.documents.push(...documents.values());
+        result.schemas.push(...closure.additions.values());
+      }
+      return result;
+    },
+  };
 };
 
 /**

--- a/packages/memory/v2/repair-coverage.ts
+++ b/packages/memory/v2/repair-coverage.ts
@@ -1,0 +1,298 @@
+/**
+ * Transaction-owned document coverage for server synchronization. Repair
+ * delivery composes with graph frames while keeping ownership and wake keys
+ * separate from graph watches and execution demand.
+ */
+
+import {
+  type CellScope,
+  type ClientCommit,
+  type CommitRepairAddress,
+  type CommitRepairFailure,
+  type CommitRepairReceipt,
+  type CommitRepairVersion,
+  type EntitySnapshot,
+  ProtocolError,
+  resolveScopeKey,
+  type ScopeKeyIdentity,
+  type SessionSync,
+  type SessionSyncRemove,
+  type SessionSyncUpsert,
+} from "../v2.ts";
+import { type DocumentSnapshotReader, SchemaClosureError } from "./query.ts";
+import {
+  cacheKeyForEntity,
+  compareSyncAddress,
+  sameSnapshot,
+  type SessionCacheEntry,
+  toCacheEntry,
+  toWireRemove,
+  toWireUpsert,
+  trackedIdsFromEntries,
+} from "./server-sync.ts";
+import { getCommitRepairFootprint } from "./transaction-repair.ts";
+
+/**
+ * A complete frame whose repair bookkeeping is still staged. Commit after
+ * successful delivery under the session's publication lock; discard on failure.
+ */
+export type PreparedRepairSync = {
+  readonly sync: SessionSync;
+  commit(): void;
+};
+
+type Repair = {
+  readonly documents: CommitRepairAddress[];
+  readonly retryAfterSeq: number;
+  pending: boolean;
+};
+
+/**
+ * Coverage belonging to one authenticated logical session. The caller owns
+ * authorization, publication ordering, reconnect restoration, and destruction
+ * on identity change. Ordinary watch mutations never replace this ownership.
+ */
+export class RepairCoverage {
+  readonly #space: string;
+  readonly #identity: ScopeKeyIdentity;
+  readonly #repairs = new Map<number, Repair>();
+  #delivered = new Map<string, SessionCacheEntry>();
+  #wakeKeys = new Set<string>();
+  #generation = 0;
+  #ownershipChanged = false;
+
+  constructor(space: string, identity: ScopeKeyIdentity) {
+    this.#space = space;
+    this.#identity = { ...identity };
+  }
+
+  /** Number of rejected operations still owning document coverage. */
+  get size(): number {
+    return this.#repairs.size;
+  }
+
+  /**
+   * Stages complete delivery for a rejection, including replay of one already
+   * delivered. Reusing a local sequence for different dependencies is invalid.
+   */
+  register(commit: ClientCommit, retryAfterSeq: number): void {
+    if (
+      !Number.isSafeInteger(commit.localSeq) || commit.localSeq < 0 ||
+      !Number.isSafeInteger(retryAfterSeq) || retryAfterSeq < 0
+    ) {
+      throw new ProtocolError("Invalid transaction repair sequence");
+    }
+    const documents = getCommitRepairFootprint(commit);
+    const existing = this.#repairs.get(commit.localSeq);
+    if (
+      existing !== undefined && !sameAddresses(existing.documents, documents)
+    ) {
+      throw new ProtocolError(
+        "Transaction repair replay changed its dependencies",
+      );
+    }
+    this.#repairs.set(commit.localSeq, {
+      documents,
+      retryAfterSeq: Math.max(existing?.retryAfterSeq ?? 0, retryAfterSeq),
+      pending: true,
+    });
+    this.#generation++;
+    this.#ownershipChanged = true;
+  }
+
+  /** Releases one owner idempotently; delivery is retracted by the next frame. */
+  release(localSeq: number): void {
+    if (this.#repairs.delete(localSeq)) {
+      this.#generation++;
+      this.#ownershipChanged = true;
+    }
+  }
+
+  /** Whether a pass owes receipts, release cleanup, or changed covered bases. */
+  needsSync(dirtyIds?: ReadonlySet<string>): boolean {
+    if (this.#ownershipChanged) return true;
+    if (this.#repairs.size === 0) return this.#delivered.size > 0;
+    if (dirtyIds === undefined) return true;
+    for (const repair of this.#repairs.values()) {
+      if (repair.pending) return true;
+    }
+    for (const id of dirtyIds) {
+      if (this.#wakeKeys.has(id)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Composes a graph frame with raw repair bases at the same server cut.
+   * `graphEntries` is graph provenance only and is never mutated. Complete
+   * receipts force all required snapshots into their first delivery, even if
+   * the graph cache remembers sending them. Shared addresses appear once.
+   */
+  prepare(
+    reader: DocumentSnapshotReader,
+    graphSync: SessionSync,
+    graphEntries: ReadonlyMap<string, SessionCacheEntry>,
+    keyed = false,
+  ): PreparedRepairSync {
+    if (
+      reader.space !== this.#space ||
+      reader.identity.principal !== this.#identity.principal ||
+      reader.identity.sessionId !== this.#identity.sessionId
+    ) {
+      throw new ProtocolError(
+        "Repair reader belongs to a different logical session",
+      );
+    }
+    if (reader.atSeq !== graphSync.toSeq) {
+      throw new ProtocolError(
+        "Repair and graph snapshots require the same server cut",
+      );
+    }
+    const generation = this.#generation;
+    const next = new Map<string, SessionCacheEntry>();
+    const forced = new Set<string>();
+    const receipts: CommitRepairReceipt[] = [];
+    const failures: CommitRepairFailure[] = [];
+    const entriesFor = (
+      snapshots: readonly EntitySnapshot[],
+    ) => snapshots.map((snapshot) => toCacheEntry(snapshot, this.#identity));
+
+    for (const [localSeq, repair] of this.#repairs) {
+      if (reader.atSeq < repair.retryAfterSeq) {
+        throw new ProtocolError("Repair snapshot predates its rejection");
+      }
+      if (repair.documents.length === 0) {
+        failures.push({ localSeq, reason: "unsupported-dependency" });
+        continue;
+      }
+      try {
+        const batch = reader.read(repair.documents);
+        const documents = entriesFor(batch.documents);
+        const schemas = entriesFor(batch.schemas);
+        for (const entry of [...documents, ...schemas]) {
+          const key = cacheKeyForEntity(entry.branch, entry.id, entry.scopeKey);
+          next.set(key, entry);
+          if (repair.pending) forced.add(key);
+        }
+        if (repair.pending) {
+          receipts.push({
+            localSeq,
+            atSeq: reader.atSeq,
+            documents: documents.map(versionOf),
+            schemas: schemas.map(versionOf),
+          });
+        }
+      } catch (error) {
+        if (error instanceof SchemaClosureError) {
+          failures.push({ localSeq, reason: "invalid-schema" });
+        } else if (error instanceof ProtocolError) {
+          failures.push({ localSeq, reason: "unresolvable-address" });
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    const upserts = new Map<string, SessionSyncUpsert>();
+    const removes = new Map<string, SessionSyncRemove>();
+    for (const upsert of graphSync.upserts) {
+      upserts.set(this.#wireKey(upsert), upsert);
+    }
+    for (const remove of graphSync.removes) {
+      const key = this.#wireKey(remove);
+      if (!next.has(key)) removes.set(key, remove);
+    }
+    for (const [key, entry] of next) {
+      const graphUpsert = upserts.get(key);
+      if (graphUpsert !== undefined && graphUpsert.seq > entry.seq) {
+        throw new ProtocolError(
+          "Graph delivery is newer than the repair snapshot",
+        );
+      }
+      if (
+        forced.has(key) || !sameSnapshot(this.#delivered.get(key), entry) ||
+        graphUpsert !== undefined
+      ) {
+        upserts.set(key, toWireUpsert(entry, keyed));
+      }
+    }
+    for (const [key, entry] of this.#delivered) {
+      if (!next.has(key) && !graphEntries.has(key)) {
+        removes.set(key, toWireRemove(entry, keyed));
+      }
+    }
+    for (const key of upserts.keys()) removes.delete(key);
+    const sync: SessionSync = {
+      ...graphSync,
+      upserts: [...upserts.values()].sort(compareSyncAddress),
+      removes: [...removes.values()].sort(compareSyncAddress),
+      ...(receipts.length === 0 ? {} : { repairs: receipts }),
+      ...(failures.length === 0 ? {} : { repairFailures: failures }),
+    };
+    let committed = false;
+    return {
+      sync,
+      commit: () => {
+        if (committed) return;
+        if (generation !== this.#generation) {
+          throw new ProtocolError(
+            "Repair ownership changed during frame delivery",
+          );
+        }
+        this.#delivered = next;
+        this.#wakeKeys = trackedIdsFromEntries(next.values());
+        for (const receipt of receipts) {
+          this.#repairs.get(receipt.localSeq)!.pending = false;
+        }
+        for (const failure of failures) this.#repairs.delete(failure.localSeq);
+        this.#generation++;
+        this.#ownershipChanged = false;
+        committed = true;
+      },
+    };
+  }
+
+  #wireKey(address: SessionSyncRemove): string {
+    return cacheKeyForEntity(
+      address.branch,
+      address.id,
+      address.scopeKey ?? resolveScopeKey(address.scope, this.#identity),
+    );
+  }
+}
+
+/** Document version requirements use the recipient's scope vocabulary. */
+function versionOf(entry: SessionCacheEntry): CommitRepairVersion {
+  return {
+    branch: entry.branch,
+    id: entry.id,
+    scope: entry.scope,
+    seq: entry.seq,
+    ...(entry.deleted === true ? { deleted: true } : {}),
+  };
+}
+
+/** Replay identity is set membership, independent of transaction read order. */
+function sameAddresses(
+  left: readonly CommitRepairAddress[],
+  right: readonly CommitRepairAddress[],
+): boolean {
+  if (left.length !== right.length) return false;
+  const keys = new Map<string, Map<CellScope, Set<string>>>();
+  for (const address of left) {
+    let branch = keys.get(address.branch);
+    if (branch === undefined) {
+      branch = new Map();
+      keys.set(address.branch, branch);
+    }
+    let ids = branch.get(address.scope);
+    if (ids === undefined) {
+      ids = new Set();
+      branch.set(address.scope, ids);
+    }
+    ids.add(address.id);
+  }
+  return right.every((address) =>
+    keys.get(address.branch)?.get(address.scope)?.has(address.id)
+  );
+}

--- a/packages/memory/v2/server-sync.ts
+++ b/packages/memory/v2/server-sync.ts
@@ -54,7 +54,9 @@ export const sameSnapshot = (
 
 export const isEmptySync = (sync: SessionSync): boolean =>
   sync.upserts.length === 0 && sync.removes.length === 0 &&
-  (sync.operationFields?.length ?? 0) === 0;
+  (sync.operationFields?.length ?? 0) === 0 &&
+  (sync.repairs?.length ?? 0) === 0 &&
+  (sync.repairFailures?.length ?? 0) === 0;
 
 /**
  * Build a session cache entry for one tracked instance. The instance key

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -158,6 +158,10 @@ import { assertReadOnly } from "./sqlite/guard.ts";
 import { ReadConnectionPool } from "./sqlite/read-pool.ts";
 import type { TableSchema } from "./sqlite/schema.ts";
 import { resolveSpaceStoreUrl } from "./storage-path.ts";
+import {
+  getCommitRepairFootprint,
+  resolveCommitRepairAddress,
+} from "./transaction-repair.ts";
 import { type ArmedTurn, armTurn } from "./turn.ts";
 
 export { SessionRegistry } from "./session-registry.ts";
@@ -6530,23 +6534,14 @@ export class Server {
     );
     const identity = this.#sessionScopeIdentity(session);
     const ids = new Set<string>();
-    const addInstanceKey = (id: string, scope: CellScope | undefined) => {
+    for (const address of getCommitRepairFootprint(commit)) {
       // A rejected commit's scoped addresses resolve against the
       // rejected session's own identity (M4 instance keys). A scope the
       // session holds no identity for could not have applied or been
       // read by it — skip rather than throw on the repair path.
-      if (!canResolveScopeKey(scope, identity)) return;
-      ids.add(toDirtyKey(id, resolveScopeKey(scope, identity)));
-    };
-    for (const operation of commit.operations) {
-      if (operation.op === "sqlite") continue; // no entity id
-      addInstanceKey(operation.id, operation.scope);
-    }
-    for (const read of commit.reads.confirmed) {
-      addInstanceKey(read.id, read.scope);
-    }
-    for (const read of commit.reads.pending) {
-      addInstanceKey(read.id, read.scope);
+      if (!canResolveScopeKey(address.scope, identity)) continue;
+      const resolved = resolveCommitRepairAddress(address, identity);
+      ids.add(toDirtyKey(resolved.id, resolved.scopeKey));
     }
     this.markSpaceDirty(space, ids);
   }

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -51,6 +51,7 @@ import {
   type OperationFieldQueryRequest,
   type OperationFieldQueryResult,
   parseMemoryProtocolFlags,
+  ProtocolError,
   resolveScopeKey,
   type ResponseMessage,
   type ScopeKey,
@@ -96,6 +97,7 @@ import * as Engine from "./engine.ts";
 import { respondToHello } from "./handshake.ts";
 import {
   cloneTrackedGraphState,
+  createDocumentSnapshotReader,
   createQueryEvaluationCache,
   extendTrackedGraph,
   fromDirtyKey,
@@ -114,6 +116,7 @@ import {
   type TrackedGraphState,
   trackGraph,
 } from "./query.ts";
+import type { PreparedRepairSync } from "./repair-coverage.ts";
 import {
   executionLeaseHolder,
   liveExecutionLeaseHolder,
@@ -810,6 +813,7 @@ class Connection {
     timing.time(schemaStart, "memory", "response", "prepareSchemas");
     const sendStart = performance.now();
     this.#sendRaw(prepared);
+    this.#server.commitDeliveredRepair(message);
     timing.time(sendStart, "memory", "response", "sendRaw");
   }
 
@@ -1234,13 +1238,14 @@ class Connection {
           return;
         }
         {
-          const response = await this.#server.watchSet(parsed);
-          this.#sendSessionResponse(
-            parsed.space,
-            parsed.sessionId,
-            parsed.requestId,
-            response,
-          );
+          await this.#server.watchSet(parsed, (response) => {
+            this.#sendSessionResponse(
+              parsed.space,
+              parsed.sessionId,
+              parsed.requestId,
+              response,
+            );
+          });
         }
         return;
       case "session.watch.add":
@@ -1254,13 +1259,14 @@ class Connection {
           return;
         }
         {
-          const response = await this.#server.watchAdd(parsed);
-          this.#sendSessionResponse(
-            parsed.space,
-            parsed.sessionId,
-            parsed.requestId,
-            response,
-          );
+          await this.#server.watchAdd(parsed, (response) => {
+            this.#sendSessionResponse(
+              parsed.space,
+              parsed.sessionId,
+              parsed.requestId,
+              response,
+            );
+          });
         }
         return;
       case "session.ack":
@@ -1443,6 +1449,10 @@ export type EngineOpener = (
 export class Server {
   #sessions: SessionRegistry;
   #connections = new Map<string, Connection>();
+  readonly #preparedRepairSyncs = new WeakMap<
+    SessionSync,
+    PreparedRepairSync
+  >();
 
   /** Whole-evaluation caches, one per space (see QueryEvaluationCache in
    * query.ts for the sharing, purity, and seq-rotation rules), held for at
@@ -1742,6 +1752,45 @@ export class Server {
    * exactly them and no other server's. */
   #pushPriorityStatsProvider = () => this.pushPriorityStats();
   #documentCachesDiagnosticsProvider = () => this.documentCachesDiagnostics();
+
+  /** Commits repair delivery only after the connection's send succeeds. */
+  commitDeliveredRepair(message: ServerMessage): void {
+    const sync = message.type === "session/effect"
+      ? message.effect
+      : message.type === "response" && isObjectNotArray(message.ok)
+      ? message.ok.sync
+      : undefined;
+    if (!isObjectNotArray(sync)) return;
+    const prepared = this.#preparedRepairSyncs.get(sync as SessionSync);
+    if (prepared === undefined) return;
+    prepared.commit();
+    this.#preparedRepairSyncs.delete(prepared.sync);
+  }
+
+  /** Composes independent repair delivery without changing graph provenance. */
+  #composeRepairSync(
+    space: string,
+    session: SessionState,
+    engine: Engine.Engine,
+    sync: SessionSync,
+    graphEntries = session.entities,
+  ): SessionSync {
+    if (session.repairs === undefined || !session.repairs.needsSync()) {
+      return sync;
+    }
+    const prepared = session.repairs.prepare(
+      createDocumentSnapshotReader(
+        space,
+        engine,
+        this.#sessionScopeIdentity(session),
+      ),
+      sync,
+      graphEntries,
+      session.leaseHolderReads === true,
+    );
+    this.#preparedRepairSyncs.set(prepared.sync, prepared);
+    return prepared.sync;
+  }
 
   /** Every open engine's document-cache counters, keyed by space. A peek:
    * nothing is opened by asking. */
@@ -3310,6 +3359,30 @@ export class Server {
   async ackSession(
     message: SessionAckRequest,
   ): Promise<ResponseMessage<SessionAckResult>> {
+    if (message.releaseRepairs !== undefined) {
+      if (
+        this.#sessions.get(message.space, message.sessionId)?.repairs ===
+          undefined
+      ) {
+        return respondTypedError<SessionAckResult>(
+          message.requestId,
+          toError(
+            "ProtocolError",
+            "Transaction repair is not enabled for this session",
+          ),
+        );
+      }
+      return await this.#withSpacePublicationLock(
+        message.space,
+        () => this.#ackSession(message),
+      );
+    }
+    return await this.#ackSession(message);
+  }
+
+  async #ackSession(
+    message: SessionAckRequest,
+  ): Promise<ResponseMessage<SessionAckResult>> {
     const session = this.#sessions.updateSeenSeq(
       message.space,
       message.sessionId,
@@ -3323,6 +3396,16 @@ export class Server {
     }
     try {
       const engine = await this.#openEngine(message.space);
+      if (message.releaseRepairs !== undefined) {
+        if (this.#sessions.get(message.space, message.sessionId) !== session) {
+          throw new ProtocolError("Session changed during repair release");
+        }
+        const count = session.repairs!.size;
+        for (const localSeq of message.releaseRepairs) {
+          session.repairs!.release(localSeq);
+        }
+        if (session.repairs!.size !== count) this.markSpaceDirty(message.space);
+      }
       return {
         type: "response",
         requestId: message.requestId,
@@ -4011,6 +4094,15 @@ export class Server {
             );
             const engine = await this.#openEngine(message.space);
             retryAfterSeq = Engine.serverSeq(engine);
+            try {
+              session.repairs?.register(message.commit, retryAfterSeq);
+            } catch (repairError) {
+              if (!(repairError instanceof ProtocolError)) throw repairError;
+              return respondTypedError<Engine.AppliedCommit>(
+                message.requestId,
+                toError(repairError.name, repairError.message),
+              );
+            }
           }
           const messageText = error instanceof Error
             ? error.message
@@ -4046,6 +4138,9 @@ export class Server {
           );
           if (retryAfterSeq !== undefined) {
             responseError.retryAfterSeq = retryAfterSeq;
+            if (session.repairs !== undefined) {
+              responseError.repair = { localSeq: message.commit.localSeq };
+            }
           }
           span.recordException(
             error instanceof Error ? error : new Error(messageText),
@@ -4374,6 +4469,21 @@ export class Server {
 
   async watchSet(
     message: WatchSetRequest,
+    publish?: (response: ResponseMessage<WatchSetResult>) => void,
+  ): Promise<ResponseMessage<WatchSetResult>> {
+    const run = async () => {
+      const response = await this.#watchSet(message);
+      publish?.(response);
+      return response;
+    };
+    return this.#sessions.get(message.space, message.sessionId)?.repairs ===
+        undefined
+      ? await run()
+      : await this.#withSpacePublicationLock(message.space, run);
+  }
+
+  async #watchSet(
+    message: WatchSetRequest,
   ): Promise<ResponseMessage<WatchSetResult>> {
     const session = this.#sessions.get(message.space, message.sessionId);
     if (session === null) {
@@ -4437,6 +4547,9 @@ export class Server {
 
     try {
       const nextOperationCursors = new Map<string, OpCursor>();
+      const repairEngine = session.repairs === undefined
+        ? undefined
+        : aclEngine ?? await this.#openEngine(message.space);
       const { serverSeq, graphs, entities } = await this.evaluateWatchSet(
         message.space,
         message.watches,
@@ -4486,6 +4599,15 @@ export class Server {
         message.watches,
         nextOperationCursors,
       );
+      const deliveredSync = repairEngine === undefined
+        ? sync
+        : this.#composeRepairSync(
+          message.space,
+          session,
+          repairEngine,
+          sync,
+          entities,
+        );
       session.watches = message.watches;
       session.operationCursors = nextOperationCursors;
       session.graphs = graphs;
@@ -4503,7 +4625,7 @@ export class Server {
         requestId: message.requestId,
         ok: {
           serverSeq,
-          sync,
+          sync: deliveredSync,
         },
       };
     } catch (error) {
@@ -4524,10 +4646,19 @@ export class Server {
   /** Add session watches, timing admission through the handler's completion. */
   async watchAdd(
     message: WatchAddRequest,
+    publish?: (response: ResponseMessage<WatchAddResult>) => void,
   ): Promise<ResponseMessage<WatchAddResult>> {
     const startedAt = performance.now();
+    const run = async () => {
+      const response = await this.#watchAdd(message);
+      publish?.(response);
+      return response;
+    };
     try {
-      return await this.#watchAdd(message);
+      return this.#sessions.get(message.space, message.sessionId)?.repairs ===
+          undefined
+        ? await run()
+        : await this.#withSpacePublicationLock(message.space, run);
     } finally {
       timing.time(startedAt, "memory", "watchAdd", "total");
     }
@@ -4781,6 +4912,12 @@ export class Server {
           upserts: upserts.length,
           ...attribution,
         },
+      );
+      response.ok!.sync = this.#composeRepairSync(
+        message.space,
+        session,
+        engine,
+        response.ok!.sync,
       );
       return response;
     } catch (error) {
@@ -5146,7 +5283,72 @@ export class Server {
     }
   }
 
-  syncSessionForConnection(
+  async syncSessionForConnection(
+    space: string,
+    sessionId: string,
+    dirtyIds?: ReadonlySet<string>,
+    dirtyOrigins?: ReadonlyMap<string, DirtyOrigin>,
+  ): Promise<SessionEffectMessage | null> {
+    const session = this.#sessions.get(space, sessionId);
+    if (session?.repairs === undefined || !session.repairs.needsSync()) {
+      return await this.#syncGraphSessionForConnection(
+        space,
+        sessionId,
+        dirtyIds,
+        dirtyOrigins,
+      );
+    }
+    // The caller holds the publication lock through evaluation and send.
+    const engine = await this.#openEngine(space);
+    const graph = await this.#syncGraphSessionForConnection(
+      space,
+      sessionId,
+      dirtyIds,
+      dirtyOrigins,
+    );
+    if (this.#sessions.get(space, sessionId) !== session) return null;
+    if (graph === null && !session.repairs.needsSync(dirtyIds)) return null;
+    try {
+      const sync = this.#composeRepairSync(
+        space,
+        session,
+        engine,
+        graph?.effect ?? {
+          type: "sync",
+          fromSeq: session.lastSyncedSeq,
+          toSeq: Engine.serverSeq(engine),
+          upserts: [],
+          removes: [],
+        },
+      );
+      if (isEmptySync(sync) && sync.caughtUpLocalSeq === undefined) {
+        this.#preparedRepairSyncs.get(sync)?.commit();
+        this.#preparedRepairSyncs.delete(sync);
+        return null;
+      }
+      const effect: SessionEffectMessage = {
+        type: "session/effect",
+        space,
+        sessionId,
+        effect: sync,
+      };
+      // Rollback belongs to graph delivery only; a failed repair send leaves
+      // its independent prepared state uncommitted and therefore replayable.
+      this.#deliveredFrameEntries.set(
+        effect,
+        graph === null
+          ? { upserts: [], removes: [] }
+          : this.#deliveredFrameEntries.get(graph) ??
+            { upserts: [], removes: [] },
+      );
+      return effect;
+    } catch (error) {
+      if (graph !== null) this.rollbackUndeliveredSync(space, sessionId, graph);
+      throw error;
+    }
+  }
+
+  #syncGraphSessionForConnection(
     space: string,
     sessionId: string,
     dirtyIds?: ReadonlySet<string>,
@@ -7442,12 +7644,22 @@ export const parseClientMessage = (
     typeof parsed.sessionId === "string" &&
     typeof parsed.seenSeq === "number"
   ) {
+    if (
+      parsed.releaseRepairs !== undefined &&
+      (!Array.isArray(parsed.releaseRepairs) ||
+        !parsed.releaseRepairs.every((seq) =>
+          Number.isSafeInteger(seq) && seq >= 0
+        ))
+    ) return null;
     return {
       type: "session.ack",
       requestId: parsed.requestId,
       space: parsed.space,
       sessionId: parsed.sessionId,
       seenSeq: parsed.seenSeq,
+      ...(parsed.releaseRepairs === undefined
+        ? {}
+        : { releaseRepairs: parsed.releaseRepairs as number[] }),
     };
   }
 

--- a/packages/memory/v2/session-registry.ts
+++ b/packages/memory/v2/session-registry.ts
@@ -5,6 +5,7 @@ import type {
   WatchSpec,
 } from "../v2.ts";
 import type { TrackedGraphState } from "./query.ts";
+import type { RepairCoverage } from "./repair-coverage.ts";
 import type { SessionCacheEntry } from "./server-sync.ts";
 import { trackedIdsFromEntries } from "./server-sync.ts";
 
@@ -18,6 +19,10 @@ export type SessionState = {
   operationCursors: Map<string, OpCursor>;
   graphs: Map<string, TrackedGraphState>;
   entities: Map<string, SessionCacheEntry>;
+
+  /** Independently owned repair delivery; never part of graph demand. */
+  repairs?: RepairCoverage;
+
   trackedIds: Set<string>;
   caughtUpLocalSeq: number;
   pendingCaughtUpLocalSeq: number;
@@ -149,6 +154,7 @@ export class SessionRegistry {
       operationCursors: existing?.operationCursors ?? new Map(),
       graphs: existing?.graphs ?? new Map(),
       entities: existing?.entities ?? new Map(),
+      ...(existing?.repairs === undefined ? {} : { repairs: existing.repairs }),
       trackedIds: existing?.trackedIds ??
         trackedIdsFromEntries(existing?.entities?.values() ?? []),
       caughtUpLocalSeq: existing?.caughtUpLocalSeq ?? 0,

--- a/packages/memory/v2/transaction-repair.ts
+++ b/packages/memory/v2/transaction-repair.ts
@@ -8,6 +8,7 @@ import {
   type BranchName,
   type CellScope,
   type ClientCommit,
+  type CommitRepairAddress,
   DEFAULT_BRANCH,
   type EntityId,
   ProtocolError,
@@ -16,12 +17,7 @@ import {
   type ScopeKeyIdentity,
 } from "../v2.ts";
 
-/** A document in a transaction's space, before resolving its scope instance. */
-export type CommitRepairAddress = {
-  readonly branch: BranchName;
-  readonly id: EntityId;
-  readonly scope: CellScope;
-};
+export type { CommitRepairAddress } from "../v2.ts";
 
 /** A repair address resolved under the transaction's authenticated identity. */
 export type ResolvedCommitRepairAddress = CommitRepairAddress & {

--- a/packages/memory/v2/transaction-repair.ts
+++ b/packages/memory/v2/transaction-repair.ts
@@ -1,0 +1,101 @@
+/**
+ * Document addresses used to repair a rejected transaction in one memory space.
+ * Footprints retain branch and scope names; an authenticated session supplies
+ * the identity that resolves each scope instance.
+ */
+
+import {
+  type BranchName,
+  type CellScope,
+  type ClientCommit,
+  DEFAULT_BRANCH,
+  type EntityId,
+  ProtocolError,
+  resolveScopeKey,
+  type ScopeKey,
+  type ScopeKeyIdentity,
+} from "../v2.ts";
+
+/** A document in a transaction's space, before resolving its scope instance. */
+export type CommitRepairAddress = {
+  readonly branch: BranchName;
+  readonly id: EntityId;
+  readonly scope: CellScope;
+};
+
+/** A repair address resolved under the transaction's authenticated identity. */
+export type ResolvedCommitRepairAddress = CommitRepairAddress & {
+  readonly scopeKey: ScopeKey;
+};
+
+/**
+ * Returns the distinct document addresses in a commit's writes and both read
+ * sets, in first-encounter order. Paths and read versions share a document
+ * address; different branches and scopes retain separate addresses. SQLite
+ * statements contribute their declared document reads, not a synthetic target.
+ */
+export function getCommitRepairFootprint(
+  commit: Pick<ClientCommit, "branch" | "operations" | "reads">,
+): CommitRepairAddress[] {
+  const branch = commit.branch ?? DEFAULT_BRANCH;
+  const seen = new Map<BranchName, Map<CellScope, Set<EntityId>>>();
+  const addresses: CommitRepairAddress[] = [];
+  const add = (
+    id: EntityId,
+    scope: CellScope = "space",
+    readBranch: BranchName = branch,
+  ) => {
+    let scopes = seen.get(readBranch);
+    if (scopes === undefined) {
+      scopes = new Map();
+      seen.set(readBranch, scopes);
+    }
+    let ids = scopes.get(scope);
+    if (ids === undefined) {
+      ids = new Set();
+      scopes.set(scope, ids);
+    }
+    if (ids.has(id)) return;
+    ids.add(id);
+    addresses.push({ branch: readBranch, id, scope });
+  };
+
+  for (const operation of commit.operations) {
+    switch (operation.op) {
+      case "set":
+      case "patch":
+      case "delete":
+      case "apply-op":
+      case "release-op-field":
+        add(operation.id, operation.scope);
+        break;
+      case "sqlite":
+        break;
+      default:
+        unexpectedOperation(operation);
+    }
+  }
+  for (const read of commit.reads.confirmed) {
+    add(read.id, read.scope, read.branch);
+  }
+  for (const read of commit.reads.pending) {
+    add(read.id, read.scope);
+  }
+  return addresses;
+}
+
+/**
+ * Resolves a repair address using the memory protocol's scope identity rules.
+ * Throws `ProtocolError` when the identity cannot name the required instance.
+ */
+export function resolveCommitRepairAddress(
+  address: CommitRepairAddress,
+  identity: ScopeKeyIdentity,
+): ResolvedCommitRepairAddress {
+  return { ...address, scopeKey: resolveScopeKey(address.scope, identity) };
+}
+
+/** Refuses an operation without a defined document-footprint rule. */
+function unexpectedOperation(_operation: never): never {
+  throw new ProtocolError("Unsupported operation in commit repair footprint");
+}


### PR DESCRIPTION
> **Closed as superseded:** #7217 and [merged #7610](https://github.com/commontoolsinc/labs/pull/7610) provide scoped conflict recovery and its reactive scheduler integration. The inactive server receipt/ownership implementation in this draft is retired. The [review assessment](https://github.com/commontoolsinc/labs/blob/09c10e7bc82bc842f69fe74dbba704016ad3088f/docs/history/packages/runner/scoped-conflict-recovery-review-2026-09-16.md) preserves the regression requirements and deferred watch-lifetime questions. The [original design](https://github.com/commontoolsinc/labs/blob/5603bf4b0ff329672c5a49b96181d5392183236a/docs/plans/transaction-conflict-repair.md) and [implementation](https://github.com/commontoolsinc/labs/tree/5603bf4b0ff329672c5a49b96181d5392183236a) remain available at the reviewed commit.

A rejected transaction can depend on a scoped document outside its current graph watches. The catch-up marker can arrive without that document, allowing the runtime to retry the same stale absence indefinitely.

This draft implements independent server repair delivery and defines the remaining client lifecycle. The design remains the first commit.

Implemented:
- A shared transaction footprint preserving branch and scope across writes, confirmed reads, and pending reads.
- `RepairCoverage`, with separate ownership and delivery state from graph watches and execution demand. Direct snapshots include authoritative absence/tombstone versions and reuse the query layer's verified schema closure assembly.
- Complete receipts and typed failures, composed into incremental/full/no-watch fan-out and watch replacement/addition. Shared documents are sent once per frame. Delivery bookkeeping commits only after send succeeds.
- Explicit, idempotent release independent of `seenSeq`, scheduling cleanup without another commit. Tests cover shared ownership, failed sends, changed bases, corruption, branches, scopes, and transport framing.

Activation remains off: session admission does not instantiate repair coverage, and no new capability is advertised. Server transport tests install coverage through the internal session registry. They verify that the previously unwatched user document is delivered, a fresh transaction succeeds, and cleanup creates no graph demand.

Before activation, this PR still needs negotiated admission, complete reconnect declarations, authorization lifecycle tests and resource bounds, replica-applied receipt validation, and runtime retry/cancellation ownership. Existing runtimes retain their current recovery behavior; the original runner loop is not fixed by this server slice alone.

Validation: all 614 memory tests pass (592 steps). The 28 new component/server checks also pass independently with server execution OFF and ON. Repository type checking, formatting, and lint pass; all 596 checked documentation code blocks pass. The staged implementation and acceptance matrix are in `docs/plans/transaction-conflict-repair.md`.

