### PR TITLE
Keep agent session synchronization bounded in memory

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -1692,13 +1692,16 @@ server](#clients-that-are-not-built-alongside-their-server).
 - Only one set of experimental flags is active per JavaScript context at a time.
 - In the browser the web worker is a separate JavaScript context, so its flags
   are independent of the main thread.
-- For most flags, creating a new `Runtime` overwrites the ambient config and
-  disposing it resets to the defaults. Two exceptions: `serverExecution`'s
-  enabler is an OWNED refcounted claim — acquired at construction, released
-  by that runtime's dispose (or its throwing construction) — so a co-hosted
-  runtime's dispose cannot lift another's live claim; and
-  `readerSchemaPrecedence` is construction-set only — dispose leaves it
-  standing, since serving runtimes are per-space and idle-disposed.
+- Creating a `Runtime` applies its experimental settings to their ambient
+  controls. The last runtime's disposal resets `modernCellRep` and
+  `commitPreconditions` to their defaults. Disposing one of several live
+  runtimes preserves those settings. Failed construction and disposal also
+  release ownership, and repeated disposal releases it only once.
+- `serverExecution` counts explicit enablers separately. Construction acquires
+  an enabler; disposal or failed construction releases it. The last enabler's
+  release resets the flag.
+- `readerSchemaPrecedence` is set during construction. Disposal leaves it in
+  effect.
 
 ---
 

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -1696,7 +1696,8 @@ server](#clients-that-are-not-built-alongside-their-server).
   controls. The last runtime's disposal resets `modernCellRep` and
   `commitPreconditions` to their defaults. Disposing one of several live
   runtimes preserves those settings. Failed construction and disposal also
-  release ownership, and repeated disposal releases it only once.
+  release ownership, and repeated disposal releases it only once. Failed
+  construction restores the preceding settings.
 - `serverExecution` counts explicit enablers separately. Construction acquires
   an enabler; disposal or failed construction releases it. The last enabler's
   release resets the flag.

--- a/packages/connectors/agents/connector/docs/architecture.md
+++ b/packages/connectors/agents/connector/docs/architecture.md
@@ -54,10 +54,17 @@ view for indexes and user interfaces.
 
 ### Collection and preparation
 
-`collectSource()` walks every inventory page from one driver. It then reads each
-listed session. A provider or session read error is returned in the collection
-result instead of discarding successfully read sessions. An optional owner
-signal stops work at provider call boundaries.
+`collectSource()` reads one inventory page at a time. It reads each listed
+session and writes an immutable snapshot to a private temporary spool before
+requesting the next session. The result holds a count and an asynchronous
+iterator over the spool. A provider or session read error makes the collection
+incomplete while retaining successfully collected sessions. Cancellation and
+spool failures remove the temporary files and reject the collection.
+
+The host collects sources sequentially and owns their spools until publication
+finishes. It removes them on success, cancellation, and failure. Collection runs
+outside the target's mutation queue so command receipts and targeted refreshes
+can proceed while a provider is being read.
 
 `prepareSession()` derives the stable session key, divides native events into
 chunks, computes content hashes, and computes a snapshot hash. The snapshot hash
@@ -76,6 +83,25 @@ The next publication creates a fresh scope.
 Fabric space. It stores native event chunks before the session manifest. It then
 publishes the recent and complete indexes after all changed session graphs have
 committed.
+
+The target reads snapshots from the spool one at a time. It prepares and commits
+one event chunk at a time, then writes the session manifest. The host supplies
+`createPublicationRuntime` on the Fabric connection. The target uses one fresh
+runtime for index reconciliation and a separate runtime for each changed
+session. Each runtime has its own storage manager and is disposed after its
+commits settle, releasing its document replica and storage watches.
+
+Graph reads synchronize each document with a `false` schema. Writes use the same
+document-only synchronization barrier and mark the protected cell handle as
+synchronized before applying its write policy. Explicit link traversal decides
+which child documents to read. Index reconciliation preserves manifest links.
+
+Memory use during collection is proportional to one provider snapshot and one
+inventory page. Publication holds one prepared session, one chunk's graph plan,
+and index metadata. Each provider's `readSession()` still returns a whole
+session; the full corpus is held on disk. Targeted refreshes also spool each
+completed read before waiting for publication. Independent provider reads can
+proceed concurrently, and pending publications hold spool descriptors.
 
 The target compares snapshot hashes with the previous index. It does not rewrite
 an unchanged session graph. It still refreshes source capabilities, recent
@@ -155,7 +181,8 @@ A host normally performs these steps:
    owner DID.
 4. Open `CommandLedger`, create `CommandWorker`, and call
    `recoverUnpublishedReceipts()`.
-5. Run `collectSource()` for each driver and publish all results together.
+5. Collect each driver's sessions into a temporary spool, publish all source
+   results together, and dispose the spools.
 6. Subscribe to or poll each target's command cell and pass values to
    `CommandWorker.handle()`.
 7. Publish host-defined health details when they change.

--- a/packages/connectors/agents/connector/docs/interfaces.md
+++ b/packages/connectors/agents/connector/docs/interfaces.md
@@ -110,14 +110,24 @@ refresh finishes.
 
 `collectSource(driver, signal?)` consumes `listSessions()` until `nextCursor` is
 absent. It records an inventory error for a repeated cursor. It also records an
-error before retaining a page that would raise the inventory above 100,000
-summaries. It then calls `readSession()` once for every retained summary. The
-optional signal is checked before and after every provider call. A host still
-stops the driver to interrupt a provider call that does not return on its own.
+error before reading a page that would raise the inventory above 100,000
+summaries. Each page's sessions are read and spooled before requesting the next
+page. The optional signal is checked before and after every provider call and
+after each spool write. A host still stops the driver to interrupt a provider
+call that does not return on its own.
 
-The returned `CollectedSource` contains successful snapshots and structured
-errors. Its `complete` field is true only when enumeration completed, every
-session read succeeded, and every snapshot reported itself complete.
+The returned `CollectedSource & AsyncDisposable` contains a replayable
+asynchronous `sessions` iterator with a `length`, plus structured errors. Its
+`complete` field is true only when enumeration completed, every session read
+succeeded, and every snapshot reported itself complete. Publication also accepts
+snapshot arrays for callers that already own a single session or a small batch.
+
+The spool uses the Fabric JSON codec to retain native values and sparse arrays.
+Its directory is private and its files are created with mode `0600`. Disposing
+the result removes all temporary files. The host uses an `AsyncDisposableStack`
+to own every source result through publication. Cancellation and spool I/O
+failures dispose an unfinished collection and reject instead of reporting an
+incomplete provider inventory.
 
 `prepareSession(sourceId, snapshot, targetChunkBytes?)` is available when a host
 or another target needs the connector's stable key, chunks, and hashes without
@@ -135,8 +145,15 @@ interface AgentFabricConnection {
   runtime: Runtime;
   spaceDid: MemorySpace;
   ownerDid: string;
+  createPublicationRuntime?: () => Runtime;
 }
 ```
+
+Long-lived hosts supply `createPublicationRuntime`. It creates an independent
+runtime and storage manager using the same destination, identity, and runtime
+configuration. The target disposes one runtime per changed session and one per
+index publication after their commits settle. A caller omitting the factory owns
+the supplied runtime and its retained documents.
 
 The owner DID participates in every connector cause and stored protocol
 envelope. Every connector cell has a Common Fabric confidentiality label for
@@ -362,6 +379,9 @@ connector-owned prompts. `bypassPermissions` is advertised only when
 The Codex transport uses JSON-RPC 2.0 objects separated by newlines on child
 process stdin and stdout. Request IDs are increasing integers. Notifications
 have a method and no ID. Server requests have both a method and an ID.
+
+`SessionSummary.raw` contains the thread metadata with `turns` excluded. The
+snapshot's native events contain the complete turn array.
 
 The launch modes are:
 
@@ -717,15 +737,18 @@ coordination for each API, space, and owner.
 The callback must finish synchronously and return a plain record. Causes and
 values must be accepted by the Common Fabric cell and value converters.
 
-Session graph publication batches at most ten content-addressed chunk cells per
-transaction and one manifest per transaction. Index cells are committed after
+Session graph publication prepares and commits one content-addressed event chunk
+at a time, followed by one manifest transaction. Index cells are committed after
 session graphs. Because changed chunks use new root and child cells, committing
 chunks before a manifest cannot mutate the graph reachable from the prior
 manifest.
 
-`readStableCellGraphValue()` synchronizes a root cell and recursively hydrates
-`FabricLink`s. It caches repeated links within one read and synchronizes at most
-50 array children concurrently.
+`readStableCellGraphValue()` synchronizes each document with a `false` schema
+and explicitly follows its `FabricLink`s. It caches repeated links within one
+read and synchronizes at most 50 array children concurrently. Protected graph
+writes synchronize through a `false` schema and mark their cell handles
+document-synchronized before applying write policies, so those operations keep
+their document-only read.
 
 Its optional fourth argument accepts `preserveLinkFields`. A link stored under a
 named object field in that set remains a link instead of being hydrated. The

--- a/packages/connectors/agents/connector/src/drivers/codex-app-server.ts
+++ b/packages/connectors/agents/connector/src/drivers/codex-app-server.ts
@@ -105,6 +105,7 @@ function threadSummary(
   archivedFallback: boolean | null = null,
 ): SessionSummary {
   const thread = record(value);
+  const { turns: _turns, ...metadata } = thread;
   return {
     nativeSessionId: String(thread.id ?? ""),
     title: typeof thread.name === "string"
@@ -119,7 +120,7 @@ function threadSummary(
       ? thread.archived
       : archivedFallback,
     active: threadActive(thread.status),
-    raw: { ...thread },
+    raw: metadata,
   };
 }
 

--- a/packages/connectors/agents/connector/src/fabric-graph.ts
+++ b/packages/connectors/agents/connector/src/fabric-graph.ts
@@ -4,6 +4,7 @@ import {
   type Cell,
   cfcAtom,
   type JSONSchema,
+  markCellDocumentSynced,
   type MemorySpace,
   type Runtime,
 } from "@commonfabric/runner";
@@ -15,6 +16,27 @@ export interface AgentFabricConnection {
   runtime: Runtime;
   spaceDid: MemorySpace;
   ownerDid: string;
+
+  /**
+   * Creates a runtime with an independent storage manager for a publication.
+   * The connector disposes it after its writes settle. Long-lived hosts supply
+   * this factory to release transcript documents and their storage watches.
+   */
+  createPublicationRuntime?: () => Runtime;
+}
+
+/** Opens a publication scope and owns the runtime created for it. */
+export function openPublicationConnection(
+  connection: AgentFabricConnection,
+): AgentFabricConnection & AsyncDisposable {
+  const runtime = connection.createPublicationRuntime?.();
+  return {
+    ...connection,
+    runtime: runtime ?? connection.runtime,
+    async [Symbol.asyncDispose]() {
+      await runtime?.dispose();
+    },
+  };
 }
 
 export const AGENT_CONNECTOR_WRITER_ID = "commonfabric.agents-connector";
@@ -176,8 +198,11 @@ export async function pushStableCellGraph(
     offset += HYDRATION_BATCH_SIZE
   ) {
     await Promise.all(
-      uniqueCells.slice(offset, offset + HYDRATION_BATCH_SIZE).map((cell) =>
-        cell.sync()
+      uniqueCells.slice(offset, offset + HYDRATION_BATCH_SIZE).map(
+        async (cell) => {
+          await cell.asSchema(false).sync();
+          markCellDocumentSynced(cell);
+        },
       ),
     );
   }
@@ -281,7 +306,7 @@ async function resolveStableGraphLinks(
     const pending = (async () => {
       const child = connection.runtime.getCellFromLink(
         link as Parameters<Runtime["getCellFromLink"]>[0],
-      );
+      ).asSchema(false);
       await child.sync();
       await connection.runtime.storageManager.synced();
       return await resolveStableGraphLinks(
@@ -345,11 +370,12 @@ export async function readStableCellGraphValue(
   cache: Map<string, Promise<unknown>> = new Map(),
   options: { preserveLinkFields?: ReadonlySet<string> } = {},
 ): Promise<unknown> {
-  await cell.sync();
+  const rawCell = cell.asSchema(false);
+  await rawCell.sync();
   await connection.runtime.storageManager.synced();
   return await resolveStableGraphLinks(
     connection,
-    cell.getRaw(),
+    rawCell.getRaw(),
     cache,
     options.preserveLinkFields ?? new Set(),
   );

--- a/packages/connectors/agents/connector/src/fabric.ts
+++ b/packages/connectors/agents/connector/src/fabric.ts
@@ -1,14 +1,18 @@
-import type { Cancel, Cell } from "@commonfabric/runner";
+import {
+  type Cancel,
+  type Cell,
+  markCellDocumentSynced,
+} from "@commonfabric/runner";
 import {
   AGENT_CONNECTOR_WRITER_ID,
   type AgentFabricConnection,
   agentOwnerSchema,
   agentPrincipalSchema,
   cellHasOwnerProtection,
+  openPublicationConnection,
   pushStableCellGraph,
   readStableActions,
   readStableCellGraphValue,
-  type StableCellGraphEntry,
   stableCellId,
   subscribeStableActions,
 } from "./fabric-graph.ts";
@@ -44,6 +48,7 @@ import {
   type StableArrayCellPlan,
 } from "./array-cell-identity.ts";
 import { AsyncSerialQueue } from "./serial-queue.ts";
+import { SessionSpool } from "./session-spool.ts";
 import { isAbsolute as isPosixAbsolute } from "@std/path/posix";
 import { isAbsolute as isWindowsAbsolute } from "@std/path/windows";
 
@@ -435,13 +440,12 @@ async function syncAgentFabricCells(
   conn: AgentFabricConnection,
 ): Promise<AgentFabricCells> {
   const cells = createAgentFabricCells(conn);
-  await Promise.all([
-    cells.index.sync(),
-    cells.allIndex.sync(),
-    cells.health.sync(),
-    cells.commands.sync(),
-    cells.receipts.sync(),
-  ]);
+  await Promise.all(
+    Object.values(cells).map(async (cell) => {
+      await cell.asSchema(false).sync();
+      markCellDocumentSynced(cell);
+    }),
+  );
   await conn.runtime.storageManager.synced();
   return cells;
 }
@@ -641,21 +645,14 @@ function asIndex(
   return record as unknown as AgentSessionIndex;
 }
 
-interface PlannedSessionGraph {
-  chunks: StableCellGraphEntry[];
-  manifest: StableCellGraphEntry;
-  indexEntry: IndexEntry;
-}
-
-const SESSION_GRAPH_BATCH_SIZE = 10;
-const MANIFEST_GRAPH_BATCH_SIZE = 1;
-
-async function planSessionGraph(
+/** Publishes each event chunk before publishing its session manifest. */
+async function publishSessionGraph(
   conn: AgentFabricConnection,
   prepared: PreparedSession,
   driver: string,
   gitContext: GitContext,
-): Promise<PlannedSessionGraph> {
+  onCommit: () => void,
+): Promise<IndexEntry> {
   const manifest = conn.runtime.getCell(
     conn.spaceDid,
     sessionCause(
@@ -666,7 +663,8 @@ async function planSessionGraph(
     ),
     agentOwnerSchema(conn.ownerDid),
   );
-  const chunkEntries = await Promise.all(prepared.chunks.map(async (chunk) => {
+  const descriptors = [];
+  for (const chunk of prepared.chunks) {
     const cell = conn.runtime.getCell(
       conn.spaceDid,
       sessionChunkCause(
@@ -687,26 +685,25 @@ async function planSessionGraph(
       contentHash: chunk.contentHash,
       events: chunk.events,
     };
-    return {
-      cell,
-      plan: await planStableArrayCells(
-        value,
-        childScope(conn.spaceDid, conn.ownerDid, "session-events", {
-          sourceId: prepared.sourceId,
-          nativeSessionId: prepared.nativeSessionId,
-          part: chunk.part,
-          contentHash: chunk.contentHash,
-        }),
-      ),
-      descriptor: {
+    const plan = await planStableArrayCells(
+      value,
+      childScope(conn.spaceDid, conn.ownerDid, "session-events", {
+        sourceId: prepared.sourceId,
+        nativeSessionId: prepared.nativeSessionId,
         part: chunk.part,
-        link: cell,
         contentHash: chunk.contentHash,
-        byteLength: chunk.byteLength,
-        eventCount: chunk.eventCount,
-      },
-    };
-  }));
+      }),
+    );
+    onCommit();
+    await pushStableCellGraph(conn, [graphEntry(cell, plan)]);
+    descriptors.push({
+      part: chunk.part,
+      link: cell,
+      contentHash: chunk.contentHash,
+      byteLength: chunk.byteLength,
+      eventCount: chunk.eventCount,
+    });
+  }
   const manifestValue = {
     schema: AGENT_CONNECTOR_SCHEMAS.session,
     ownerDid: conn.ownerDid,
@@ -717,7 +714,7 @@ async function planSessionGraph(
     metadata: prepared.summary.raw,
     summary: prepared.summary,
     normalized: { messages: prepared.normalizedMessages },
-    chunks: chunkEntries.map(({ descriptor }) => descriptor),
+    chunks: descriptors,
     snapshotHash: prepared.snapshotHash,
     revision: prepared.revision ?? null,
     observedAt: new Date().toISOString(),
@@ -730,62 +727,32 @@ async function planSessionGraph(
       nativeSessionId: prepared.nativeSessionId,
     }),
   );
+  onCommit();
+  await pushStableCellGraph(conn, [graphEntry(manifest, manifestPlan)]);
   return {
-    chunks: chunkEntries.map(({ cell, plan }) => graphEntry(cell, plan)),
-    manifest: graphEntry(manifest, manifestPlan),
-    indexEntry: {
-      ownerDid: conn.ownerDid,
-      key: prepared.key,
-      sourceId: prepared.sourceId,
-      driver,
-      nativeSessionId: prepared.nativeSessionId,
-      title: prepared.summary.title,
-      cwd: prepared.summary.cwd,
-      gitRepo: prepared.summary.gitRepo ?? null,
-      gitBranch: prepared.summary.gitBranch ?? null,
-      gitWorktreeRoot: prepared.summary.gitWorktreeRoot ?? null,
-      gitHeadSha: gitContext.gitHeadSha,
-      gitRemotes: gitContext.gitRemotes,
-      gitObservedAt: gitContext.gitObservedAt,
-      createdAt: prepared.summary.createdAt,
-      updatedAt: prepared.summary.updatedAt,
-      archived: prepared.summary.archived,
-      active: prepared.summary.active,
-      capabilities: {},
-      recentMessages: recentSessionMessages(prepared.normalizedMessages),
-      manifest,
-      contentHash: prepared.snapshotHash,
-      syncStatus: prepared.complete ? "complete" : "partial",
-    },
+    ownerDid: conn.ownerDid,
+    key: prepared.key,
+    sourceId: prepared.sourceId,
+    driver,
+    nativeSessionId: prepared.nativeSessionId,
+    title: prepared.summary.title,
+    cwd: prepared.summary.cwd,
+    gitRepo: prepared.summary.gitRepo ?? null,
+    gitBranch: prepared.summary.gitBranch ?? null,
+    gitWorktreeRoot: prepared.summary.gitWorktreeRoot ?? null,
+    gitHeadSha: gitContext.gitHeadSha,
+    gitRemotes: gitContext.gitRemotes,
+    gitObservedAt: gitContext.gitObservedAt,
+    createdAt: prepared.summary.createdAt,
+    updatedAt: prepared.summary.updatedAt,
+    archived: prepared.summary.archived,
+    active: prepared.summary.active,
+    capabilities: {},
+    recentMessages: recentSessionMessages(prepared.normalizedMessages),
+    manifest,
+    contentHash: prepared.snapshotHash,
+    syncStatus: prepared.complete ? "complete" : "partial",
   };
-}
-
-async function pushSessionGraphBatch(
-  conn: AgentFabricConnection,
-  graphs: PlannedSessionGraph[],
-): Promise<void> {
-  const chunks = graphs.flatMap((graph) => graph.chunks);
-  for (
-    let offset = 0;
-    offset < chunks.length;
-    offset += SESSION_GRAPH_BATCH_SIZE
-  ) {
-    await pushStableCellGraph(
-      conn,
-      chunks.slice(offset, offset + SESSION_GRAPH_BATCH_SIZE),
-    );
-  }
-  const manifests = graphs.map((graph) => graph.manifest);
-  for (
-    let offset = 0;
-    offset < manifests.length;
-    offset += MANIFEST_GRAPH_BATCH_SIZE
-  ) {
-    await pushStableCellGraph(
-      conn,
-      manifests.slice(offset, offset + MANIFEST_GRAPH_BATCH_SIZE),
-    );
-  }
 }
 
 export class AgentFabricTarget implements CommandTarget {
@@ -881,9 +848,12 @@ export class AgentFabricTarget implements CommandTarget {
     collected: CollectedSource[],
     options: AgentFabricPublishOptions & { observationSequence: number },
   ): Promise<number> {
+    await using conn = openPublicationConnection(this.conn);
+    const cells = createAgentFabricCells(conn);
     let graphCommitStarted = false;
     const startGraphCommit = () => {
       if (graphCommitStarted) return;
+      options.signal?.throwIfAborted();
       options.onCommit?.();
       graphCommitStarted = true;
     };
@@ -906,22 +876,22 @@ export class AgentFabricTarget implements CommandTarget {
     const graphReadCache = new Map<string, Promise<unknown>>();
     const previousRecent = asIndex(
       await readStableCellGraphValue(
-        this.conn,
-        this.cells.index,
+        conn,
+        cells.index,
         graphReadCache,
         { preserveLinkFields: new Set(["manifest"]) },
       ),
-      this.conn.ownerDid,
+      conn.ownerDid,
       "recent",
     );
     const previousAll = asIndex(
       await readStableCellGraphValue(
-        this.conn,
-        this.cells.allIndex,
+        conn,
+        cells.allIndex,
         graphReadCache,
         { preserveLinkFields: new Set(["manifest"]) },
       ),
-      this.conn.ownerDid,
+      conn.ownerDid,
       "all",
     );
     const discoveredCheckouts: GitContext[] = [];
@@ -955,15 +925,15 @@ export class AgentFabricTarget implements CommandTarget {
               ? entry.archived
               : null,
             active: typeof entry.active === "boolean" ? entry.active : null,
-            manifest: this.conn.runtime.getCell(
-              this.conn.spaceDid,
+            manifest: conn.runtime.getCell(
+              conn.spaceDid,
               sessionCause(
-                this.conn.spaceDid,
-                this.conn.ownerDid,
+                conn.spaceDid,
+                conn.ownerDid,
                 entry.sourceId,
                 entry.nativeSessionId,
               ),
-              agentOwnerSchema(this.conn.ownerDid),
+              agentOwnerSchema(conn.ownerDid),
             ),
           };
           return [
@@ -983,18 +953,9 @@ export class AgentFabricTarget implements CommandTarget {
         source,
       ) => [String(source.id), { ...source }]),
     );
-    let pendingGraphs: PlannedSessionGraph[] = [];
     const observedSessionKeys = new Set<string>();
     const observedCompleteSourceIds = new Set<string>();
     const observedDescriptorSourceIds = new Set<string>();
-    const flushGraphs = async () => {
-      if (pendingGraphs.length === 0) return;
-      throwIfPublicationCanStop();
-      const batch = pendingGraphs;
-      pendingGraphs = [];
-      startGraphCommit();
-      await pushSessionGraphBatch(this.conn, batch);
-    };
 
     for (const source of collected) {
       if (isSourceSuperseded(source.source.id)) continue;
@@ -1015,7 +976,7 @@ export class AgentFabricTarget implements CommandTarget {
         entry.sourceId === source.source.id
       );
       const currentKeys = new Set<string>();
-      for (const snapshot of source.sessions) {
+      for await (const snapshot of source.sessions) {
         throwIfPublicationCanStop();
         const key = sessionKey(
           source.source.id,
@@ -1083,19 +1044,19 @@ export class AgentFabricTarget implements CommandTarget {
           });
           continue;
         }
-        const graph = await planSessionGraph(
-          this.conn,
+        await using sessionConnection = openPublicationConnection(conn);
+        const entry = await publishSessionGraph(
+          sessionConnection,
           prepared,
           driver,
           context,
+          startGraphCommit,
         );
-        const entry = graph.indexEntry;
+        entry.manifest = conn.runtime.getCellFromLink(
+          entry.manifest.getAsNormalizedFullLink(),
+        );
         entry.capabilities = { ...capabilities };
         entriesByKey.set(entry.key, entry);
-        pendingGraphs.push(graph);
-        if (pendingGraphs.length >= SESSION_GRAPH_BATCH_SIZE) {
-          await flushGraphs();
-        }
       }
       for (const prior of priorForSource) {
         if (currentKeys.has(prior.key)) continue;
@@ -1147,7 +1108,6 @@ export class AgentFabricTarget implements CommandTarget {
         });
       }
     }
-    await flushGraphs();
     throwIfPublicationCanStop();
     const generatedAt = new Date().toISOString();
     const generation = Math.max(
@@ -1179,7 +1139,7 @@ export class AgentFabricTarget implements CommandTarget {
       : checkoutEntries(activeSessions, discoveredCheckouts);
     const recentIndex: AgentSessionIndex = {
       schema: AGENT_CONNECTOR_SCHEMAS.sessionIndex,
-      ownerDid: this.conn.ownerDid,
+      ownerDid: conn.ownerDid,
       bucket: "recent",
       generatedAt,
       generation,
@@ -1191,7 +1151,7 @@ export class AgentFabricTarget implements CommandTarget {
     };
     const allIndex: AgentSessionIndex = {
       schema: AGENT_CONNECTOR_SCHEMAS.sessionIndex,
-      ownerDid: this.conn.ownerDid,
+      ownerDid: conn.ownerDid,
       bucket: "all",
       generatedAt,
       generation,
@@ -1202,8 +1162,8 @@ export class AgentFabricTarget implements CommandTarget {
       sessions: allSessions,
     };
     const indexChildScope = childScope(
-      this.conn.spaceDid,
-      this.conn.ownerDid,
+      conn.spaceDid,
+      conn.ownerDid,
       "session-index",
     );
     const [recentIndexPlan, allIndexPlan] = await Promise.all([
@@ -1213,10 +1173,10 @@ export class AgentFabricTarget implements CommandTarget {
     throwIfPublicationCanStop();
     startGraphCommit();
     await pushStableCellGraph(
-      this.conn,
+      conn,
       [
-        graphEntry(this.cells.index, recentIndexPlan),
-        graphEntry(this.cells.allIndex, allIndexPlan),
+        graphEntry(cells.index, recentIndexPlan),
+        graphEntry(cells.allIndex, allIndexPlan),
       ],
     );
     for (const key of observedSessionKeys) {
@@ -1516,14 +1476,10 @@ export class AgentFabricTarget implements CommandTarget {
     nativeSessionId: string,
   ): Promise<void> {
     const observationSequence = this.beginSessionObservation();
-    const snapshot = await driver.readSession(nativeSessionId);
+    await using sessions = await SessionSpool.create();
+    await sessions.append(await driver.readSession(nativeSessionId));
     await this.publish(
-      [{
-        source: driver.source,
-        sessions: [snapshot],
-        errors: [],
-        complete: false,
-      }],
+      [{ source: driver.source, sessions, errors: [], complete: false }],
       { preserveUntouchedStatus: true, observationSequence },
     );
   }

--- a/packages/connectors/agents/connector/src/reconcile.ts
+++ b/packages/connectors/agents/connector/src/reconcile.ts
@@ -1,4 +1,5 @@
 import { chunkEvents } from "./chunking.ts";
+import { SessionSpool } from "./session-spool.ts";
 import { hashStableArrayValue } from "./array-cell-identity.ts";
 import { stableFabricValue } from "./stable-fabric-value.ts";
 import { sessionKey } from "./session-contract.ts";
@@ -8,9 +9,16 @@ import type {
   SourceDescriptor,
 } from "./types.ts";
 
+/** A replayable sequence whose snapshots are read on demand. */
+export interface CollectedSessions
+  extends AsyncIterable<NativeSessionSnapshot> {
+  /** Number of successfully collected snapshots. */
+  readonly length: number;
+}
+
 export interface CollectedSource {
   source: SourceDescriptor;
-  sessions: NativeSessionSnapshot[];
+  sessions: readonly NativeSessionSnapshot[] | CollectedSessions;
   errors: Array<{ nativeSessionId?: string; message: string }>;
   complete: boolean;
 }
@@ -37,69 +45,83 @@ export interface PreparedSession {
 
 const MAX_SESSION_SUMMARIES = 100_000;
 
+/**
+ * Collects one inventory page at a time and spools each successful snapshot to
+ * disk. The caller disposes the result after publication. Provider failures
+ * produce an incomplete inventory; spool failures and cancellation reject.
+ */
 export async function collectSource(
   driver: AgentDriver,
   signal?: AbortSignal,
-): Promise<CollectedSource> {
+): Promise<CollectedSource & AsyncDisposable> {
   signal?.throwIfAborted();
-  const summaries = [];
-  const errors: CollectedSource["errors"] = [];
-  const seenCursors = new Set<string>();
-  let cursor: string | undefined;
-  let enumerationComplete = false;
+  const sessions = await SessionSpool.create();
   try {
+    const errors: CollectedSource["errors"] = [];
+    const seenCursors = new Set<string>();
+    let cursor: string | undefined;
+    let summaryCount = 0;
+    let complete = true;
     while (true) {
-      if (cursor && seenCursors.has(cursor)) {
-        throw new Error(`repeated session cursor: ${cursor}`);
-      }
-      if (cursor) seenCursors.add(cursor);
-      signal?.throwIfAborted();
-      const page = await driver.listSessions(cursor);
-      signal?.throwIfAborted();
-      if (page.sessions.length > MAX_SESSION_SUMMARIES - summaries.length) {
-        throw new Error("session enumeration exceeded safety limit");
-      }
-      summaries.push(...page.sessions);
-      if (!page.nextCursor) {
-        enumerationComplete = true;
+      let page;
+      try {
+        if (cursor && seenCursors.has(cursor)) {
+          throw new Error(`repeated session cursor: ${cursor}`);
+        }
+        if (cursor) seenCursors.add(cursor);
+        signal?.throwIfAborted();
+        page = await driver.listSessions(cursor);
+        signal?.throwIfAborted();
+        if (page.sessions.length > MAX_SESSION_SUMMARIES - summaryCount) {
+          throw new Error("session enumeration exceeded safety limit");
+        }
+        summaryCount += page.sessions.length;
+      } catch (error) {
+        signal?.throwIfAborted();
+        errors.push({ message: String(error) });
+        complete = false;
         break;
       }
+      for (const summary of page.sessions) {
+        let snapshot: NativeSessionSnapshot;
+        try {
+          signal?.throwIfAborted();
+          snapshot = await driver.readSession(summary.nativeSessionId);
+          signal?.throwIfAborted();
+        } catch (error) {
+          signal?.throwIfAborted();
+          errors.push({
+            nativeSessionId: summary.nativeSessionId,
+            message: String(error),
+          });
+          complete = false;
+          continue;
+        }
+        await sessions.append({
+          ...snapshot,
+          summary: {
+            ...snapshot.summary,
+            archived: snapshot.summary.archived ?? summary.archived,
+            active: snapshot.summary.active ?? summary.active,
+          },
+        });
+        complete &&= snapshot.complete;
+        signal?.throwIfAborted();
+      }
+      if (!page.nextCursor) break;
       cursor = page.nextCursor;
     }
+    return {
+      source: driver.source,
+      sessions,
+      errors,
+      complete,
+      [Symbol.asyncDispose]: () => sessions[Symbol.asyncDispose](),
+    };
   } catch (error) {
-    signal?.throwIfAborted();
-    errors.push({ message: String(error) });
+    await sessions[Symbol.asyncDispose]();
+    throw error;
   }
-
-  const sessions: NativeSessionSnapshot[] = [];
-  for (const summary of summaries) {
-    try {
-      signal?.throwIfAborted();
-      const snapshot = await driver.readSession(summary.nativeSessionId);
-      sessions.push({
-        ...snapshot,
-        summary: {
-          ...snapshot.summary,
-          archived: snapshot.summary.archived ?? summary.archived,
-          active: snapshot.summary.active ?? summary.active,
-        },
-      });
-      signal?.throwIfAborted();
-    } catch (error) {
-      signal?.throwIfAborted();
-      errors.push({
-        nativeSessionId: summary.nativeSessionId,
-        message: String(error),
-      });
-    }
-  }
-  return {
-    source: driver.source,
-    sessions,
-    errors,
-    complete: enumerationComplete && errors.length === 0 &&
-      sessions.every((session) => session.complete),
-  };
 }
 
 export async function prepareSession(
@@ -116,13 +138,14 @@ export async function prepareSession(
   ) as unknown as NativeSessionSnapshot["normalizedMessages"];
   const complete = snapshot.complete;
   const revision = snapshot.revision;
-  const chunks = await Promise.all(
-    chunkEvents(events, targetChunkBytes).map(async (chunk) => ({
+  const chunks: PreparedSessionChunk[] = [];
+  for (const chunk of chunkEvents(events, targetChunkBytes)) {
+    chunks.push({
       ...chunk,
       eventCount: chunk.events.length,
       contentHash: await hashStableArrayValue(chunk.events),
-    })),
-  );
+    });
+  }
   const base = {
     key: sessionKey(sourceId, summary.nativeSessionId),
     sourceId,

--- a/packages/connectors/agents/connector/src/session-spool.ts
+++ b/packages/connectors/agents/connector/src/session-spool.ts
@@ -1,0 +1,53 @@
+import { newDefaultJsonCodecEngine } from "@commonfabric/data-model/codecs";
+import { stableFabricValue } from "./stable-fabric-value.ts";
+import type { NativeSessionSnapshot } from "./types.ts";
+
+/**
+ * Stores collected snapshots in a private temporary directory. Iteration reads
+ * one snapshot at a time. Disposal removes the directory and its contents.
+ */
+export class SessionSpool
+  implements AsyncIterable<NativeSessionSnapshot>, AsyncDisposable {
+  readonly #directory: string;
+  readonly #codec = newDefaultJsonCodecEngine();
+  #length = 0;
+
+  /** Constructs an instance backed by `directory`. */
+  private constructor(directory: string) {
+    this.#directory = directory;
+  }
+
+  /** Number of snapshots successfully written. */
+  get length(): number {
+    return this.#length;
+  }
+
+  /** Writes an immutable copy of `snapshot` before accepting another. */
+  async append(snapshot: NativeSessionSnapshot): Promise<void> {
+    await Deno.writeTextFile(
+      `${this.#directory}/${this.#length}.json`,
+      this.#codec.encode(stableFabricValue(snapshot)),
+      { createNew: true, mode: 0o600 },
+    );
+    this.#length++;
+  }
+
+  /** Reads snapshots in collection order, with no read ahead. */
+  async *[Symbol.asyncIterator](): AsyncGenerator<NativeSessionSnapshot> {
+    for (let index = 0; index < this.#length; index++) {
+      yield this.#codec.decode(
+        await Deno.readTextFile(`${this.#directory}/${index}.json`),
+      ) as unknown as NativeSessionSnapshot;
+    }
+  }
+
+  /** Removes every snapshot, including an incomplete write. */
+  async [Symbol.asyncDispose](): Promise<void> {
+    await Deno.remove(this.#directory, { recursive: true });
+  }
+
+  /** Opens an empty spool in a newly created private temporary directory. */
+  static async create(): Promise<SessionSpool> {
+    return new SessionSpool(await Deno.makeTempDir({ prefix: "agents-sync-" }));
+  }
+}

--- a/packages/connectors/agents/connector/test/collection-memory.test.ts
+++ b/packages/connectors/agents/connector/test/collection-memory.test.ts
@@ -1,0 +1,108 @@
+/** Exercises collection in a separate process with a constrained V8 heap. */
+
+import { expect } from "@std/expect";
+import { fromFileUrl } from "@std/path";
+import { describe, it } from "@std/testing/bdd";
+
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
+
+import { collectSource } from "../src/reconcile.ts";
+import type { AgentDriver, SessionSummary } from "../src/types.ts";
+
+const sessionCount = 96;
+const transcriptBytes = 4 * 1024 * 1024;
+
+/** Collects and reads a corpus whose transcripts exceed the child's heap. */
+async function exerciseCollection(): Promise<void> {
+  const summary = (id: string): SessionSummary => ({
+    nativeSessionId: id,
+    title: id,
+    cwd: null,
+    createdAt: null,
+    updatedAt: null,
+    archived: false,
+    active: false,
+    raw: { id },
+  });
+  const driver: AgentDriver = {
+    source: {
+      id: "test:memory",
+      driver: "acp",
+      capabilities: {
+        inventory: true,
+        read: true,
+        prompt: false,
+        cancel: false,
+        rename: false,
+        setMode: false,
+        setConfigOption: false,
+      },
+    },
+    start: () => Promise.resolve(),
+    stop: () => Promise.resolve(),
+    listSessions: (cursor) => {
+      const index = Number(cursor ?? 0);
+      return Promise.resolve({
+        sessions: [summary(String(index))],
+        nextCursor: index + 1 < sessionCount ? String(index + 1) : undefined,
+      });
+    },
+    readSession: (id) =>
+      Promise.resolve({
+        summary: summary(id),
+        events: [new TextDecoder().decode(
+          new Uint8Array(transcriptBytes).fill(Number(id) + 32),
+        )],
+        normalizedMessages: [],
+        complete: true,
+      }),
+    prompt: () => Promise.resolve({ status: "unsupported" }),
+    cancel: () => Promise.resolve({ status: "unsupported" }),
+    renameSession: () => Promise.resolve({ status: "unsupported" }),
+    setMode: () => Promise.resolve({ status: "unsupported" }),
+    setConfigOption: () => Promise.resolve({ status: "unsupported" }),
+  };
+  await using collected = await collectSource(driver);
+  expect(collected.complete).toBe(true);
+  expect(collected.sessions.length).toBe(sessionCount);
+  let index = 0;
+  for await (const snapshot of collected.sessions) {
+    expect(snapshot.summary.nativeSessionId).toBe(String(index));
+    const transcript = snapshot.events[0] as string;
+    expect(transcript.length).toBe(transcriptBytes);
+    expect(transcript.charCodeAt(0)).toBe(index + 32);
+    expect(transcript.charCodeAt(transcript.length - 1)).toBe(index + 32);
+    index++;
+  }
+  expect(index).toBe(sessionCount);
+  console.log(`Read ${index * transcriptBytes} transcript bytes`);
+}
+
+if (import.meta.main) {
+  await exerciseCollection();
+} else {
+  describe("collection memory", () => {
+    it("collects and replays 384 MiB of transcripts with a 192 MiB heap", async () => {
+      const result = await runDenoCommandWithTemporaryLock({
+        root: fromFileUrl(new URL("../../../../../", import.meta.url)),
+        args: (lock) => [
+          "run",
+          "--frozen=true",
+          "--lock",
+          lock,
+          "--allow-env",
+          "--allow-read",
+          "--allow-write",
+          "--v8-flags=--max-old-space-size=192",
+          fromFileUrl(import.meta.url),
+        ],
+      });
+      expect(result.success, new TextDecoder().decode(result.stderr)).toBe(
+        true,
+      );
+      expect(new TextDecoder().decode(result.stdout)).toContain(
+        `Read ${sessionCount * transcriptBytes} transcript bytes`,
+      );
+    });
+  });
+}

--- a/packages/connectors/agents/connector/test/drivers/codex-app-server_test.ts
+++ b/packages/connectors/agents/connector/test/drivers/codex-app-server_test.ts
@@ -509,6 +509,8 @@ Deno.test("Codex driver enumerates persisted active and archived threads", async
     assertEquals(snapshot.complete, true);
     assertEquals(snapshot.summary.active, true);
     assertEquals(snapshot.events.length, 2);
+    assertEquals(Object.hasOwn(snapshot.summary.raw, "turns"), false);
+    assertEquals(snapshot.summary.raw.id, "thread-1");
     assertEquals(snapshot.normalizedMessages[0].textPreview, "hello");
     assertEquals(
       snapshot.normalizedMessages.map((message) => message.rawIndex),

--- a/packages/connectors/agents/connector/test/fabric-graph_test.ts
+++ b/packages/connectors/agents/connector/test/fabric-graph_test.ts
@@ -472,8 +472,13 @@ Deno.test("stable graph field writes preserve document metadata", async () => {
   }
 });
 
-function fakeCell(id = "of:parent") {
-  const cell = {
+async function fakeCell(id = "of:parent") {
+  const identity = await Identity.fromPassphrase("stable graph write fixture");
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: StorageManager.emulate({ as: identity }),
+  });
+  const cell = Object.assign(runtime.getCell(identity.did(), { id }), {
     getAsNormalizedFullLink: () => ({
       space: "did:test:space",
       id,
@@ -484,8 +489,8 @@ function fakeCell(id = "of:parent") {
     asSchema: () => cell,
     setRawUntyped: () => {},
     applyCfcSchemaToExistingValue: () => {},
-  };
-  return cell;
+  });
+  return { cell, [Symbol.asyncDispose]: () => runtime.dispose() };
 }
 
 Deno.test("stable graph hydrates the owner-schema cell before writing", async () => {
@@ -499,8 +504,13 @@ Deno.test("stable graph hydrates the owner-schema cell before writing", async ()
     id: "of:parent",
     path: [],
   };
-  const protectedCell = {
+  await using fixture = await fakeCell();
+  const protectedCell = Object.assign(fixture.cell, {
     getAsNormalizedFullLink: () => link,
+    asSchema: (schema: unknown) => {
+      assertEquals(schema, false);
+      return protectedCell;
+    },
     sync: () => {
       syncs++;
       hydrated = true;
@@ -512,7 +522,7 @@ Deno.test("stable graph hydrates the owner-schema cell before writing", async ()
       writes++;
     },
     applyCfcSchemaToExistingValue: () => assertEquals(hydrated, true),
-  };
+  });
   const makeCell = () => ({
     getAsNormalizedFullLink: () => link,
     asSchema: () => {
@@ -558,6 +568,7 @@ Deno.test("stable graph hydrates the owner-schema cell before writing", async ()
 });
 
 Deno.test("stable graph writes await one commit", async () => {
+  await using fixture = await fakeCell();
   const commitStarted = Promise.withResolvers<void>();
   const commitResult = Promise.withResolvers<{
     ok: Record<string, never>;
@@ -589,7 +600,7 @@ Deno.test("stable graph writes await one commit", async () => {
     connection as any,
     [{
       // deno-lint-ignore no-explicit-any -- focused cell fixture.
-      cell: fakeCell() as any,
+      cell: fixture.cell as any,
       value: () => ({ value: "ready" }),
     }],
   ).finally(() => settled = true);
@@ -602,6 +613,7 @@ Deno.test("stable graph writes await one commit", async () => {
 });
 
 Deno.test("stable graph writes surface a commit failure without retrying", async () => {
+  await using fixture = await fakeCell();
   const commitError = {
     name: "ConflictError",
     message: "commit rejected",
@@ -633,7 +645,7 @@ Deno.test("stable graph writes surface a commit failure without retrying", async
         connection as any,
         [{
           // deno-lint-ignore no-explicit-any -- focused cell fixture.
-          cell: fakeCell() as any,
+          cell: fixture.cell as any,
           value: () => ({ value: "ready" }),
         }],
       ),
@@ -656,12 +668,20 @@ Deno.test("stable graph hydration bounds concurrent child syncs", async () => {
     (_, index) => linkRefFrom({ id: `of:child-${index}`, path: [], space }),
   );
   const parent = {
+    asSchema: (schema: unknown) => {
+      assertEquals(schema, false);
+      return parent;
+    },
     sync: () => Promise.resolve(),
     getRaw: () => links,
   };
   const runtime = {
     storageManager: { synced: () => Promise.resolve() },
     getCellFromLink: (link: { id: string }) => ({
+      asSchema(schema: unknown) {
+        assertEquals(schema, false);
+        return this;
+      },
       async sync() {
         started++;
         active++;

--- a/packages/connectors/agents/connector/test/publication-lifetime.test.ts
+++ b/packages/connectors/agents/connector/test/publication-lifetime.test.ts
@@ -1,0 +1,222 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { Identity } from "@commonfabric/identity";
+import { getModernCellRepConfig } from "@commonfabric/data-model/cell-rep";
+import { getCommitPreconditionsConfig } from "@commonfabric/memory/v2";
+import { Runtime } from "@commonfabric/runner";
+import {
+  EmulatedStorageManager,
+  newLoopbackServer,
+} from "@commonfabric/runner/storage/cache.deno";
+
+import { AgentFabricTarget } from "../src/fabric.ts";
+import { readStableCellGraphValue } from "../src/fabric-graph.ts";
+import { sessionCause } from "../src/session-contract.ts";
+import type {
+  AgentDriver,
+  NativeSessionSnapshot,
+  SourceDescriptor,
+} from "../src/types.ts";
+
+describe("publication lifetime", () => {
+  const source: SourceDescriptor = {
+    id: "test:publication",
+    driver: "acp",
+    capabilities: {
+      inventory: true,
+      read: true,
+      prompt: false,
+      cancel: false,
+      rename: false,
+      setMode: false,
+      setConfigOption: false,
+    },
+  };
+  const snapshot = (id: string): NativeSessionSnapshot => ({
+    summary: {
+      nativeSessionId: id,
+      title: id,
+      cwd: null,
+      createdAt: null,
+      updatedAt: null,
+      archived: false,
+      active: false,
+      raw: { id },
+    },
+    events: [{ id, content: "transcript" }],
+    normalizedMessages: [],
+    complete: true,
+  });
+
+  it("releases session runtimes before reading the next snapshot and leaves transcripts out of the host runtime", async () => {
+    const identity = await Identity.fromPassphrase("publication lifetime");
+    const spaceDid = identity.did();
+    const server = newLoopbackServer();
+    let opened = 0;
+    let closed = 0;
+    const createRuntime = () =>
+      new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: EmulatedStorageManager.connectTo(server, {
+          as: identity,
+        }),
+        experimental: { modernCellRep: true, commitPreconditions: false },
+      });
+    const runtime = createRuntime();
+    const connection = {
+      runtime,
+      spaceDid,
+      ownerDid: spaceDid,
+      createPublicationRuntime: () => {
+        opened++;
+        const publication = createRuntime();
+        const dispose = publication.dispose.bind(publication);
+        publication.dispose = async () => {
+          await dispose();
+          closed++;
+        };
+        return publication;
+      },
+    };
+    try {
+      const target = await AgentFabricTarget.open(connection);
+      const sessions = {
+        length: 2,
+        async *[Symbol.asyncIterator]() {
+          expect(opened - closed).toBe(1);
+          yield snapshot("one");
+          expect(opened).toBe(2);
+          expect(closed).toBe(1);
+          expect(getModernCellRepConfig()).toBe(true);
+          expect(getCommitPreconditionsConfig()).toBe(false);
+          yield snapshot("two");
+          expect(opened).toBe(3);
+          expect(closed).toBe(2);
+        },
+      };
+      expect(
+        await target.publish([{
+          source,
+          sessions,
+          errors: [],
+          complete: true,
+        }]),
+      ).toBe(2);
+      expect(opened).toBe(3);
+      expect(closed).toBe(opened);
+      for (const id of ["one", "two"]) {
+        const manifest = runtime.getCell(
+          spaceDid,
+          sessionCause(spaceDid, spaceDid, source.id, id),
+        );
+        expect(
+          runtime.readTx().readValueOrThrow(manifest.getAsNormalizedFullLink()),
+        ).toBeUndefined();
+      }
+      const index = await readStableCellGraphValue(
+        connection,
+        target.cells.allIndex,
+        undefined,
+        { preserveLinkFields: new Set(["manifest"]) },
+      ) as { sessions: Array<{ nativeSessionId: string }> };
+      expect(index.sessions.map((entry) => entry.nativeSessionId)).toEqual([
+        "one",
+        "two",
+      ]);
+      const manifest = runtime.getCell(
+        spaceDid,
+        sessionCause(spaceDid, spaceDid, source.id, "one"),
+      );
+      expect(
+        runtime.readTx().readValueOrThrow(manifest.getAsNormalizedFullLink()),
+      ).toBeUndefined();
+      const stored = await readStableCellGraphValue(connection, manifest) as {
+        chunks: Array<{ link: { events: unknown[] } }>;
+      };
+      expect(stored.chunks[0].link.events).toEqual([
+        { id: "one", content: "transcript" },
+      ]);
+
+      const previousOpened = opened;
+      expect(
+        await target.publish([{
+          source,
+          sessions: [snapshot("one"), snapshot("two")],
+          errors: [],
+          complete: true,
+        }]),
+      ).toBe(2);
+      expect(opened).toBe(previousOpened + 1);
+      expect(closed).toBe(opened);
+
+      await expect(target.publish([{
+        source,
+        sessions: {
+          length: 1,
+          [Symbol.asyncIterator]() {
+            throw new Error("spool read failed");
+          },
+        },
+        errors: [],
+        complete: true,
+      }])).rejects.toThrow("spool read failed");
+      expect(closed).toBe(opened);
+    } finally {
+      await runtime.dispose();
+      await server.close();
+      expect(getModernCellRepConfig()).toBe(false);
+      expect(getCommitPreconditionsConfig()).toBe(true);
+    }
+  });
+
+  it("publishes an independent refresh while another session read is pending", async () => {
+    const identity = await Identity.fromPassphrase("queued refresh reads");
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: EmulatedStorageManager.emulate({ as: identity }),
+    });
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const reads: string[] = [];
+    const driver = {
+      source,
+      async readSession(id: string) {
+        reads.push(id);
+        if (id === "one") {
+          entered.resolve();
+          await release.promise;
+        }
+        return snapshot(id);
+      },
+    } as AgentDriver;
+    try {
+      const target = await AgentFabricTarget.open({
+        runtime,
+        ownerDid: identity.did(),
+        spaceDid: identity.did(),
+      });
+      const first = target.refreshSession(driver, "one");
+      await entered.promise;
+      try {
+        await target.refreshSession(driver, "two");
+        expect(reads).toEqual(["one", "two"]);
+        const index = await readStableCellGraphValue(
+          target.conn,
+          target.cells.allIndex,
+          undefined,
+          { preserveLinkFields: new Set(["manifest"]) },
+        ) as { sessions: Array<{ nativeSessionId: string }> };
+        expect(index.sessions.map((entry) => entry.nativeSessionId)).toEqual([
+          "two",
+        ]);
+      } finally {
+        release.resolve();
+        await first;
+      }
+      expect(reads).toEqual(["one", "two"]);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+});

--- a/packages/connectors/agents/connector/test/reconcile_test.ts
+++ b/packages/connectors/agents/connector/test/reconcile_test.ts
@@ -1,4 +1,7 @@
 import { assertEquals } from "@std/assert";
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { stub } from "@std/testing/mock";
 import { collectSource, prepareSession } from "../src/reconcile.ts";
 import type {
   AgentDriver,
@@ -6,132 +9,233 @@ import type {
   SessionPage,
 } from "../src/types.ts";
 
-function fakeDriver(): AgentDriver {
-  const summaries = ["one", "two"].map((id) => ({
-    nativeSessionId: id,
-    title: id,
-    cwd: null,
-    createdAt: null,
-    updatedAt: null,
-    archived: false,
-    active: false,
-    raw: { id },
-  }));
-  return {
-    source: {
-      id: "fake:default",
-      driver: "acp",
-      capabilities: {
-        inventory: true,
-        read: true,
-        prompt: false,
-        cancel: false,
-        rename: false,
-        setMode: false,
-        setConfigOption: false,
-      },
-    },
-    start: () => Promise.resolve(),
-    stop: () => Promise.resolve(),
-    listSessions: (cursor?: string): Promise<SessionPage> =>
-      Promise.resolve(
-        cursor
-          ? { sessions: [summaries[1]] }
-          : { sessions: [summaries[0]], nextCursor: "next" },
-      ),
-    readSession: (id: string): Promise<NativeSessionSnapshot> =>
-      Promise.resolve({
-        summary: summaries.find((summary) => summary.nativeSessionId === id)!,
-        events: [{ id: `${id}-message`, text: "hello" }],
-        normalizedMessages: [],
-        complete: true,
-      }),
-    prompt: () => Promise.resolve({ status: "unsupported" }),
-    cancel: () => Promise.resolve({ status: "unsupported" }),
-    renameSession: () => Promise.resolve({ status: "unsupported" }),
-    setMode: () => Promise.resolve({ status: "unsupported" }),
-    setConfigOption: () => Promise.resolve({ status: "unsupported" }),
-  };
-}
-
-Deno.test("collectSource consumes every page and prepares stable session snapshots", async () => {
-  const collected = await collectSource(fakeDriver());
-  assertEquals(collected.complete, true);
-  assertEquals(
-    collected.sessions.map((session) => session.summary.nativeSessionId),
-    ["one", "two"],
-  );
-
-  const first = await prepareSession("fake:default", collected.sessions[0], 64);
-  const again = await prepareSession("fake:default", collected.sessions[0], 64);
-  assertEquals(first, again);
-  assertEquals(first.key, "fake%3Adefault/one");
-  assertEquals(first.chunks[0].events, [{ id: "one-message", text: "hello" }]);
-  assertEquals(first.snapshotHash.startsWith("sha256:"), true);
-});
-
-Deno.test("collectSource retains lifecycle state reported only by inventory", async () => {
-  const inventorySummary = {
-    nativeSessionId: "one",
-    title: "one",
-    cwd: null,
-    createdAt: null,
-    updatedAt: null,
-    archived: true,
-    active: false,
-    raw: { id: "one", archived: true },
-  };
-  const driver: AgentDriver = {
-    ...fakeDriver(),
-    listSessions: () => Promise.resolve({ sessions: [inventorySummary] }),
-    readSession: () =>
-      Promise.resolve({
-        summary: {
-          ...inventorySummary,
-          archived: null,
-          active: null,
-          raw: { id: "one" },
+describe("reconcile", () => {
+  function fakeDriver(): AgentDriver {
+    const summaries = ["one", "two"].map((id) => ({
+      nativeSessionId: id,
+      title: id,
+      cwd: null,
+      createdAt: null,
+      updatedAt: null,
+      archived: false,
+      active: false,
+      raw: { id },
+    }));
+    return {
+      source: {
+        id: "fake:default",
+        driver: "acp",
+        capabilities: {
+          inventory: true,
+          read: true,
+          prompt: false,
+          cancel: false,
+          rename: false,
+          setMode: false,
+          setConfigOption: false,
         },
-        events: [],
-        normalizedMessages: [],
-        complete: true,
-      }),
-  };
+      },
+      start: () => Promise.resolve(),
+      stop: () => Promise.resolve(),
+      listSessions: (cursor?: string): Promise<SessionPage> =>
+        Promise.resolve(
+          cursor
+            ? { sessions: [summaries[1]] }
+            : { sessions: [summaries[0]], nextCursor: "next" },
+        ),
+      readSession: (id: string): Promise<NativeSessionSnapshot> =>
+        Promise.resolve({
+          summary: summaries.find((summary) => summary.nativeSessionId === id)!,
+          events: [{ id: `${id}-message`, text: "hello" }],
+          normalizedMessages: [],
+          complete: true,
+        }),
+      prompt: () => Promise.resolve({ status: "unsupported" }),
+      cancel: () => Promise.resolve({ status: "unsupported" }),
+      renameSession: () => Promise.resolve({ status: "unsupported" }),
+      setMode: () => Promise.resolve({ status: "unsupported" }),
+      setConfigOption: () => Promise.resolve({ status: "unsupported" }),
+    };
+  }
 
-  const collected = await collectSource(driver);
+  it("consumes every page and prepares stable session snapshots", async () => {
+    await using collected = await collectSource(fakeDriver());
+    const sessions = await Array.fromAsync(collected.sessions);
+    assertEquals(collected.complete, true);
+    assertEquals(
+      sessions.map((session) => session.summary.nativeSessionId),
+      ["one", "two"],
+    );
 
-  assertEquals(collected.sessions[0].summary.archived, true);
-  assertEquals(collected.sessions[0].summary.active, false);
-});
+    const first = await prepareSession("fake:default", sessions[0], 64);
+    const again = await prepareSession("fake:default", sessions[0], 64);
+    assertEquals(first, again);
+    assertEquals(first.key, "fake%3Adefault/one");
+    assertEquals(first.chunks[0].events, [{
+      id: "one-message",
+      text: "hello",
+    }]);
+    assertEquals(first.snapshotHash.startsWith("sha256:"), true);
+  });
 
-Deno.test("collectSource rejects an oversized terminal inventory page", async () => {
-  const summary = {
-    nativeSessionId: "one",
-    title: "one",
-    cwd: null,
-    createdAt: null,
-    updatedAt: null,
-    archived: false,
-    active: false,
-    raw: { id: "one" },
-  };
-  let readCalls = 0;
-  const driver: AgentDriver = {
-    ...fakeDriver(),
-    listSessions: () =>
-      Promise.resolve({ sessions: Array(100_001).fill(summary) }),
-    readSession: () => {
-      readCalls++;
-      return Promise.reject(new Error("oversized inventory was read"));
-    },
-  };
+  it("retains lifecycle state reported only by inventory", async () => {
+    const inventorySummary = {
+      nativeSessionId: "one",
+      title: "one",
+      cwd: null,
+      createdAt: null,
+      updatedAt: null,
+      archived: true,
+      active: false,
+      raw: { id: "one", archived: true },
+    };
+    const driver: AgentDriver = {
+      ...fakeDriver(),
+      listSessions: () => Promise.resolve({ sessions: [inventorySummary] }),
+      readSession: () =>
+        Promise.resolve({
+          summary: {
+            ...inventorySummary,
+            archived: null,
+            active: null,
+            raw: { id: "one" },
+          },
+          events: [],
+          normalizedMessages: [],
+          complete: true,
+        }),
+    };
 
-  const collected = await collectSource(driver);
+    await using collected = await collectSource(driver);
 
-  assertEquals(collected.complete, false);
-  assertEquals(collected.sessions, []);
-  assertEquals(collected.errors, [{
-    message: "Error: session enumeration exceeded safety limit",
-  }]);
-  assertEquals(readCalls, 0);
+    const sessions = await Array.fromAsync(collected.sessions);
+    assertEquals(sessions[0].summary.archived, true);
+    assertEquals(sessions[0].summary.active, false);
+  });
+
+  it("rejects an oversized terminal inventory page", async () => {
+    const summary = {
+      nativeSessionId: "one",
+      title: "one",
+      cwd: null,
+      createdAt: null,
+      updatedAt: null,
+      archived: false,
+      active: false,
+      raw: { id: "one" },
+    };
+    let readCalls = 0;
+    const driver: AgentDriver = {
+      ...fakeDriver(),
+      listSessions: () =>
+        Promise.resolve({ sessions: Array(100_001).fill(summary) }),
+      readSession: () => {
+        readCalls++;
+        return Promise.reject(new Error("oversized inventory was read"));
+      },
+    };
+
+    await using collected = await collectSource(driver);
+
+    assertEquals(collected.complete, false);
+    assertEquals(await Array.fromAsync(collected.sessions), []);
+    assertEquals(collected.errors, [{
+      message: "Error: session enumeration exceeded safety limit",
+    }]);
+    assertEquals(readCalls, 0);
+  });
+
+  it("reads each inventory page before requesting the next page", async () => {
+    const driver = fakeDriver();
+    const calls: string[] = [];
+    const list = driver.listSessions;
+    const read = driver.readSession;
+    driver.listSessions = (cursor) => {
+      calls.push(`list:${cursor ?? "first"}`);
+      return list(cursor);
+    };
+    driver.readSession = (id) => {
+      calls.push(`read:${id}`);
+      return read(id);
+    };
+    await using collected = await collectSource(driver);
+    expect(calls).toEqual(["list:first", "read:one", "list:next", "read:two"]);
+    expect(collected.complete).toBe(true);
+  });
+
+  it("retains successful reads and reports failed session reads", async () => {
+    const driver = fakeDriver();
+    const read = driver.readSession;
+    driver.readSession = (id) =>
+      id === "one"
+        ? Promise.reject(new Error("session unavailable"))
+        : read(id);
+    await using collected = await collectSource(driver);
+    expect(collected.complete).toBe(false);
+    expect(collected.errors).toEqual([{
+      nativeSessionId: "one",
+      message: "Error: session unavailable",
+    }]);
+    const sessions = await Array.fromAsync(collected.sessions);
+    expect(sessions.map((value) => value.summary.nativeSessionId)).toEqual([
+      "two",
+    ]);
+  });
+
+  it("retains collected sessions after an inventory failure", async () => {
+    const driver = fakeDriver();
+    const list = driver.listSessions;
+    driver.listSessions = (cursor) =>
+      cursor ? Promise.reject(new Error("inventory unavailable")) : list();
+    await using collected = await collectSource(driver);
+    expect(collected.complete).toBe(false);
+    expect(collected.sessions.length).toBe(1);
+    expect(collected.errors).toEqual([{
+      message: "Error: inventory unavailable",
+    }]);
+  });
+
+  it("reports a repeated cursor after empty inventory pages", async () => {
+    const driver = fakeDriver();
+    driver.listSessions = () =>
+      Promise.resolve({ sessions: [], nextCursor: "again" });
+    await using collected = await collectSource(driver);
+    expect(collected.complete).toBe(false);
+    expect(collected.sessions.length).toBe(0);
+    expect(collected.errors).toEqual([{
+      message: "Error: repeated session cursor: again",
+    }]);
+  });
+
+  for (const failure of ["cancellation", "spool write"] as const) {
+    it(`removes the temporary spool after ${failure} failure`, async () => {
+      const originalMakeTempDir = Deno.makeTempDir;
+      let directory: string | undefined;
+      using _directory = stub(Deno, "makeTempDir", async (options) => {
+        directory = await originalMakeTempDir(options);
+        return directory;
+      });
+      const driver = fakeDriver();
+      const controller = new AbortController();
+      if (failure === "cancellation") {
+        const list = driver.listSessions;
+        driver.listSessions = (cursor) => {
+          if (cursor) controller.abort(new Error("collection cancelled"));
+          return list(cursor);
+        };
+        await expect(collectSource(driver, controller.signal)).rejects.toThrow(
+          "collection cancelled",
+        );
+      } else {
+        using _write = stub(
+          Deno,
+          "writeTextFile",
+          () => Promise.reject(new Error("disk full")),
+        );
+        await expect(collectSource(driver)).rejects.toThrow("disk full");
+      }
+      expect(directory).toBeDefined();
+      await expect(Deno.stat(directory!)).rejects.toThrow(Deno.errors.NotFound);
+    });
+  }
 });

--- a/packages/connectors/agents/connector/test/session-spool.test.ts
+++ b/packages/connectors/agents/connector/test/session-spool.test.ts
@@ -1,0 +1,72 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+
+import { SessionSpool } from "../src/session-spool.ts";
+import type { NativeSessionSnapshot } from "../src/types.ts";
+
+describe("SessionSpool", () => {
+  const snapshot = (id: string): NativeSessionSnapshot => ({
+    summary: {
+      nativeSessionId: id,
+      title: id,
+      cwd: null,
+      createdAt: null,
+      updatedAt: null,
+      archived: false,
+      active: false,
+      raw: { id },
+    },
+    events: [],
+    normalizedMessages: [],
+    complete: true,
+  });
+
+  describe("instance members", () => {
+    describe("append()", () => {
+      it("captures native values and sparse arrays before the caller mutates them", async () => {
+        await using spool = await SessionSpool.create();
+        const bytes = new Uint8Array([1, 2, 3]);
+        const events = [bytes, , undefined, -0];
+        const first = { ...snapshot("one"), events };
+        await spool.append(first);
+        bytes[0] = 9;
+        first.summary.title = "changed";
+        events[1] = 5;
+        await spool.append(snapshot("two"));
+
+        expect(spool.length).toBe(2);
+        const values = await Array.fromAsync(spool);
+        expect(values.map((value) => value.summary.title)).toEqual([
+          "one",
+          "two",
+        ]);
+        expect((values[0].events[0] as FabricBytes).slice()).toEqual(
+          new Uint8Array([1, 2, 3]),
+        );
+        expect(1 in values[0].events).toBe(false);
+        expect(2 in values[0].events).toBe(true);
+        expect(values[0].events[2]).toBeUndefined();
+        expect(values[0].events[3]).toBe(-0);
+        expect(await Array.fromAsync(spool)).toEqual(values);
+      });
+    });
+
+    describe("[Symbol.asyncDispose]()", () => {
+      it("removes persisted snapshots when iteration ends early", async () => {
+        const spool = await SessionSpool.create();
+        await spool.append(snapshot("one"));
+        await spool.append(snapshot("two"));
+        for await (const value of spool) {
+          expect(value.summary.title).toBe("one");
+          break;
+        }
+        await spool[Symbol.asyncDispose]();
+        await expect(Array.fromAsync(spool)).rejects.toThrow(
+          Deno.errors.NotFound,
+        );
+      });
+    });
+  });
+});

--- a/packages/connectors/agents/host/README.md
+++ b/packages/connectors/agents/host/README.md
@@ -224,11 +224,19 @@ when the replacement host does not share the earlier host's local ledger.
 The command-line wrapper requests collections periodically and on `SIGHUP`. It
 keeps one pending request while a collection is active. Calls that reach
 `AgentsHost.synchronize(reason)` are serialized. Each collection asks every
-running driver for its complete inventory and session snapshots. The host
-allocates a target observation sequence before those reads. It publishes all
-successful and partial source results together through
-`AgentFabricTarget.publish()`. The sequence prevents that collection from
-overwriting a newer session refresh if the refresh finishes first.
+running driver for its complete inventory and session snapshots. Drivers are
+collected sequentially. Each snapshot is captured in a private temporary spool,
+which publication reads one session at a time. The host removes the spools after
+publication or failure. The host allocates a target observation sequence before
+those reads. It publishes all successful and partial source results together
+through `AgentFabricTarget.publish()`. The sequence prevents that collection
+from overwriting a newer session refresh if the refresh finishes first.
+
+The host supplies independent runtimes for session and index publications. Each
+runtime is disposed after its commits settle. The persistent command runtime
+does not retain the transcript documents written during full collection.
+Targeted refreshes spool completed session reads before waiting for publication.
+Independent provider reads can proceed concurrently.
 
 Provider read failures do not discard sessions read successfully from the same
 source. They make that source and the overall host degraded. A Fabric

--- a/packages/connectors/agents/host/src/fabric-runtime.ts
+++ b/packages/connectors/agents/host/src/fabric-runtime.ts
@@ -62,20 +62,21 @@ export async function openAgentFabricRuntime(options: {
     ...(options.signal !== undefined ? { signal: options.signal } : {}),
   });
   options.signal?.throwIfAborted();
-  const storageManager = StorageManager.open({
-    as: session.as,
-    memoryHost: apiUrl,
-    spaceIdentity: session.spaceIdentity,
-  });
-  const runtime = new Runtime(runtimePresets.remoteClient({
-    apiUrl,
-    storageManager,
-    experimental,
-    trustSnapshotProvider: () => ({
-      id: `principal:${session.as.did()}`,
-      actingPrincipal: session.as.did(),
-    }),
-  }));
+  const createRuntime = () =>
+    new Runtime(runtimePresets.remoteClient({
+      apiUrl,
+      storageManager: StorageManager.open({
+        as: session.as,
+        memoryHost: apiUrl,
+        spaceIdentity: session.spaceIdentity,
+      }),
+      experimental,
+      trustSnapshotProvider: () => ({
+        id: `principal:${session.as.did()}`,
+        actingPrincipal: session.as.did(),
+      }),
+    }));
+  const runtime = createRuntime();
   let disposeTask: Promise<void> | undefined;
   const dispose = () => disposeTask ??= runtime.dispose();
 
@@ -106,6 +107,7 @@ export async function openAgentFabricRuntime(options: {
     options.signal?.throwIfAborted();
     const connection = {
       runtime,
+      createPublicationRuntime: createRuntime,
       spaceDid: session.space,
       ownerDid: options.ownerDid,
     };

--- a/packages/connectors/agents/host/src/host.ts
+++ b/packages/connectors/agents/host/src/host.ts
@@ -665,11 +665,13 @@ export class AgentsHost {
 
     try {
       await this.#publishHealth(signal);
-      const collected = await Promise.all(
-        [...this.#drivers.entries()].map(([sourceId, driver]) =>
-          this.#collectSource(sourceId, driver, signal)
-        ),
-      );
+      await using collections = new AsyncDisposableStack();
+      const collected: CollectedSource[] = [];
+      for (const [sourceId, driver] of this.#drivers) {
+        collected.push(
+          await this.#collectSource(sourceId, driver, collections, signal),
+        );
+      }
       signal?.throwIfAborted();
       const checkoutDirectories = this.#checkoutRoots.length > 0
         ? await this.#discoverCheckouts(
@@ -758,6 +760,7 @@ export class AgentsHost {
   async #collectSource(
     sourceId: string,
     driver: AgentDriver,
+    collections: AsyncDisposableStack,
     signal?: AbortSignal,
   ): Promise<CollectedSource> {
     const state = this.#sources.get(sourceId)!;
@@ -767,18 +770,7 @@ export class AgentsHost {
       undefined,
       sourceId,
     );
-    let collected: CollectedSource;
-    try {
-      collected = await collectSource(driver, signal);
-    } catch (error) {
-      signal?.throwIfAborted();
-      collected = {
-        source: driver.source,
-        sessions: [],
-        errors: [{ message: errorMessage(error) }],
-        complete: false,
-      };
-    }
+    const collected = collections.use(await collectSource(driver, signal));
 
     state.capabilities = structuredClone(driver.source.capabilities);
     state.sessionCount = collected.sessions.length;

--- a/packages/connectors/agents/host/test/host_test.ts
+++ b/packages/connectors/agents/host/test/host_test.ts
@@ -176,6 +176,7 @@ class FakeDriver implements AgentDriver {
 class FakeTarget implements AgentsHostTarget {
   healthValues: Record<string, unknown>[] = [];
   publications: CollectedSource[][] = [];
+  sessionSpools: CollectedSource["sessions"][] = [];
   allocatedObservationSequences: number[] = [];
   observationSequences: number[] = [];
   checkoutDirectories: string[][] = [];
@@ -207,7 +208,7 @@ class FakeTarget implements AgentsHostTarget {
     return sequence;
   }
 
-  publish(
+  async publish(
     collected: CollectedSource[],
     options?: {
       observationSequence?: number;
@@ -216,7 +217,17 @@ class FakeTarget implements AgentsHostTarget {
       onCommit?: () => void;
     },
   ): Promise<number> {
-    this.publications.push(structuredClone(collected));
+    const captured: CollectedSource[] = [];
+    for (const source of collected) {
+      this.sessionSpools.push(source.sessions);
+      captured.push({
+        source: structuredClone(source.source),
+        sessions: await Array.fromAsync(source.sessions),
+        complete: source.complete,
+        errors: structuredClone(source.errors),
+      });
+    }
+    this.publications.push(captured);
     if (options?.observationSequence !== undefined) {
       this.observationSequences.push(options.observationSequence);
     }
@@ -419,6 +430,10 @@ Deno.test("AgentsHost publishes sessions, health, and lifecycle activity", async
     assertEquals(await host.start(), 1);
     assertEquals(target.publications.length, 1);
     assertEquals(target.publications[0][0].source.id, "codex");
+    await assertRejects(
+      () => Array.fromAsync(target.sessionSpools[0]),
+      Deno.errors.NotFound,
+    );
     assertEquals(target.checkoutDirectories, [[
       "/workspace/checkouts/project",
     ]]);
@@ -1036,6 +1051,10 @@ Deno.test("AgentsHost reports post-commit health failure", async () => {
       () => host.synchronize("health-failure", controller.signal),
       Error,
       "health publication rejected",
+    );
+    await assertRejects(
+      () => Array.fromAsync(target.sessionSpools.at(-1)!),
+      Deno.errors.NotFound,
     );
     assertEquals(host.health().sync?.status, "failed");
     assertEquals(

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -111,6 +111,7 @@ export {
   isCell,
   isReadableCell,
   isStream,
+  markCellDocumentSynced,
 } from "./cell.ts";
 export {
   getCellOrThrow,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -937,6 +937,8 @@ function cellAsLink(value: object | ((...args: never[]) => unknown)): unknown {
  * ```
  */
 export class Runtime {
+  static #ambientConfigUsers = 0;
+  #holdsAmbientConfig = false;
   #tearingDownWrites = false;
   readonly #writeTeardown = new AbortController();
 
@@ -1400,10 +1402,9 @@ export class Runtime {
     // Validate-then-apply: option combinations are refused BEFORE any
     // process-global write (the ambient experimental-flag propagation
     // below, the server-execution enabler), so a refused construction
-    // leaves no trace in the process — the try/catch further down rolls
-    // back only the enabler, and everything above it must not need
-    // rolling back. A serving runtime uses the DEFAULT trust-snapshot
-    // provider — the run stamper attaches per-run snapshots via
+    // leaves no trace in the process. The try/catch further down releases
+    // the runtime's ambient config ownership. A serving runtime uses the
+    // DEFAULT trust-snapshot provider — the run stamper attaches per-run snapshots via
     // trustSnapshotForPrincipal (serving-loop.md §3c), whose revision is
     // the runtime's own; a custom provider would be silently bypassed
     // for every acting run and would compose a revision the stamper
@@ -1509,6 +1510,8 @@ export class Runtime {
     this.experimental.serverExecution = this.#explicitServerExecution ??
       getServerExecutionConfig();
     this.servingPosture = options.servingPosture === true;
+    Runtime.#ambientConfigUsers++;
+    this.#holdsAmbientConfig = true;
     // Everything below can throw (URL parsing, host validation, engine
     // construction). The enabler claimed above is process-global state,
     // so a THROWING construction must roll it back — a leaked enabler
@@ -1702,6 +1705,7 @@ export class Runtime {
       this.#defaultFrame = pushFrame({ runtime: this });
     } catch (error) {
       this.#releaseServerExecutionEnabler();
+      this.#releaseAmbientConfig();
       throw error;
     }
   }
@@ -1983,14 +1987,11 @@ export class Runtime {
    * Passing `false` makes closing the CALLER's job — nothing else will. Note
    * `await using` / `[Symbol.asyncDispose]` always takes the closing path.
    *
-   * Either way this resets the PROCESS-GLOBAL experimental config to defaults
-   * (`resetModernCellRepConfig` and friends) — except
-   * `readerSchemaPrecedence`, which dispose leaves standing: serving
-   * runtimes are per-space and idle-disposed, so a teardown reset would
-   * lift a live rollback from under the survivors. Under a non-default
-   * flag that is visible to a second runtime still running against the
-   * same store, which is exactly the caller this option serves — so set
-   * the flags per process, not per runtime, if two of them must agree.
+   * The last runtime's disposal resets the process-global modernCellRep and
+   * commitPreconditions settings to defaults. Disposing one of several live
+   * runtimes leaves those settings in effect. Explicit construction changes
+   * remain process-global. readerSchemaPrecedence stays in effect after every
+   * runtime has been disposed.
    */
   async dispose(
     { closeStorage = true }: { closeStorage?: boolean } = {},
@@ -2001,6 +2002,7 @@ export class Runtime {
       // Exception-safe: a rejecting teardown step must not leak the
       // process-global enabler (the reset would then never fire).
       this.#releaseServerExecutionEnabler();
+      this.#releaseAmbientConfig();
     }
 
     // Clear the current runtime reference
@@ -2129,13 +2131,21 @@ export class Runtime {
       // contract: the last enabler's dispose resets. Released in
       // #releaseServerExecutionEnabler (also called from the dispose
       // catch), so a REJECTING async teardown cannot leak the enabler.
-      resetModernCellRepConfig();
-      resetCommitPreconditionsConfig();
       // readerSchemaPrecedence deliberately does NOT reset here: a server
       // runs one serving runtime per space and disposes idle ones while
       // the rest live, so a dispose-time reset would lift a rollback out
       // from under them. The ambient changes only when a construction
       // sets it (last construction wins).
+    }
+  }
+
+  /** Releases ambient settings when the last runtime finishes teardown. */
+  #releaseAmbientConfig(): void {
+    if (!this.#holdsAmbientConfig) return;
+    this.#holdsAmbientConfig = false;
+    if (--Runtime.#ambientConfigUsers === 0) {
+      resetModernCellRepConfig();
+      resetCommitPreconditionsConfig();
     }
   }
 

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -1457,6 +1457,9 @@ export class Runtime {
     this.experimental.plainResultReceipts ??= true;
     this.experimental.lazyMaterialization ??= true;
 
+    const previousModernCellRep = getModernCellRepConfig();
+    const previousCommitPreconditions = getCommitPreconditionsConfig();
+
     // Propagate experimental flags to their ambient control points, then read
     // back the effective state so `experimental.*` reflects what is actually in
     // effect (matters when the caller didn't pass an explicit value and the
@@ -1706,6 +1709,8 @@ export class Runtime {
     } catch (error) {
       this.#releaseServerExecutionEnabler();
       this.#releaseAmbientConfig();
+      setModernCellRepConfig(previousModernCellRep);
+      setCommitPreconditionsConfig(previousCommitPreconditions);
       throw error;
     }
   }
@@ -1999,8 +2004,9 @@ export class Runtime {
     try {
       await this.#disposeInner(closeStorage);
     } finally {
-      // Exception-safe: a rejecting teardown step must not leak the
-      // process-global enabler (the reset would then never fire).
+      // Release process-global flag ownership after teardown, including a
+      // failed teardown. The last runtime resets modernCellRep and
+      // commitPreconditions; the last serverExecution enabler resets that flag.
       this.#releaseServerExecutionEnabler();
       this.#releaseAmbientConfig();
     }
@@ -2097,17 +2103,7 @@ export class Runtime {
     } finally {
       this.#tearingDownWrites = true;
       this.#writeTeardown.abort();
-      // Released whatever happened above. `storageManager.close()` can reject
-      // — through a provider's `replica.close()` — and it is the one await
-      // here that can. Every statement below is synchronous field-clearing
-      // that cannot fail in turn, so running them on the error path costs
-      // nothing while skipping them strands the process: the config resets
-      // are PROCESS-GLOBAL, and one skipped leaves a non-default experimental
-      // flag set for every runtime built afterwards, with nothing to put it
-      // back.
-      //
-      // The error still propagates. What changes is how much has been
-      // released by the time it does, not whether disposal fails.
+      // Release local services after every teardown outcome.
       this.scheduler.dispose();
       this.runner.dispose();
 
@@ -2120,22 +2116,6 @@ export class Runtime {
       // Dispose the Engine (clears compiler/runtime state and the console
       // hook)
       this.harness.dispose();
-
-      // Reset experimental config to defaults. serverExecution releases
-      // this runtime's ENABLER (stage F): the flag resets only when the
-      // last live enabler process-wide goes — disposing a flag-less
-      // runtime, or parking one serving runtime of several, must not clear
-      // the ambient flag other owners and the memory server's admission
-      // still depend on (mid-wave `derived` commits would be refused as
-      // unclaimable). A single-runtime test keeps its stage-A cleanup
-      // contract: the last enabler's dispose resets. Released in
-      // #releaseServerExecutionEnabler (also called from the dispose
-      // catch), so a REJECTING async teardown cannot leak the enabler.
-      // readerSchemaPrecedence deliberately does NOT reset here: a server
-      // runs one serving runtime per space and disposes idle ones while
-      // the rest live, so a dispose-time reset would lift a rollback out
-      // from under them. The ambient changes only when a construction
-      // sets it (last construction wins).
     }
   }
 

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -259,6 +259,31 @@ describe("ExperimentalOptions", () => {
       });
     }
 
+    it("restores a surviving runtime's settings when another construction fails", async () => {
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: StorageManager.emulate({ as: signer }),
+        experimental: { modernCellRep: true, commitPreconditions: false },
+      });
+      const failedStorage = StorageManager.emulate({ as: signer });
+      try {
+        expect(() =>
+          new Runtime({
+            apiUrl: "invalid URL" as never,
+            storageManager: failedStorage,
+            experimental: { modernCellRep: false, commitPreconditions: true },
+          })
+        ).toThrow("Invalid URL");
+        expect(getModernCellRepConfig()).toBe(true);
+        expect(getCommitPreconditionsConfig()).toBe(false);
+      } finally {
+        await failedStorage.close();
+        await runtime.dispose();
+      }
+      expect(getModernCellRepConfig()).toBe(false);
+      expect(getCommitPreconditionsConfig()).toBe(true);
+    });
+
     it("releases ambient config ownership when construction or disposal fails", async () => {
       const failedStorage = StorageManager.emulate({ as: signer });
       try {

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -231,6 +231,66 @@ describe("ExperimentalOptions", () => {
       expect(getCommitPreconditionsConfig()).toBe(true);
       expect(getServerExecutionConfig()).toBe(false);
     });
+
+    for (const firstDisposed of [0, 1]) {
+      it(`keeps ambient config until both runtimes are disposed, disposing runtime ${firstDisposed} first`, async () => {
+        const runtimes = [true, false].map((explicit) =>
+          new Runtime({
+            apiUrl: new URL(import.meta.url),
+            storageManager: StorageManager.emulate({ as: signer }),
+            experimental: {
+              ...(explicit ? { modernCellRep: true } : {}),
+              commitPreconditions: false,
+            },
+          })
+        );
+        try {
+          await runtimes[firstDisposed].dispose();
+          expect(getModernCellRepConfig()).toBe(true);
+          expect(getCommitPreconditionsConfig()).toBe(false);
+          await runtimes[firstDisposed].dispose();
+          expect(getModernCellRepConfig()).toBe(true);
+          expect(getCommitPreconditionsConfig()).toBe(false);
+        } finally {
+          await runtimes[1 - firstDisposed].dispose();
+        }
+        expect(getModernCellRepConfig()).toBe(false);
+        expect(getCommitPreconditionsConfig()).toBe(true);
+      });
+    }
+
+    it("releases ambient config ownership when construction or disposal fails", async () => {
+      const failedStorage = StorageManager.emulate({ as: signer });
+      try {
+        expect(() =>
+          new Runtime({
+            apiUrl: "invalid URL" as never,
+            storageManager: failedStorage,
+            experimental: { modernCellRep: true, commitPreconditions: false },
+          })
+        ).toThrow("Invalid URL");
+      } finally {
+        await failedStorage.close();
+      }
+      expect(getModernCellRepConfig()).toBe(false);
+      expect(getCommitPreconditionsConfig()).toBe(true);
+
+      const storage = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: storage,
+        experimental: { modernCellRep: true, commitPreconditions: false },
+      });
+      runtime.scheduler.idle = () =>
+        Promise.reject(new Error("disposal failed"));
+      try {
+        await expect(runtime.dispose()).rejects.toThrow("disposal failed");
+        expect(getModernCellRepConfig()).toBe(false);
+        expect(getCommitPreconditionsConfig()).toBe(true);
+      } finally {
+        await storage.close();
+      }
+    });
   });
 });
 

--- a/packages/runner/test/runtime-dispose-keep-storage.test.ts
+++ b/packages/runner/test/runtime-dispose-keep-storage.test.ts
@@ -369,9 +369,8 @@ describe("runtime.dispose({ closeStorage })", () => {
         "provider destroy failed",
       );
 
-      // PROCESS-GLOBAL, which is why this one matters beyond the runtime that
-      // set it: skipped once, a non-default flag reaches every runtime built
-      // afterwards in the same process and nothing puts it back.
+      expect(getModernCellRepConfig()).toBe(true);
+      await witnessRuntime.dispose();
       expect(getModernCellRepConfig()).toBe(false);
       expect(registered.filter((s) => failing.live.has(s))).toEqual([]);
     } finally {


### PR DESCRIPTION
PROBLEM

The agent host collects every transcript before publishing them. The target then retains written session graphs in its long-lived runtime. Large archives can exhaust the host heap during either phase.

SOLUTION

Spool provider snapshots to private temporary files. Read and publish one session at a time, with one chunk graph prepared per commit. Dispose independent publication runtimes after their writes settle and keep transcript links out of index reads. Spool targeted refreshes before they wait to publish.

Keep process-wide runtime settings alive until the last runtime is disposed. Preserve Codex metadata without duplicating its turns.

Add coverage for memory usage, data fidelity, cleanup, partial inventories, independent refreshes, and publication lifetimes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/7206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

