### PR TITLE
Return scoped conflict arrays and repair every instance before retrying

### DIFF
--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -411,16 +411,23 @@ interface ConflictError extends Error {
    * reaching this seq reflects the winning write.
    */
   retryAfterSeq: number;
+  /** Present when a confirmed read names the conflicting scoped entity. */
+  conflict?: { of: string; scope: "space" | "user" | "session" };
 }
 ```
 
 The rejection carries no document values. Instead the server marks the commit's
 write targets and both read sets (`reads.confirmed` and `reads.pending`) dirty
 for the session — origin-less, so the session's own echo suppression does not
-hide them — and the next sync frame delivers the current documents for all of
-them as ordinary upserts. Repair therefore arrives as a consistent cut over the
-session's watched view — covering stale read dependencies as well as write
-targets, with every document the frame links to delivered in the same cut.
+hide them — and the next sync frame delivers the watched documents as ordinary
+upserts. Repair therefore arrives as a consistent cut over the
+session's watched view, with every document the frame links to delivered in the
+same cut. A dirty address outside that view does not gain a watch through dirty
+marking alone. For stale confirmed reads, the error's `conflict` address
+preserves the entity ID and scope so a retry helper can explicitly sync the
+conflicting instance. The scope resolves under the rejected session's identity.
+Older responses can omit this address; their diagnostic identifies the entity
+but does not preserve its scope.
 
 ## 3.7 Server-Side Commit Processing
 

--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -411,8 +411,13 @@ interface ConflictError extends Error {
    * reaching this seq reflects the winning write.
    */
   retryAfterSeq: number;
-  /** Present when a confirmed read names the conflicting scoped entity. */
-  conflict?: { of: string; scope: "space" | "user" | "session" };
+  /** Every stale confirmed read, including a single-read conflict. */
+  conflicts?: Array<{
+    of: string;
+    scope: "space" | "user" | "session";
+    seq: number;
+    conflictSeq: number;
+  }>;
 }
 ```
 
@@ -423,11 +428,14 @@ hide them — and the next sync frame delivers the watched documents as ordinary
 upserts. Repair therefore arrives as a consistent cut over the
 session's watched view, with every document the frame links to delivered in the
 same cut. A dirty address outside that view does not gain a watch through dirty
-marking alone. For stale confirmed reads, the error's `conflict` address
-preserves the entity ID and scope so a retry helper can explicitly sync the
-conflicting instance. The scope resolves under the rejected session's identity.
-Older responses can omit this address; their diagnostic identifies the entity
-but does not preserve its scope.
+marking alone. Confirmed-read validation collects every stale read before
+rejecting. The error's `conflicts` array preserves each entity ID, scope, read
+sequence, and conflicting sequence, including when only one read is stale. A
+retry helper can explicitly sync all conflicting instances before retrying;
+repeated reads of one instance require only one pull. Each scope resolves under
+the rejected session's identity. Older responses can omit this array; their
+diagnostic identifies entities but does not preserve their scopes. The runner
+also exposes the first descriptor as `conflict` for existing consumers.
 
 ## 3.7 Server-Side Commit Processing
 

--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -411,10 +411,12 @@ interface ConflictError extends Error {
    * reaching this seq reflects the winning write.
    */
   retryAfterSeq: number;
-  /** First stale confirmed read per entity and scope, even for one conflict. */
+  /** First stale confirmed read per branch, entity, and scope. */
   conflicts?: Array<{
     of: string;
     scope: "space" | "user" | "session";
+    /** Absent for the default branch. */
+    branch?: string;
     seq: number;
     conflictSeq: number;
   }>;
@@ -428,14 +430,17 @@ hide them — and the next sync frame delivers the watched documents as ordinary
 upserts. Repair therefore arrives as a consistent cut over the session's watched
 view, with every document the frame links to delivered in the same cut. A dirty
 address outside that view does not gain a watch through dirty marking alone.
-Confirmed-read validation reports each stale entity and scope once. Its first
-stale read supplies the diagnostic read sequence and conflicting sequence;
+Confirmed-read validation reports each stale branch, entity, and scope once. Its
+first stale read supplies the diagnostic read sequence and conflicting sequence;
 subsequent reads of that instance skip the staleness scan. Every read still
 validates its branch and resolves its scope. An unknown branch or unresolvable
 scope takes precedence over any stale reads already found. The `conflicts` array
-includes an entry even when only one instance is stale. A retry helper can
-explicitly sync all conflicting instances before retrying; repeated reads of one
-instance require only one pull. Each scope resolves under the rejected session's
+includes an entry even when only one instance is stale. Non-default branches are
+named in the descriptor; an absent `branch` means the default branch, regardless
+of the commit's target branch. A client can query each conflicting branch,
+entity, and scope before retrying. The runner emits default-branch reads and its
+retry helper repairs those instances; cross-branch clients use the memory
+protocol's branch-aware queries. Each scope resolves under the rejected session's
 identity. Older responses can omit this array; their diagnostic identifies
 entities but does not preserve their scopes. The runner also exposes the first
 descriptor as `conflict` for existing consumers. The diagnostic previews up to

--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -425,17 +425,22 @@ The rejection carries no document values. Instead the server marks the commit's
 write targets and both read sets (`reads.confirmed` and `reads.pending`) dirty
 for the session — origin-less, so the session's own echo suppression does not
 hide them — and the next sync frame delivers the watched documents as ordinary
-upserts. Repair therefore arrives as a consistent cut over the
-session's watched view, with every document the frame links to delivered in the
-same cut. A dirty address outside that view does not gain a watch through dirty
-marking alone. Confirmed-read validation collects every stale read before
-rejecting. The error's `conflicts` array preserves each entity ID, scope, read
-sequence, and conflicting sequence, including when only one read is stale. A
-retry helper can explicitly sync all conflicting instances before retrying;
-repeated reads of one instance require only one pull. Each scope resolves under
-the rejected session's identity. Older responses can omit this array; their
-diagnostic identifies entities but does not preserve their scopes. The runner
-also exposes the first descriptor as `conflict` for existing consumers.
+upserts. Repair therefore arrives as a consistent cut over the session's watched
+view, with every document the frame links to delivered in the same cut. A dirty
+address outside that view does not gain a watch through dirty marking alone.
+Confirmed-read validation collects every stale read before rejecting. An unknown
+branch or unresolvable scope prevents validation from completing and takes
+precedence over any stale reads already found. The error's `conflicts` array
+preserves each entity ID, scope, read sequence, and conflicting sequence,
+including when only one read is stale. A retry helper can explicitly sync all
+conflicting instances before retrying; repeated reads of one instance require
+only one pull. Each scope resolves under the rejected session's identity. Older
+responses can omit this array; their diagnostic identifies entities but does not
+preserve their scopes. The runner also exposes the first descriptor as `conflict`
+for existing consumers. The diagnostic previews up to three distinct
+entity/sequence clauses and counts the remaining clauses; repeated path reads
+share a clause. The structured array remains complete regardless of the
+diagnostic's length.
 
 ## 3.7 Server-Side Commit Processing
 

--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -444,9 +444,10 @@ protocol's branch-aware queries. Each scope resolves under the rejected session'
 identity. Older responses can omit this array; their diagnostic identifies
 entities but does not preserve their scopes. The runner also exposes the first
 descriptor as `conflict` for existing consumers. The diagnostic previews up to
-three distinct entity/sequence clauses and counts the remaining clauses;
-repeated path reads share a clause. The structured array remains complete
-regardless of the diagnostic's length.
+three distinct entity IDs and counts the remaining IDs. Each entity's clause
+uses its first reported instance's sequences; other scopes or branches of that
+entity share the clause. The structured array remains complete regardless of
+the diagnostic's length.
 
 ## 3.7 Server-Side Commit Processing
 

--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -411,7 +411,7 @@ interface ConflictError extends Error {
    * reaching this seq reflects the winning write.
    */
   retryAfterSeq: number;
-  /** Every stale confirmed read, including a single-read conflict. */
+  /** First stale confirmed read per entity and scope, even for one conflict. */
   conflicts?: Array<{
     of: string;
     scope: "space" | "user" | "session";
@@ -428,19 +428,20 @@ hide them — and the next sync frame delivers the watched documents as ordinary
 upserts. Repair therefore arrives as a consistent cut over the session's watched
 view, with every document the frame links to delivered in the same cut. A dirty
 address outside that view does not gain a watch through dirty marking alone.
-Confirmed-read validation collects every stale read before rejecting. An unknown
-branch or unresolvable scope prevents validation from completing and takes
-precedence over any stale reads already found. The error's `conflicts` array
-preserves each entity ID, scope, read sequence, and conflicting sequence,
-including when only one read is stale. A retry helper can explicitly sync all
-conflicting instances before retrying; repeated reads of one instance require
-only one pull. Each scope resolves under the rejected session's identity. Older
-responses can omit this array; their diagnostic identifies entities but does not
-preserve their scopes. The runner also exposes the first descriptor as `conflict`
-for existing consumers. The diagnostic previews up to three distinct
-entity/sequence clauses and counts the remaining clauses; repeated path reads
-share a clause. The structured array remains complete regardless of the
-diagnostic's length.
+Confirmed-read validation reports each stale entity and scope once. Its first
+stale read supplies the diagnostic read sequence and conflicting sequence;
+subsequent reads of that instance skip the staleness scan. Every read still
+validates its branch and resolves its scope. An unknown branch or unresolvable
+scope takes precedence over any stale reads already found. The `conflicts` array
+includes an entry even when only one instance is stale. A retry helper can
+explicitly sync all conflicting instances before retrying; repeated reads of one
+instance require only one pull. Each scope resolves under the rejected session's
+identity. Older responses can omit this array; their diagnostic identifies
+entities but does not preserve their scopes. The runner also exposes the first
+descriptor as `conflict` for existing consumers. The diagnostic previews up to
+three distinct entity/sequence clauses and counts the remaining clauses;
+repeated path reads share a clause. The structured array remains complete
+regardless of the diagnostic's length.
 
 ## 3.7 Server-Side Commit Processing
 

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -1054,10 +1054,12 @@ interface ConflictError extends Error {
   name: "ConflictError";
   /** Server head seq at rejection time (§3.6.4). */
   retryAfterSeq: number;
-  /** First stale confirmed read per entity and scope, even for one conflict. */
+  /** First stale confirmed read per branch, entity, and scope. */
   conflicts?: Array<{
     of: string;
     scope: "space" | "user" | "session";
+    /** Absent for the default branch. */
+    branch?: string;
     seq: number;
     conflictSeq: number;
   }>;

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -1054,7 +1054,7 @@ interface ConflictError extends Error {
   name: "ConflictError";
   /** Server head seq at rejection time (§3.6.4). */
   retryAfterSeq: number;
-  /** Every stale confirmed read, including a single-read conflict. */
+  /** First stale confirmed read per entity and scope, even for one conflict. */
   conflicts?: Array<{
     of: string;
     scope: "space" | "user" | "session";

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -1054,6 +1054,8 @@ interface ConflictError extends Error {
   name: "ConflictError";
   /** Server head seq at rejection time (§3.6.4). */
   retryAfterSeq: number;
+  /** Present when a confirmed read names the conflicting scoped entity. */
+  conflict?: { of: string; scope: "space" | "user" | "session" };
 }
 
 interface TransactionError extends Error {

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -1054,8 +1054,13 @@ interface ConflictError extends Error {
   name: "ConflictError";
   /** Server head seq at rejection time (§3.6.4). */
   retryAfterSeq: number;
-  /** Present when a confirmed read names the conflicting scoped entity. */
-  conflict?: { of: string; scope: "space" | "user" | "session" };
+  /** Every stale confirmed read, including a single-read conflict. */
+  conflicts?: Array<{
+    of: string;
+    scope: "space" | "user" | "session";
+    seq: number;
+    conflictSeq: number;
+  }>;
 }
 
 interface TransactionError extends Error {

--- a/docs/specs/space-model/5-transactions.md
+++ b/docs/specs/space-model/5-transactions.md
@@ -196,7 +196,7 @@ outcome:
 
 | Class | Why a re-run can converge |
 | --- | --- |
-| `ConflictError` | Stale basis from upstream. The retry first awaits the conflict's `readyToRetry` catch-up gate, then pulls the doc in the scope the conflict names. Errors without scope retain the default space-scoped pull. |
+| `ConflictError` | Stale basis from upstream. The retry first awaits the conflict's `readyToRetry` catch-up gate, then pulls every document in the scope named by the conflict list. Repeated addresses share one pull; entries without scope retain the default space-scoped pull. |
 | `StorageTransactionInconsistent` | Stale basis on this replica — a value read during the transaction changed locally; re-reading resolves it. |
 | `ConnectionError`, `InvalidMessageError` | Liveness failure: the commit never reached a verdict, and the memory client re-establishes the link on its own (a transport close schedules `reconnect()`; a `transact` issued while disconnected queues and calls `restoreConnection()`), so a retry can land the identical write. `InvalidMessageError` is collateral — an undecodable frame makes the client reject every in-flight request, including commits it says nothing about. |
 | `StorageTransactionAborted` | The attempt was discarded before storage, and a re-run is a genuinely new attempt that costs no round-trip. Producers: the callback called `tx.abort()`; a prepared CFC transaction's inputs drifted before the verdict (`cfc-prepared-digest-mismatch`, and the `invalidateCfc` drift reasons such as `read-after-prepare`); or a CFC refusal that is not wholly a verdict (`cfc-refusal-not-a-verdict`) — prepare could not evaluate an input it needed, or a resolution failed. Those clear on a fresh attempt once the input is there. |

--- a/docs/specs/space-model/5-transactions.md
+++ b/docs/specs/space-model/5-transactions.md
@@ -196,7 +196,7 @@ outcome:
 
 | Class | Why a re-run can converge |
 | --- | --- |
-| `ConflictError` | Stale basis from upstream. The retry first awaits the conflict's `readyToRetry` catch-up gate, then pulls the doc the conflict names, so it runs against fresh state. |
+| `ConflictError` | Stale basis from upstream. The retry first awaits the conflict's `readyToRetry` catch-up gate, then pulls the doc in the scope the conflict names. Errors without scope retain the default space-scoped pull. |
 | `StorageTransactionInconsistent` | Stale basis on this replica — a value read during the transaction changed locally; re-reading resolves it. |
 | `ConnectionError`, `InvalidMessageError` | Liveness failure: the commit never reached a verdict, and the memory client re-establishes the link on its own (a transport close schedules `reconnect()`; a `transact` issued while disconnected queues and calls `restoreConnection()`), so a retry can land the identical write. `InvalidMessageError` is collateral — an undecodable frame makes the client reject every in-flight request, including commits it says nothing about. |
 | `StorageTransactionAborted` | The attempt was discarded before storage, and a re-run is a genuinely new attempt that costs no round-trip. Producers: the callback called `tx.abort()`; a prepared CFC transaction's inputs drifted before the verdict (`cfc-prepared-digest-mismatch`, and the `invalidateCfc` drift reasons such as `read-after-prepare`); or a CFC refusal that is not wholly a verdict (`cfc-refusal-not-a-verdict`) — prepare could not evaluate an input it needed, or a resolution failed. Those clear on a fresh attempt once the input is there. |

--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -151,6 +151,9 @@ export interface ConflictError extends Error {
   transaction: ClientCommit;
 
   conflict: Conflict;
+
+  /** All known conflicts; `conflict` is the first for compatibility. */
+  conflicts?: Conflict[];
   retryAfterSeq?: number;
   readyToRetry?: () => Promise<void>;
 }

--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -1,6 +1,6 @@
 import type { FabricValue, SchemaPathSelector } from "@commonfabric/api";
 import type { Signer as IdentitySigner } from "@commonfabric/identity";
-import type { ClientCommit } from "./v2.ts";
+import type { CellScope, ClientCommit } from "./v2.ts";
 
 export type {
   AsBytes,
@@ -139,6 +139,9 @@ export type Conflict = {
    * Identifier of the entity where conflict occurred.
    */
   of: Entity;
+
+  /** Scope of the conflicting instance; omitted by peers without scoped errors. */
+  scope?: CellScope;
 };
 
 export interface ConflictError extends Error {

--- a/packages/memory/test/v2-client.test.ts
+++ b/packages/memory/test/v2-client.test.ts
@@ -1155,6 +1155,13 @@ Deno.test("memory v2 client readyToRetry waits for caught-up local sequence", as
       readyToRetry?: () => Promise<void>;
     }).readyToRetry;
     assertExists(readyToRetry);
+    assertEquals(
+      (error as Error & { conflicts?: unknown }).conflicts,
+      [
+        { of: "of:doc:1", scope: "space", seq: 0, conflictSeq: 1 },
+        { of: "of:doc:2", scope: "space", seq: 0, conflictSeq: 2 },
+      ],
+    );
 
     let ready = false;
     const readyPromise = readyToRetry().then(() => {
@@ -1944,6 +1951,10 @@ class ConflictReadyTransport implements Transport {
             name: "ConflictError",
             message: "conflict",
             retryAfterSeq: 2,
+            conflicts: [
+              { of: "of:doc:1", scope: "space", seq: 0, conflictSeq: 1 },
+              { of: "of:doc:2", scope: "space", seq: 0, conflictSeq: 2 },
+            ],
           },
         });
         return Promise.resolve();

--- a/packages/memory/test/v2-client.test.ts
+++ b/packages/memory/test/v2-client.test.ts
@@ -1159,7 +1159,13 @@ Deno.test("memory v2 client readyToRetry waits for caught-up local sequence", as
       (error as Error & { conflicts?: unknown }).conflicts,
       [
         { of: "of:doc:1", scope: "space", seq: 0, conflictSeq: 1 },
-        { of: "of:doc:2", scope: "space", seq: 0, conflictSeq: 2 },
+        {
+          of: "of:doc:2",
+          scope: "space",
+          branch: "feature",
+          seq: 0,
+          conflictSeq: 2,
+        },
       ],
     );
 
@@ -1953,7 +1959,13 @@ class ConflictReadyTransport implements Transport {
             retryAfterSeq: 2,
             conflicts: [
               { of: "of:doc:1", scope: "space", seq: 0, conflictSeq: 1 },
-              { of: "of:doc:2", scope: "space", seq: 0, conflictSeq: 2 },
+              {
+                of: "of:doc:2",
+                scope: "space",
+                branch: "feature",
+                seq: 0,
+                conflictSeq: 2,
+              },
             ],
           },
         });

--- a/packages/memory/test/v2-conflict-scope.test.ts
+++ b/packages/memory/test/v2-conflict-scope.test.ts
@@ -13,7 +13,7 @@ import {
 
 describe("v2-conflict-scope", () => {
   for (const scope of ["space", "user", "session"] as const) {
-    it(`returns the conflicting ${scope} instance when another scope shares its ID`, async () => {
+    it(`returns every conflicting instance including ${scope} when scopes share an ID`, async () => {
       const server = new Server({
         store: new URL("memory://conflict-scope"),
         subscriptionRefreshDelayMs: "manual",
@@ -38,6 +38,9 @@ describe("v2-conflict-scope", () => {
           })),
         });
         const otherScope = scope === "space" ? "user" : "space";
+        const thirdScope = scopes.find((candidate) =>
+          candidate !== scope && candidate !== otherScope
+        )!;
         await expect(session.transact({
           localSeq: 2,
           reads: {
@@ -51,6 +54,11 @@ describe("v2-conflict-scope", () => {
               scope,
               path: toDocumentPath(["value"]),
               seq: 0,
+            }, {
+              id: "of:shared-id",
+              scope: thirdScope,
+              path: toDocumentPath(["value"]),
+              seq: 0,
             }],
             pending: [],
           },
@@ -61,7 +69,15 @@ describe("v2-conflict-scope", () => {
           }],
         })).rejects.toMatchObject({
           name: "ConflictError",
-          conflict: { of: "of:shared-id", scope },
+          conflicts: [
+            { of: "of:shared-id", scope, seq: 0, conflictSeq: seeded.seq },
+            {
+              of: "of:shared-id",
+              scope: thirdScope,
+              seq: 0,
+              conflictSeq: seeded.seq,
+            },
+          ],
           retryAfterSeq: seeded.seq,
         });
       } finally {

--- a/packages/memory/test/v2-conflict-scope.test.ts
+++ b/packages/memory/test/v2-conflict-scope.test.ts
@@ -1,0 +1,73 @@
+/** Scoped conflict addresses survive the server response and client decoding. */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+
+import { type CellScope, toDocumentPath } from "../v2.ts";
+import { connect, loopback } from "../v2/client.ts";
+import { Server } from "../v2/server.ts";
+import {
+  testSessionOpenAuthFactory,
+  testSessionOpenServerOptions,
+} from "./v2-auth-test-helpers.ts";
+
+describe("v2-conflict-scope", () => {
+  for (const scope of ["space", "user", "session"] as const) {
+    it(`returns the conflicting ${scope} instance when another scope shares its ID`, async () => {
+      const server = new Server({
+        store: new URL("memory://conflict-scope"),
+        subscriptionRefreshDelayMs: "manual",
+        ...testSessionOpenServerOptions,
+      });
+      const client = await connect({ transport: loopback(server) });
+      try {
+        const session = await client.mount(
+          "did:key:conflict-scope",
+          {},
+          testSessionOpenAuthFactory,
+        );
+        const scopes: CellScope[] = ["space", "user", "session"];
+        const seeded = await session.transact({
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: scopes.map((scope) => ({
+            op: "set",
+            id: "of:shared-id",
+            scope,
+            value: { value: scope },
+          })),
+        });
+        const otherScope = scope === "space" ? "user" : "space";
+        await expect(session.transact({
+          localSeq: 2,
+          reads: {
+            confirmed: [{
+              id: "of:shared-id",
+              scope: otherScope,
+              path: toDocumentPath(["value"]),
+              seq: seeded.seq,
+            }, {
+              id: "of:shared-id",
+              scope,
+              path: toDocumentPath(["value"]),
+              seq: 0,
+            }],
+            pending: [],
+          },
+          operations: [{
+            op: "set",
+            id: "of:separate-output",
+            value: { value: "updated" },
+          }],
+        })).rejects.toMatchObject({
+          name: "ConflictError",
+          conflict: { of: "of:shared-id", scope },
+          retryAfterSeq: seeded.seq,
+        });
+      } finally {
+        await client.close();
+        await server.close();
+      }
+    });
+  }
+});

--- a/packages/memory/test/v2-engine.test.ts
+++ b/packages/memory/test/v2-engine.test.ts
@@ -1276,12 +1276,10 @@ Deno.test("memory v2 engine conflicts are scoped by declared scope", async () =>
   }
 });
 
-Deno.test("memory v2 engine: stale-read ConflictError carries the conflicted entity structurally and in the message", async () => {
-  // CT-1824 contract: a stale-read ConflictError must name the conflicted
-  // entity structurally (of/scope/seq/conflictSeq) and in the message with
-  // this exact shape. The wire response preserves the scoped address; older
-  // peers rely on the diagnostic parsed by runner storage/v2.ts's
-  // toRejectedError. Both surfaces support conflict recovery for blind writes.
+Deno.test("memory v2 engine: stale-read ConflictError carries every conflicted entity structurally and in the message", async () => {
+  // A stale-read ConflictError names every conflicted entity structurally and
+  // in the message. The message is also a compatibility surface for transports
+  // that retain only standard Error fields.
 
   const { engine, path } = await createEngine();
   const sessionId = "session:alice";
@@ -1298,6 +1296,10 @@ Deno.test("memory v2 engine: stale-read ConflictError carries the conflicted ent
           op: "set",
           id: "entity:stale-named",
           value: toEntityDocument({ v: 1 }),
+        }, {
+          op: "set",
+          id: "entity:also-stale",
+          value: toEntityDocument({ v: 1 }),
         }],
       },
     });
@@ -1311,6 +1313,10 @@ Deno.test("memory v2 engine: stale-read ConflictError carries the conflicted ent
           op: "set",
           id: "entity:stale-named",
           value: toEntityDocument({ v: 2 }),
+        }, {
+          op: "set",
+          id: "entity:also-stale",
+          value: toEntityDocument({ v: 2 }),
         }],
       },
     });
@@ -1323,11 +1329,18 @@ Deno.test("memory v2 engine: stale-read ConflictError carries the conflicted ent
           commit: {
             localSeq: 3,
             reads: {
-              confirmed: [{
-                id: "entity:stale-named",
-                path: toDocumentPath(["value"]),
-                seq: 1,
-              }],
+              confirmed: [
+                {
+                  id: "entity:stale-named",
+                  path: toDocumentPath(["value"]),
+                  seq: 1,
+                },
+                {
+                  id: "entity:also-stale",
+                  path: toDocumentPath(["value"]),
+                  seq: 1,
+                },
+              ],
               pending: [],
             },
             operations: [{
@@ -1343,14 +1356,19 @@ Deno.test("memory v2 engine: stale-read ConflictError carries the conflicted ent
     assertEquals(error.scope, "space");
     assertEquals(error.seq, 1);
     assertEquals(error.conflictSeq, 2);
-    assertMatch(
-      error.message,
-      /^stale confirmed read: \S+ at seq \d+ conflicted with seq \d+$/,
-    );
-    // The exact parse the runner client performs on the wire-crossed message.
     assertEquals(
-      error.message.match(/stale confirmed read: (\S+) at seq/)?.[1],
-      "entity:stale-named",
+      error.conflicts,
+      [
+        { of: "entity:stale-named", scope: "space", seq: 1, conflictSeq: 2 },
+        { of: "entity:also-stale", scope: "space", seq: 1, conflictSeq: 2 },
+      ],
+    );
+    assertEquals(
+      Array.from(
+        error.message.matchAll(/stale confirmed read: (\S+) at seq/g),
+        (match) => match[1],
+      ),
+      ["entity:stale-named", "entity:also-stale"],
     );
   } finally {
     close(engine);

--- a/packages/memory/test/v2-engine.test.ts
+++ b/packages/memory/test/v2-engine.test.ts
@@ -1276,10 +1276,9 @@ Deno.test("memory v2 engine conflicts are scoped by declared scope", async () =>
   }
 });
 
-Deno.test("memory v2 engine: stale-read ConflictError carries every conflicted entity structurally and in the message", async () => {
-  // A stale-read ConflictError names every conflicted entity structurally and
-  // in the message. The message is also a compatibility surface for transports
-  // that retain only standard Error fields.
+Deno.test("memory v2 engine: stale-read ConflictError carries every conflicted entity and previews them in the message", async () => {
+  // The message preview is a compatibility surface for transports that retain
+  // only standard Error fields. The structured array includes every stale read.
 
   const { engine, path } = await createEngine();
   const sessionId = "session:alice";

--- a/packages/memory/test/v2-engine.test.ts
+++ b/packages/memory/test/v2-engine.test.ts
@@ -1278,12 +1278,10 @@ Deno.test("memory v2 engine conflicts are scoped by declared scope", async () =>
 
 Deno.test("memory v2 engine: stale-read ConflictError carries the conflicted entity structurally and in the message", async () => {
   // CT-1824 contract: a stale-read ConflictError must name the conflicted
-  // entity BOTH structurally (of/seq/conflictSeq — read in-process by
-  // editWithRetry's pull) AND in the message with this exact shape — server
-  // Error fields do not survive serialization to the browser, so the runner
-  // client re-derives `of` by parsing the message (runner storage/v2.ts
-  // toRejectedError). Changing either surface breaks conflict recovery for
-  // blind writes.
+  // entity structurally (of/scope/seq/conflictSeq) and in the message with
+  // this exact shape. The wire response preserves the scoped address; older
+  // peers rely on the diagnostic parsed by runner storage/v2.ts's
+  // toRejectedError. Both surfaces support conflict recovery for blind writes.
 
   const { engine, path } = await createEngine();
   const sessionId = "session:alice";
@@ -1342,6 +1340,7 @@ Deno.test("memory v2 engine: stale-read ConflictError carries the conflicted ent
       ConflictError,
     );
     assertEquals(error.of, "entity:stale-named");
+    assertEquals(error.scope, "space");
     assertEquals(error.seq, 1);
     assertEquals(error.conflictSeq, 2);
     assertMatch(

--- a/packages/memory/test/v2-engine.test.ts
+++ b/packages/memory/test/v2-engine.test.ts
@@ -1278,7 +1278,7 @@ Deno.test("memory v2 engine conflicts are scoped by declared scope", async () =>
 
 Deno.test("memory v2 engine: stale-read ConflictError carries every conflicted entity and previews them in the message", async () => {
   // The message preview is a compatibility surface for transports that retain
-  // only standard Error fields. The structured array includes every stale read.
+  // only standard Error fields. The structured array includes every stale instance.
 
   const { engine, path } = await createEngine();
   const sessionId = "session:alice";

--- a/packages/memory/test/v2-server.test.ts
+++ b/packages/memory/test/v2-server.test.ts
@@ -3110,6 +3110,10 @@ Deno.test("memory v2 server returns conflicts before deferred caught-up session 
           op: "set",
           id: "of:doc:1",
           value: { value: { version: 1 } },
+        }, {
+          op: "set",
+          id: "of:doc:2",
+          value: { value: { version: 1 } },
         }],
       },
     }));
@@ -3130,6 +3134,10 @@ Deno.test("memory v2 server returns conflicts before deferred caught-up session 
           op: "set",
           id: "of:doc:1",
           value: { value: { version: 3 } },
+        }, {
+          op: "set",
+          id: "of:doc:2",
+          value: { value: { version: 3 } },
         }],
       },
     }));
@@ -3144,11 +3152,18 @@ Deno.test("memory v2 server returns conflicts before deferred caught-up session 
       commit: {
         localSeq: 3,
         reads: {
-          confirmed: [{
-            id: "of:doc:1",
-            path: [],
-            seq: 1,
-          }],
+          confirmed: [
+            {
+              id: "of:doc:1",
+              path: [],
+              seq: 1,
+            },
+            {
+              id: "of:doc:2",
+              path: [],
+              seq: 1,
+            },
+          ],
           pending: [],
         },
         operations: [{
@@ -3163,9 +3178,14 @@ Deno.test("memory v2 server returns conflicts before deferred caught-up session 
     assertEquals(rejected.requestId, "tx-3");
     assertEquals(rejected.error, {
       name: "ConflictError",
-      message: "stale confirmed read: of:doc:1 at seq 1 conflicted with seq 2",
+      message:
+        "stale confirmed read: of:doc:1 at seq 1 conflicted with seq 2; " +
+        "stale confirmed read: of:doc:2 at seq 1 conflicted with seq 2",
       retryAfterSeq: 2,
-      conflict: { of: "of:doc:1", scope: "space" },
+      conflicts: [
+        { of: "of:doc:1", scope: "space", seq: 1, conflictSeq: 2 },
+        { of: "of:doc:2", scope: "space", seq: 1, conflictSeq: 2 },
+      ],
     });
     assertEquals(messages.length, 0);
 
@@ -3402,7 +3422,7 @@ Deno.test("memory v2 server processes back-to-back websocket messages in receive
       name: "ConflictError",
       message: "stale confirmed read: of:doc:1 at seq 1 conflicted with seq 2",
       retryAfterSeq: 2,
-      conflict: { of: "of:doc:1", scope: "space" },
+      conflicts: [{ of: "of:doc:1", scope: "space", seq: 1, conflictSeq: 2 }],
     });
     assertEquals(messages.length, 0);
 

--- a/packages/memory/test/v2-server.test.ts
+++ b/packages/memory/test/v2-server.test.ts
@@ -3165,6 +3165,7 @@ Deno.test("memory v2 server returns conflicts before deferred caught-up session 
       name: "ConflictError",
       message: "stale confirmed read: of:doc:1 at seq 1 conflicted with seq 2",
       retryAfterSeq: 2,
+      conflict: { of: "of:doc:1", scope: "space" },
     });
     assertEquals(messages.length, 0);
 
@@ -3401,6 +3402,7 @@ Deno.test("memory v2 server processes back-to-back websocket messages in receive
       name: "ConflictError",
       message: "stale confirmed read: of:doc:1 at seq 1 conflicted with seq 2",
       retryAfterSeq: 2,
+      conflict: { of: "of:doc:1", scope: "space" },
     });
     assertEquals(messages.length, 0);
 

--- a/packages/memory/test/v2/engine-conflicts.test.ts
+++ b/packages/memory/test/v2/engine-conflicts.test.ts
@@ -3,11 +3,16 @@ import { toFileUrl } from "@std/path";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { spy } from "@std/testing/mock";
 
-import { type ConfirmedRead, toDocumentPath } from "../../v2.ts";
+import {
+  type ConfirmedRead,
+  DEFAULT_BRANCH,
+  toDocumentPath,
+} from "../../v2.ts";
 import {
   applyCommit,
   close,
   ConflictError,
+  createBranch,
   type Engine,
   open,
   ProtocolError,
@@ -100,6 +105,57 @@ describe("engine-conflicts", () => {
     expect(() => commitReads([read, { ...read, seq: 0 }])).toThrow(
       ConflictError,
     );
+  });
+
+  it("retains distinct branches while deduplicating repeated reads on each branch", () => {
+    createBranch(engine, "feature");
+    for (const [index, branch] of [DEFAULT_BRANCH, "feature"].entries()) {
+      applyCommit(engine, {
+        sessionId: "session:branch-updates",
+        commit: {
+          localSeq: index + 1,
+          branch,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: ids[0],
+            value: { value: { a: 10, b: 20 } },
+          }],
+        },
+      });
+    }
+    using scans = spy(engine.statements.selectSetDeleteConflict, "get");
+    let caught: unknown;
+    try {
+      commitReads(
+        ["feature", DEFAULT_BRANCH].flatMap((branch) =>
+          ["a", "b"].map((key) => ({
+            id: ids[0],
+            branch,
+            path: toDocumentPath(["value", key]),
+            seq: 1,
+          }))
+        ),
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(ConflictError);
+    const error = caught as ConflictError;
+    expect(error.conflicts).toEqual([{
+      of: ids[0],
+      scope: "space",
+      branch: "feature",
+      seq: 1,
+      conflictSeq: 3,
+    }, {
+      of: ids[0],
+      scope: "space",
+      seq: 1,
+      conflictSeq: 2,
+    }]);
+    expect(error.branch).toBe("feature");
+    expect(scans.calls).toHaveLength(2);
   });
 
   it("keeps the first stale path's sequences and skips later patch scans", () => {

--- a/packages/memory/test/v2/engine-conflicts.test.ts
+++ b/packages/memory/test/v2/engine-conflicts.test.ts
@@ -1,0 +1,101 @@
+import { expect } from "@std/expect";
+import { toFileUrl } from "@std/path";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+
+import { type ConfirmedRead, toDocumentPath } from "../../v2.ts";
+import {
+  applyCommit,
+  close,
+  ConflictError,
+  type Engine,
+  open,
+} from "../../v2/engine.ts";
+
+describe("engine", () => {
+  let engine: Engine;
+  let path: string;
+  const sessionId = "session:conflict-diagnostics";
+  const ids = Array.from({ length: 6 }, (_, index) => `of:stale-${index}`);
+
+  beforeEach(async () => {
+    path = await Deno.makeTempFile({ suffix: ".sqlite" });
+    engine = await open({ url: toFileUrl(path) });
+    applyCommit(engine, {
+      sessionId,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: ids.map((id) => ({
+          op: "set",
+          id,
+          value: { value: { a: 1, b: 2 } },
+        })),
+      },
+    });
+  });
+
+  afterEach(async () => {
+    close(engine);
+    await Deno.remove(path);
+  });
+
+  const commitReads = (confirmed: ConfirmedRead[]) =>
+    applyCommit(engine, {
+      sessionId,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed, pending: [] },
+        operations: [{
+          op: "set",
+          id: "of:output",
+          value: { value: "updated" },
+        }],
+      },
+    });
+
+  it("bounds and deduplicates the diagnostic while retaining every stale path read", () => {
+    const reads = ids.flatMap((id) =>
+      ["a", "b"].map((key) => ({
+        id,
+        path: toDocumentPath(["value", key]),
+        seq: 0,
+      }))
+    );
+    let caught: unknown;
+    try {
+      commitReads(reads);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(ConflictError);
+    const error = caught as ConflictError;
+    expect(error.conflicts).toEqual(reads.map(({ id }) => ({
+      of: id,
+      scope: "space",
+      seq: 0,
+      conflictSeq: 1,
+    })));
+    expect(error.message).toBe(
+      ids.slice(0, 3).map((id) =>
+        `stale confirmed read: ${id} at seq 0 conflicted with seq 1`
+      ).join("; ") + "; 3 more conflicts",
+    );
+  });
+
+  for (const invalidFirst of [false, true]) {
+    it(`rejects an unknown branch ${invalidFirst ? "before" : "after"} a stale read without reporting a retryable conflict`, () => {
+      const stale = { id: ids[0], path: toDocumentPath(["value"]), seq: 0 };
+      const invalid = { ...stale, branch: "missing" };
+      const reads = invalidFirst ? [invalid, stale] : [stale, invalid];
+      let caught: unknown;
+      try {
+        commitReads(reads);
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect(caught).not.toBeInstanceOf(ConflictError);
+      expect(caught).toHaveProperty("message", "unknown branch: missing");
+    });
+  }
+});

--- a/packages/memory/test/v2/engine-conflicts.test.ts
+++ b/packages/memory/test/v2/engine-conflicts.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "@std/expect";
 import { toFileUrl } from "@std/path";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { spy } from "@std/testing/mock";
 
 import { type ConfirmedRead, toDocumentPath } from "../../v2.ts";
 import {
@@ -9,9 +10,10 @@ import {
   ConflictError,
   type Engine,
   open,
+  ProtocolError,
 } from "../../v2/engine.ts";
 
-describe("engine", () => {
+describe("engine-conflicts", () => {
   let engine: Engine;
   let path: string;
   const sessionId = "session:conflict-diagnostics";
@@ -53,33 +55,89 @@ describe("engine", () => {
       },
     });
 
-  it("bounds and deduplicates the diagnostic while retaining every stale path read", () => {
-    const reads = ids.flatMap((id) =>
-      ["a", "b"].map((key) => ({
-        id,
-        path: toDocumentPath(["value", key]),
+  for (
+    const [count, remainder] of [[4, "1 more conflict"], [
+      6,
+      "3 more conflicts",
+    ]] as const
+  ) {
+    it(`scans each of ${count} stale instances once and bounds its diagnostic`, () => {
+      const staleIds = ids.slice(0, count);
+      const reads = staleIds.flatMap((id) =>
+        ["a", "b"].map((key, index) => ({
+          id,
+          scope: index === 0 ? undefined : "space" as const,
+          path: toDocumentPath(["value", key]),
+          seq: 0,
+        }))
+      );
+      using scans = spy(engine.statements.selectSetDeleteConflict, "get");
+      let caught: unknown;
+      try {
+        commitReads(reads);
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(ConflictError);
+      const error = caught as ConflictError;
+      expect(error.conflicts).toEqual(staleIds.map((id) => ({
+        of: id,
+        scope: "space",
         seq: 0,
-      }))
+        conflictSeq: 1,
+      })));
+      expect(scans.calls).toHaveLength(count);
+      expect(error.message).toBe(
+        staleIds.slice(0, 3).map((id) =>
+          `stale confirmed read: ${id} at seq 0 conflicted with seq 1`
+        ).join("; ") + `; ${remainder}`,
+      );
+    });
+  }
+
+  it("continues scanning an instance until a stale read is found", () => {
+    const read = { id: ids[0], path: toDocumentPath(["value"]), seq: 1 };
+    expect(() => commitReads([read, { ...read, seq: 0 }])).toThrow(
+      ConflictError,
     );
+  });
+
+  it("keeps the first stale path's sequences and skips later patch scans", () => {
+    for (const [index, key] of ["a", "b"].entries()) {
+      applyCommit(engine, {
+        sessionId: "session:updates",
+        commit: {
+          localSeq: index + 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "patch",
+            id: ids[0],
+            patches: [{ op: "replace", path: `/value/${key}`, value: 10 }],
+          }],
+        },
+      });
+    }
+    using scans = spy(engine.statements.selectSetDeleteConflict, "get");
+    using patches = spy(engine.statements.selectPatchConflicts, "iter");
     let caught: unknown;
     try {
-      commitReads(reads);
+      commitReads(["b", "a"].map((key) => ({
+        id: ids[0],
+        path: toDocumentPath(["value", key]),
+        seq: 1,
+      })));
     } catch (error) {
       caught = error;
     }
     expect(caught).toBeInstanceOf(ConflictError);
-    const error = caught as ConflictError;
-    expect(error.conflicts).toEqual(reads.map(({ id }) => ({
-      of: id,
+    expect((caught as ConflictError).conflicts).toEqual([{
+      of: ids[0],
       scope: "space",
-      seq: 0,
-      conflictSeq: 1,
-    })));
-    expect(error.message).toBe(
-      ids.slice(0, 3).map((id) =>
-        `stale confirmed read: ${id} at seq 0 conflicted with seq 1`
-      ).join("; ") + "; 3 more conflicts",
-    );
+      seq: 1,
+      conflictSeq: 3,
+    }]);
+    expect(scans.calls).toHaveLength(1);
+    expect(patches.calls).toHaveLength(1);
   });
 
   for (const invalidFirst of [false, true]) {
@@ -97,5 +155,14 @@ describe("engine", () => {
       expect(caught).not.toBeInstanceOf(ConflictError);
       expect(caught).toHaveProperty("message", "unknown branch: missing");
     });
+
+    for (const scope of ["user", "session"] as const) {
+      it(`rejects unresolvable ${scope} scope ${invalidFirst ? "before" : "after"} a stale read`, () => {
+        const stale = { id: ids[0], path: toDocumentPath(["value"]), seq: 0 };
+        const invalid = { ...stale, scope };
+        const reads = invalidFirst ? [invalid, stale] : [stale, invalid];
+        expect(() => commitReads(reads)).toThrow(ProtocolError);
+      });
+    }
   }
 });

--- a/packages/memory/test/v2/engine-conflicts.test.ts
+++ b/packages/memory/test/v2/engine-conflicts.test.ts
@@ -107,6 +107,45 @@ describe("engine-conflicts", () => {
     );
   });
 
+  it("keeps addresses containing delimiter characters distinct", () => {
+    const addresses = [
+      { branch: "feature", id: "left\u0000space\u0000right" },
+      { branch: "feature\u0000space\u0000left", id: "right" },
+    ];
+    for (const { branch } of addresses) createBranch(engine, branch);
+    for (const [index, { branch, id }] of addresses.entries()) {
+      applyCommit(engine, {
+        sessionId: "session:delimiter-updates",
+        commit: {
+          localSeq: index + 1,
+          branch,
+          reads: { confirmed: [], pending: [] },
+          operations: [{ op: "set", id, value: { value: 1 } }],
+        },
+      });
+    }
+    let caught: unknown;
+    try {
+      commitReads(addresses.map((address) => ({
+        ...address,
+        path: toDocumentPath(["value"]),
+        seq: 1,
+      })));
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(ConflictError);
+    expect((caught as ConflictError).conflicts).toEqual(
+      addresses.map(({ branch, id }, index) => ({
+        of: id,
+        scope: "space",
+        branch,
+        seq: 1,
+        conflictSeq: index + 2,
+      })),
+    );
+  });
+
   it("retains distinct branches while deduplicating repeated reads on each branch", () => {
     createBranch(engine, "feature");
     for (const [index, branch] of [DEFAULT_BRANCH, "feature"].entries()) {
@@ -156,6 +195,9 @@ describe("engine-conflicts", () => {
     }]);
     expect(error.branch).toBe("feature");
     expect(scans.calls).toHaveLength(2);
+    expect(error.message).toBe(
+      `stale confirmed read: ${ids[0]} at seq 1 conflicted with seq 3`,
+    );
   });
 
   it("keeps the first stale path's sequences and skips later patch scans", () => {

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1735,6 +1735,9 @@ export type V2Error = {
   precondition?: string;
   retryAfterSeq?: number;
 
+  /** Scoped entity named by a stale confirmed read, resolved by the session. */
+  conflict?: { of: EntityId; scope: CellScope };
+
   /**
    * Present on an `AuthorizationError` that a fresh handshake can heal — the
    * connection-challenge and invocation-freshness anti-replay races (an expired,

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1735,10 +1735,12 @@ export type V2Error = {
   precondition?: string;
   retryAfterSeq?: number;
 
-  /** First stale confirmed read per entity and scope, resolved by the session. */
+  /** First stale confirmed read per branch, entity, and session-resolved scope. */
   conflicts?: Array<{
     of: string;
     scope: CellScope;
+    /** Absent for the default branch. */
+    branch?: BranchName;
     seq: number;
     conflictSeq: number;
   }>;

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1735,7 +1735,7 @@ export type V2Error = {
   precondition?: string;
   retryAfterSeq?: number;
 
-  /** Every stale confirmed read, with scope resolved by the session. */
+  /** First stale confirmed read per entity and scope, resolved by the session. */
   conflicts?: Array<{
     of: string;
     scope: CellScope;

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1735,8 +1735,13 @@ export type V2Error = {
   precondition?: string;
   retryAfterSeq?: number;
 
-  /** Scoped entity named by a stale confirmed read, resolved by the session. */
-  conflict?: { of: EntityId; scope: CellScope };
+  /** Every stale confirmed read, with scope resolved by the session. */
+  conflicts?: Array<{
+    of: string;
+    scope: CellScope;
+    seq: number;
+    conflictSeq: number;
+  }>;
 
   /**
    * Present on an `AuthorizationError` that a fresh handshake can heal — the

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -361,6 +361,9 @@ export class Client {
         (error as Error & { retryAfterSeq?: number }).retryAfterSeq =
           result.error.retryAfterSeq;
       }
+      if (result.error.conflict !== undefined) {
+        Object.assign(error, { conflict: result.error.conflict });
+      }
       if (result.error.retriable !== undefined) {
         (error as Error & { retriable?: boolean }).retriable =
           result.error.retriable;

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -361,8 +361,9 @@ export class Client {
         (error as Error & { retryAfterSeq?: number }).retryAfterSeq =
           result.error.retryAfterSeq;
       }
-      if (result.error.conflict !== undefined) {
-        Object.assign(error, { conflict: result.error.conflict });
+      if (result.error.conflicts !== undefined) {
+        (error as Error & { conflicts?: unknown }).conflicts =
+          result.error.conflicts;
       }
       if (result.error.retriable !== undefined) {
         (error as Error & { retriable?: boolean }).retriable =

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -1024,7 +1024,7 @@ export type Engine = {
   stagedDocumentCache?: Map<string, DocumentCacheEntry>;
 };
 
-/** A stale confirmed read, addressed within the committing session's scope. */
+/** The first stale confirmed read of an entity in the session's declared scope. */
 export type ConfirmedReadConflict = {
   of: string;
   scope: CellScope;
@@ -6171,10 +6171,17 @@ const validateConfirmedReads = (
   // against that writer identity, even when the read points at another branch.
   // Cross-branch reads inherit this same principal context.
   const conflicts: ConfirmedReadConflict[] = [];
+  const staleIdsByScope = new Map<CellScope, Set<EntityId>>();
   for (const read of commit.reads.confirmed) {
     const readBranch = read.branch ?? branch;
     ensureReadableBranch(engine, readBranch);
     const scopeKey = resolveScopeKey(read.scope, scopeContext);
+    const scope = read.scope ?? DEFAULT_SCOPE;
+    let staleIds = staleIdsByScope.get(scope);
+    // Further path scans cannot change a known-stale entity's recovery address.
+    // Every read still validates its branch and scope before skipping the scan,
+    // so invalid addresses take precedence over stale-read conflicts.
+    if (staleIds?.has(read.id)) continue;
     const conflictSeq = findConflictSeq(
       engine,
       readBranch,
@@ -6185,9 +6192,14 @@ const validateConfirmedReads = (
       read.nonRecursive ?? false,
     );
     if (conflictSeq !== null) {
+      if (staleIds === undefined) {
+        staleIds = new Set();
+        staleIdsByScope.set(scope, staleIds);
+      }
+      staleIds.add(read.id);
       conflicts.push({
         of: read.id,
-        scope: read.scope ?? DEFAULT_SCOPE,
+        scope,
         seq: read.seq,
         conflictSeq,
       });
@@ -6195,7 +6207,7 @@ const validateConfirmedReads = (
   }
   if (conflicts.length > 0) {
     // Keep diagnostics compact for repeated path reads and large transactions.
-    // The structured array carries every read; each preview clause retains the
+    // The array carries every stale instance; each preview clause retains the
     // entity/sequence grammar used by message-only clients to recover.
     const messages = [
       ...new Set(
@@ -6206,7 +6218,8 @@ const validateConfirmedReads = (
     ];
     const preview = messages.slice(0, 3);
     if (messages.length > preview.length) {
-      preview.push(`${messages.length - preview.length} more conflicts`);
+      const remaining = messages.length - preview.length;
+      preview.push(`${remaining} more conflict${remaining === 1 ? "" : "s"}`);
     }
     throw new ConflictError(preview.join("; "), conflicts);
   }

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -6175,17 +6175,18 @@ const validateConfirmedReads = (
   // against that writer identity, even when the read points at another branch.
   // Cross-branch reads inherit this same principal context.
   const conflicts: ConfirmedReadConflict[] = [];
-  const staleInstances = new Set<string>();
+  const staleInstances = new Map<BranchName, Map<ScopeKey, Set<EntityId>>>();
   for (const read of commit.reads.confirmed) {
     const readBranch = read.branch ?? branch;
     ensureReadableBranch(engine, readBranch);
     const scopeKey = resolveScopeKey(read.scope, scopeContext);
     const scope = read.scope ?? DEFAULT_SCOPE;
-    const key = revisionKey(readBranch, read.id, scopeKey);
+    let staleScopes = staleInstances.get(readBranch);
+    let staleIds = staleScopes?.get(scopeKey);
     // Further path scans cannot change a known-stale entity's recovery address.
     // Every read still validates its branch and scope before skipping the scan,
     // so invalid addresses take precedence over stale-read conflicts.
-    if (staleInstances.has(key)) continue;
+    if (staleIds?.has(read.id)) continue;
     const conflictSeq = findConflictSeq(
       engine,
       readBranch,
@@ -6196,7 +6197,15 @@ const validateConfirmedReads = (
       read.nonRecursive ?? false,
     );
     if (conflictSeq !== null) {
-      staleInstances.add(key);
+      if (staleScopes === undefined) {
+        staleScopes = new Map();
+        staleInstances.set(readBranch, staleScopes);
+      }
+      if (staleIds === undefined) {
+        staleIds = new Set();
+        staleScopes.set(scopeKey, staleIds);
+      }
+      staleIds.add(read.id);
       conflicts.push({
         of: read.id,
         scope,
@@ -6207,19 +6216,21 @@ const validateConfirmedReads = (
     }
   }
   if (conflicts.length > 0) {
-    // Keep diagnostics compact for repeated path reads and large transactions.
-    // The array carries every stale instance; each preview clause retains the
-    // entity/sequence grammar used by message-only clients to recover.
-    const messages = [
-      ...new Set(
-        conflicts.map(({ of, seq, conflictSeq }) =>
-          `stale confirmed read: ${of} at seq ${seq} conflicted with seq ${conflictSeq}`
-        ),
-      ),
-    ];
-    const preview = messages.slice(0, 3);
-    if (messages.length > preview.length) {
-      const remaining = messages.length - preview.length;
+    // Message-only clients recover by entity ID. Multiple scopes or branches
+    // of one entity must not crowd other entities out of the bounded preview.
+    // The array carries every stale instance and its diagnostic sequences.
+    const messages = new Map<EntityId, string>();
+    for (const { of, seq, conflictSeq } of conflicts) {
+      if (!messages.has(of)) {
+        messages.set(
+          of,
+          `stale confirmed read: ${of} at seq ${seq} conflicted with seq ${conflictSeq}`,
+        );
+      }
+    }
+    const preview = [...messages.values()].slice(0, 3);
+    if (messages.size > preview.length) {
+      const remaining = messages.size - preview.length;
       preview.push(`${remaining} more conflict${remaining === 1 ? "" : "s"}`);
     }
     throw new ConflictError(preview.join("; "), conflicts);

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -1033,26 +1033,34 @@ export class ConflictError extends Error {
 
   readonly seq?: number;
   readonly conflictSeq?: number;
-
+  readonly conflicts?: readonly ConfirmedReadConflict[];
   constructor(
     message: string,
-    details?: {
-      of: string;
-      scope?: CellScope;
-      seq: number;
-      conflictSeq: number;
-    },
+    details?: ConfirmedReadConflict | readonly ConfirmedReadConflict[],
   ) {
     super(message);
     this.name = "ConflictError";
-    if (details !== undefined) {
-      this.of = details.of;
-      this.seq = details.seq;
-      this.conflictSeq = details.conflictSeq;
-      this.scope = details.scope ?? DEFAULT_SCOPE;
+    const conflicts = details === undefined
+      ? undefined
+      : Array.isArray(details)
+      ? details as readonly ConfirmedReadConflict[]
+      : [details as ConfirmedReadConflict];
+    if (conflicts !== undefined && conflicts.length > 0) {
+      this.conflicts = [...conflicts];
+      this.of = conflicts[0].of;
+      this.scope = conflicts[0].scope;
+      this.seq = conflicts[0].seq;
+      this.conflictSeq = conflicts[0].conflictSeq;
     }
   }
 }
+
+export type ConfirmedReadConflict = {
+  of: string;
+  scope: CellScope;
+  seq: number;
+  conflictSeq: number;
+};
 
 export class PreconditionFailedError extends Error {
   readonly precondition: "origin-committed" | "receipt-exists";
@@ -6166,6 +6174,7 @@ const validateConfirmedReads = (
   // Every confirmed read in the commit resolves declared user/session scope
   // against that writer identity, even when the read points at another branch.
   // Cross-branch reads inherit this same principal context.
+  const conflicts: ConfirmedReadConflict[] = [];
   for (const read of commit.reads.confirmed) {
     const readBranch = read.branch ?? branch;
     ensureReadableBranch(engine, readBranch);
@@ -6180,11 +6189,21 @@ const validateConfirmedReads = (
       read.nonRecursive ?? false,
     );
     if (conflictSeq !== null) {
-      throw new ConflictError(
-        `stale confirmed read: ${read.id} at seq ${read.seq} conflicted with seq ${conflictSeq}`,
-        { of: read.id, scope: read.scope, seq: read.seq, conflictSeq },
-      );
+      conflicts.push({
+        of: read.id,
+        scope: read.scope ?? DEFAULT_SCOPE,
+        seq: read.seq,
+        conflictSeq,
+      });
     }
+  }
+  if (conflicts.length > 0) {
+    throw new ConflictError(
+      conflicts.map(({ of, seq, conflictSeq }) =>
+        `stale confirmed read: ${of} at seq ${seq} conflicted with seq ${conflictSeq}`
+      ).join("; "),
+      conflicts,
+    );
   }
 };
 

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -1024,10 +1024,12 @@ export type Engine = {
   stagedDocumentCache?: Map<string, DocumentCacheEntry>;
 };
 
-/** The first stale confirmed read of an entity in the session's declared scope. */
+/** The first stale confirmed read of an entity on a branch in a declared scope. */
 export type ConfirmedReadConflict = {
   of: string;
   scope: CellScope;
+  /** Absent for the default branch. */
+  branch?: BranchName;
   seq: number;
   conflictSeq: number;
 };
@@ -1038,6 +1040,7 @@ export class ConflictError extends Error {
 
   /** Scope of the entity whose confirmed read went stale, when one is named. */
   readonly scope?: CellScope;
+  readonly branch?: BranchName;
 
   readonly seq?: number;
   readonly conflictSeq?: number;
@@ -1052,6 +1055,7 @@ export class ConflictError extends Error {
       this.conflicts = [...conflicts];
       this.of = conflicts[0].of;
       this.scope = conflicts[0].scope;
+      this.branch = conflicts[0].branch;
       this.seq = conflicts[0].seq;
       this.conflictSeq = conflicts[0].conflictSeq;
     }
@@ -6171,17 +6175,17 @@ const validateConfirmedReads = (
   // against that writer identity, even when the read points at another branch.
   // Cross-branch reads inherit this same principal context.
   const conflicts: ConfirmedReadConflict[] = [];
-  const staleIdsByScope = new Map<CellScope, Set<EntityId>>();
+  const staleInstances = new Set<string>();
   for (const read of commit.reads.confirmed) {
     const readBranch = read.branch ?? branch;
     ensureReadableBranch(engine, readBranch);
     const scopeKey = resolveScopeKey(read.scope, scopeContext);
     const scope = read.scope ?? DEFAULT_SCOPE;
-    let staleIds = staleIdsByScope.get(scope);
+    const key = revisionKey(readBranch, read.id, scopeKey);
     // Further path scans cannot change a known-stale entity's recovery address.
     // Every read still validates its branch and scope before skipping the scan,
     // so invalid addresses take precedence over stale-read conflicts.
-    if (staleIds?.has(read.id)) continue;
+    if (staleInstances.has(key)) continue;
     const conflictSeq = findConflictSeq(
       engine,
       readBranch,
@@ -6192,14 +6196,11 @@ const validateConfirmedReads = (
       read.nonRecursive ?? false,
     );
     if (conflictSeq !== null) {
-      if (staleIds === undefined) {
-        staleIds = new Set();
-        staleIdsByScope.set(scope, staleIds);
-      }
-      staleIds.add(read.id);
+      staleInstances.add(key);
       conflicts.push({
         of: read.id,
         scope,
+        ...(readBranch === DEFAULT_BRANCH ? {} : { branch: readBranch }),
         seq: read.seq,
         conflictSeq,
       });

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -1028,11 +1028,20 @@ export class ConflictError extends Error {
   /** Entity whose confirmed read went stale (stale-read conflicts only). */
   readonly of?: string;
 
+  /** Scope of the entity whose confirmed read went stale, when one is named. */
+  readonly scope?: CellScope;
+
   readonly seq?: number;
   readonly conflictSeq?: number;
+
   constructor(
     message: string,
-    details?: { of: string; seq: number; conflictSeq: number },
+    details?: {
+      of: string;
+      scope?: CellScope;
+      seq: number;
+      conflictSeq: number;
+    },
   ) {
     super(message);
     this.name = "ConflictError";
@@ -1040,6 +1049,7 @@ export class ConflictError extends Error {
       this.of = details.of;
       this.seq = details.seq;
       this.conflictSeq = details.conflictSeq;
+      this.scope = details.scope ?? DEFAULT_SCOPE;
     }
   }
 }
@@ -6172,7 +6182,7 @@ const validateConfirmedReads = (
     if (conflictSeq !== null) {
       throw new ConflictError(
         `stale confirmed read: ${read.id} at seq ${read.seq} conflicted with seq ${conflictSeq}`,
-        { of: read.id, seq: read.seq, conflictSeq },
+        { of: read.id, scope: read.scope, seq: read.seq, conflictSeq },
       );
     }
   }

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -1024,6 +1024,14 @@ export type Engine = {
   stagedDocumentCache?: Map<string, DocumentCacheEntry>;
 };
 
+/** A stale confirmed read, addressed within the committing session's scope. */
+export type ConfirmedReadConflict = {
+  of: string;
+  scope: CellScope;
+  seq: number;
+  conflictSeq: number;
+};
+
 export class ConflictError extends Error {
   /** Entity whose confirmed read went stale (stale-read conflicts only). */
   readonly of?: string;
@@ -1036,15 +1044,10 @@ export class ConflictError extends Error {
   readonly conflicts?: readonly ConfirmedReadConflict[];
   constructor(
     message: string,
-    details?: ConfirmedReadConflict | readonly ConfirmedReadConflict[],
+    conflicts?: readonly ConfirmedReadConflict[],
   ) {
     super(message);
     this.name = "ConflictError";
-    const conflicts = details === undefined
-      ? undefined
-      : Array.isArray(details)
-      ? details as readonly ConfirmedReadConflict[]
-      : [details as ConfirmedReadConflict];
     if (conflicts !== undefined && conflicts.length > 0) {
       this.conflicts = [...conflicts];
       this.of = conflicts[0].of;
@@ -1054,13 +1057,6 @@ export class ConflictError extends Error {
     }
   }
 }
-
-export type ConfirmedReadConflict = {
-  of: string;
-  scope: CellScope;
-  seq: number;
-  conflictSeq: number;
-};
 
 export class PreconditionFailedError extends Error {
   readonly precondition: "origin-committed" | "receipt-exists";
@@ -6198,12 +6194,21 @@ const validateConfirmedReads = (
     }
   }
   if (conflicts.length > 0) {
-    throw new ConflictError(
-      conflicts.map(({ of, seq, conflictSeq }) =>
-        `stale confirmed read: ${of} at seq ${seq} conflicted with seq ${conflictSeq}`
-      ).join("; "),
-      conflicts,
-    );
+    // Keep diagnostics compact for repeated path reads and large transactions.
+    // The structured array carries every read; each preview clause retains the
+    // entity/sequence grammar used by message-only clients to recover.
+    const messages = [
+      ...new Set(
+        conflicts.map(({ of, seq, conflictSeq }) =>
+          `stale confirmed read: ${of} at seq ${seq} conflicted with seq ${conflictSeq}`
+        ),
+      ),
+    ];
+    const preview = messages.slice(0, 3);
+    if (messages.length > preview.length) {
+      preview.push(`${messages.length - preview.length} more conflicts`);
+    }
+    throw new ConflictError(preview.join("; "), conflicts);
   }
 };
 

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -4043,6 +4043,12 @@ export class Server {
           if (retryAfterSeq !== undefined) {
             responseError.retryAfterSeq = retryAfterSeq;
           }
+          if (
+            error instanceof Engine.ConflictError &&
+            error.of !== undefined && error.scope !== undefined
+          ) {
+            responseError.conflict = { of: error.of, scope: error.scope };
+          }
           span.recordException(
             error instanceof Error ? error : new Error(messageText),
           );

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -4045,9 +4045,10 @@ export class Server {
           }
           if (
             error instanceof Engine.ConflictError &&
-            error.of !== undefined && error.scope !== undefined
+            error.conflicts !== undefined &&
+            error.conflicts.length > 0
           ) {
-            responseError.conflict = { of: error.of, scope: error.scope };
+            responseError.conflicts = [...error.conflicts];
           }
           span.recordException(
             error instanceof Error ? error : new Error(messageText),

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -799,11 +799,10 @@ function withCompileCacheBuiltin<T>(
  * not a traversal edge — so this schema pulls exactly the doc plus its edge
  * element docs and stops. A schema-less `sync()` normalizes to the rejecting
  * selector and delivers only the root, leaving the element docs unknown to
- * the replica — then the re-write touches them blind and the engine reveals
- * the conflicts one per commit attempt (the CT-1824 loop; the write-back's
- * retry budget converges it, one round per edge doc). With the element docs
- * client-known up front, the re-write diffs against true state and commits
- * on the first attempt. Recursion is deliberately omitted: the write-target
+ * the replica — then the re-write touches them blind and needs a rejected
+ * commit plus conflict repair. With the element docs client-known up front,
+ * the re-write diffs against true state and commits on the first attempt.
+ * Recursion is deliberately omitted: the write-target
  * pre-sync enumerates every module doc itself, so each doc only needs its
  * own edges — nothing beyond the write set loads (the lazy-by-default
  * posture for code docs is untouched).

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -2967,15 +2967,15 @@ export class PatternManager {
     for (const chunk of chunks) {
       // The write-back re-writes source docs whose values carry quote-cell
       // indirections (one derived doc per import edge). On a cold replica
-      // those derived docs are unknown. The engine reports every stale read
+      // those derived docs are unknown. The engine reports every stale instance
       // in one rejection and editWithRetry pulls the whole named set before
       // re-running. Further retries remain possible when a re-run reaches a
       // new dependency layer or another writer advances a document again.
       // The edge-proportional budget is conservative headroom for those
       // additional layers and concurrent writes, not one retry per edge.
-      // A conflict-free write-back commits on its first attempt. Single-chunk
-      // write-backs have a floor of 16 retries; multiple chunks each receive
-      // eight retries of slack on top of their edge-proportional share.
+      // A conflict-free write-back commits on its first attempt. Applying the
+      // floor per chunk would multiply the minimum budget by the chunk count,
+      // so only a single-chunk write-back receives the full floor.
       const importEdges = chunk.reduce((n, m) => n + m.imports.length, 0);
       const writebackMaxRetries = chunks.length === 1
         ? Math.max(16, 2 * importEdges + 8)

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -2971,18 +2971,11 @@ export class PatternManager {
       // in one rejection and editWithRetry pulls the whole named set before
       // re-running. Further retries remain possible when a re-run reaches a
       // new dependency layer or another writer advances a document again.
-      // Budget by the chunk's edge count (source + compiled edge docs) with
-      // slack. A conflict-free write-back still commits on the first attempt,
-      // so the ceiling is only paid during recovery after a compiler-version
-      // bump.
-      //
-      // The historical fixed floor (16) is NOT applied per chunk — that would
-      // multiply the minimum by chunk count (six low-edge chunks = 96 retries
-      // vs the old closure-wide 16; Codex review on #5094). A single-chunk
-      // write-back keeps the exact historical budget; a multi-chunk one gives
-      // each chunk its edge-proportional share plus one round of slack, so
-      // the aggregate stays >= 16 (8 * 2 chunks minimum) without the 16x
-      // chunk-count inflation.
+      // The edge-proportional budget is conservative headroom for those
+      // additional layers and concurrent writes, not one retry per edge.
+      // A conflict-free write-back commits on its first attempt. Single-chunk
+      // write-backs have a floor of 16 retries; multiple chunks each receive
+      // eight retries of slack on top of their edge-proportional share.
       const importEdges = chunk.reduce((n, m) => n + m.imports.length, 0);
       const writebackMaxRetries = chunks.length === 1
         ? Math.max(16, 2 * importEdges + 8)

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -2967,19 +2967,14 @@ export class PatternManager {
     for (const chunk of chunks) {
       // The write-back re-writes source docs whose values carry quote-cell
       // indirections (one derived doc per import edge). On a cold replica
-      // those derived docs are unknown, and each commit attempt discovers
-      // exactly ONE of them: the engine rejects on the first stale read,
-      // editWithRetry pulls that doc, and only then does the next attempt's
-      // diff reach the following one (CT-1824, live-traced on the browser
-      // rig — the system-app closure re-write conflicts on ~24 pre-existing
-      // edge docs, one per round). Convergence therefore needs one retry per
-      // pre-existing derived doc; the general DEFAULT_MAX_RETRIES (5)
-      // exhausts long before that and the cache never heals, so every later
-      // cold boot recompiles. Budget by the chunk's edge count (source +
-      // compiled edge docs) with slack. Rounds are bounded by actual
-      // conflicts — a conflict-free write-back still commits on the first
-      // attempt — so the ceiling is only paid during recovery after a
-      // compiler-version bump.
+      // those derived docs are unknown. The engine reports every stale read
+      // in one rejection and editWithRetry pulls the whole named set before
+      // re-running. Further retries remain possible when a re-run reaches a
+      // new dependency layer or another writer advances a document again.
+      // Budget by the chunk's edge count (source + compiled edge docs) with
+      // slack. A conflict-free write-back still commits on the first attempt,
+      // so the ceiling is only paid during recovery after a compiler-version
+      // bump.
       //
       // The historical fixed floor (16) is NOT applied per chunk — that would
       // multiply the minimum by chunk count (six low-edge chunks = 96 retries
@@ -3032,11 +3027,10 @@ export class PatternManager {
    * Pre-syncs the write targets, carrying the one-hop edge selector: a
    * schema-less sync delivers only the root doc, leaving the per-edge element
    * docs unknown to the replica, so a re-write of pre-existing docs touches
-   * them blind and conflicts one engine round per edge. With the edge docs
-   * materialized up front the write-back diffs against true state and commits
-   * on the first attempt; the retry budget in `#writeBackCompileCache()`
-   * remains as a backstop. Same-microtask syncs batch into a single server
-   * round trip.
+   * them blind and needs conflict repair. With the edge docs materialized up
+   * front the write-back diffs against true state and commits on the first
+   * attempt; the retry budget in `#writeBackCompileCache()` remains as a
+   * backstop. Same-microtask syncs batch into a single server round trip.
    */
   async #syncSourceCacheWriteTargets(
     space: MemorySpace,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -150,6 +150,7 @@ import {
 } from "./storage/reactivity-log.ts";
 import { isRetryableCommitRejection } from "./storage/rejection.ts";
 import { isCellScope, normalizeCellScope, scopeRank } from "./scope.ts";
+import { entityNameKey } from "./scheduler/keys.ts";
 import { toURI } from "./uri-utils.ts";
 import { normalizeSpaceHost, SpaceHostValidationError } from "./space-host.ts";
 import { flattenBuilderArtifacts } from "./storage-preflight.ts";
@@ -2827,10 +2828,10 @@ export class Runtime {
    * this replica never READ does not arrive with it — and a conflicted blind
    * WRITE means exactly that (the compile-cache write-back rewrites derived
    * docs a cold replica has never seen; a piece start's basis names computed
-   * docs the serving side was materializing). So the named doc is pulled
-   * in the conflict's scope too, and the retry's write carries its true
-   * version instead of re-asserting seq 0. Errors without scope use the
-   * default space instance.
+   * docs the serving side was materializing). So every document named by the
+   * rejection is pulled concurrently in its scope, and the retry's writes
+   * carry their true versions instead of re-asserting seq 0. Entries without
+   * scope use the default space instance.
    *
    * Every step is best-effort by design: this resolves rather than throws,
    * because the retry's commit — not this readiness — is what decides.
@@ -2869,25 +2870,53 @@ export class Runtime {
       }
     }
     if (teardownSignal?.aborted) return;
-    const conflict = (error as {
+    const rejection = error as {
       conflict?: { space?: MemorySpace; of?: string; scope?: CellScope };
-    })?.conflict;
-    if (
-      conflict?.space !== undefined &&
-      typeof conflict.of === "string" &&
-      conflict.of !== "of:unknown"
-    ) {
+      conflicts?: Array<{
+        space?: MemorySpace;
+        of?: string;
+        scope?: CellScope;
+      }>;
+    };
+    const conflicts = Array.isArray(rejection?.conflicts) &&
+        rejection.conflicts.length > 0
+      ? rejection.conflicts
+      : rejection?.conflict === undefined
+      ? []
+      : [rejection.conflict];
+    const pulls: Promise<unknown>[] = [];
+    const seen = new Set<string>();
+    for (const conflict of conflicts) {
+      if (
+        conflict.space === undefined ||
+        typeof conflict.of !== "string" ||
+        conflict.of === "of:unknown"
+      ) {
+        continue;
+      }
+      const key = entityNameKey({
+        space: conflict.space,
+        id: conflict.of as URI,
+        scope: conflict.scope,
+      });
+      if (seen.has(key)) continue;
+      seen.add(key);
       try {
-        await waitUnlessTeardown(
-          this.storageManager.open(conflict.space).sync(
-            conflict.of as unknown as URI,
-            { path: [], schema: false },
-            conflict.scope,
-          ),
+        pulls.push(
+          Promise.resolve(
+            this.storageManager.open(conflict.space).sync(
+              conflict.of as unknown as URI,
+              { path: [], schema: false },
+              conflict.scope,
+            ),
+          ).catch(() => undefined),
         );
       } catch {
-        // Pull failed — the retry's commit decides.
+        // A synchronous pull failure leaves the retry's commit to decide.
       }
+    }
+    if (pulls.length > 0) {
+      await waitUnlessTeardown(Promise.all(pulls));
     }
   }
 

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -2831,7 +2831,8 @@ export class Runtime {
    * docs the serving side was materializing). So every document named by the
    * rejection is pulled concurrently in its scope, and the retry's writes
    * carry their true versions instead of re-asserting seq 0. Entries without
-   * scope use the default space instance.
+   * scope use the default space instance. If no array entry names a usable
+   * address, the singular conflict supplies the recovery target.
    *
    * Every step is best-effort by design: this resolves rather than throws,
    * because the retry's commit — not this readiness — is what decides.
@@ -2870,33 +2871,28 @@ export class Runtime {
       }
     }
     if (teardownSignal?.aborted) return;
-    const rejection = error as {
-      conflict?: { space?: MemorySpace; of?: string; scope?: CellScope };
-      conflicts?: Array<{
-        space?: MemorySpace;
-        of?: string;
-        scope?: CellScope;
-      }>;
+    type ConflictAddress = { space: MemorySpace; of: URI; scope?: CellScope };
+    const isPullableConflict = (value: unknown): value is ConflictAddress => {
+      const conflict = value as Partial<ConflictAddress> | null | undefined;
+      return typeof conflict?.space === "string" &&
+        typeof conflict.of === "string" && conflict.of !== "of:unknown" &&
+        (conflict.scope === undefined || isCellScope(conflict.scope));
     };
-    const conflicts = Array.isArray(rejection?.conflicts) &&
-        rejection.conflicts.length > 0
-      ? rejection.conflicts
-      : rejection?.conflict === undefined
-      ? []
-      : [rejection.conflict];
+    const rejection = error as { conflict?: unknown; conflicts?: unknown };
+    const listedConflicts = Array.isArray(rejection?.conflicts)
+      ? rejection.conflicts.filter(isPullableConflict)
+      : [];
+    const conflicts = listedConflicts.length > 0
+      ? listedConflicts
+      : isPullableConflict(rejection?.conflict)
+      ? [rejection.conflict]
+      : [];
     const pulls: Promise<unknown>[] = [];
     const seen = new Set<string>();
     for (const conflict of conflicts) {
-      if (
-        conflict.space === undefined ||
-        typeof conflict.of !== "string" ||
-        conflict.of === "of:unknown"
-      ) {
-        continue;
-      }
       const key = entityNameKey({
         space: conflict.space,
-        id: conflict.of as URI,
+        id: conflict.of,
         scope: conflict.scope,
       });
       if (seen.has(key)) continue;
@@ -2905,7 +2901,7 @@ export class Runtime {
         pulls.push(
           Promise.resolve(
             this.storageManager.open(conflict.space).sync(
-              conflict.of as unknown as URI,
+              conflict.of,
               { path: [], schema: false },
               conflict.scope,
             ),

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -9,6 +9,7 @@ import { internSchema } from "@commonfabric/data-model-schema";
 import { createSession, Identity } from "@commonfabric/identity";
 import {
   acquireServerExecutionEnabler,
+  type CellScope,
   commitPreconditionValueHash,
   getCommitPreconditionsConfig,
   getServerExecutionConfig,
@@ -2827,8 +2828,9 @@ export class Runtime {
    * WRITE means exactly that (the compile-cache write-back rewrites derived
    * docs a cold replica has never seen; a piece start's basis names computed
    * docs the serving side was materializing). So the named doc is pulled
-   * too, and the retry's write carries its true version instead of
-   * re-asserting seq 0.
+   * in the conflict's scope too, and the retry's write carries its true
+   * version instead of re-asserting seq 0. Errors without scope use the
+   * default space instance.
    *
    * Every step is best-effort by design: this resolves rather than throws,
    * because the retry's commit — not this readiness — is what decides.
@@ -2868,7 +2870,7 @@ export class Runtime {
     }
     if (teardownSignal?.aborted) return;
     const conflict = (error as {
-      conflict?: { space?: MemorySpace; of?: string };
+      conflict?: { space?: MemorySpace; of?: string; scope?: CellScope };
     })?.conflict;
     if (
       conflict?.space !== undefined &&
@@ -2880,6 +2882,7 @@ export class Runtime {
           this.storageManager.open(conflict.space).sync(
             conflict.of as unknown as URI,
             { path: [], schema: false },
+            conflict.scope,
           ),
         );
       } catch {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -53,6 +53,7 @@ import {
   type SqliteQueryResult,
   type SqliteRegisterDiskSourceResult,
   toDocumentPath,
+  type V2Error,
 } from "@commonfabric/memory/v2";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import { mapLinkSchemas } from "@commonfabric/memory/v2/schema-table-links";
@@ -84,7 +85,7 @@ import {
 } from "../link-types.ts";
 import { sortAndCompactPaths } from "../reactive-dependencies.ts";
 import { entityKey } from "../scheduler/keys.ts";
-import { normalizeCellScope } from "../scope.ts";
+import { isCellScope, normalizeCellScope } from "../scope.ts";
 import { normalizeSpaceHost, SpaceHostValidationError } from "../space-host.ts";
 import type { RuntimeTelemetryMarker } from "../telemetry.ts";
 import { recordCommitLocalSeq } from "./commit-identity.ts";
@@ -8255,12 +8256,13 @@ const toRejectedError = (
   ) {
     const retryAfterSeq = (error as { retryAfterSeq?: unknown })?.retryAfterSeq;
     const readyToRetry = (error as { readyToRetry?: unknown })?.readyToRetry;
-    // The conflicted entity: structured field when the error is in-process;
-    // parsed from the message when it crossed the wire (Error fields do not
-    // survive serialization, the message does — its format is owned by
-    // memory/v2/engine.ts's ConflictError construction).
-    const staleReadOf = (error as { of?: unknown })?.of ??
+    // Structured wire errors preserve scope alongside identity. In-process
+    // engine errors expose the same fields directly; older peers name only
+    // the entity in the diagnostic and retain default-scope recovery.
+    const details = (error as { conflict?: V2Error["conflict"] })?.conflict;
+    const staleReadOf = details?.of ?? (error as { of?: unknown })?.of ??
       message.match(/stale confirmed read: (\S+) at seq/)?.[1];
+    const scope = details?.scope ?? (error as { scope?: unknown })?.scope;
     const firstOperation = commit.operations?.[0];
     const firstOperationId = firstOperation && "id" in firstOperation
       ? firstOperation.id
@@ -8278,6 +8280,7 @@ const toRejectedError = (
         the: DOCUMENT_MIME,
         of: ((typeof staleReadOf === "string" ? staleReadOf : undefined) ??
           firstOperationId ?? "of:unknown") as Entity,
+        ...(isCellScope(scope) ? { scope } : {}),
       },
     };
     // retryAfterSeq is carried for diagnostics; retry gating is by caughtUpLocalSeq

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -53,7 +53,6 @@ import {
   type SqliteQueryResult,
   type SqliteRegisterDiskSourceResult,
   toDocumentPath,
-  type V2Error,
 } from "@commonfabric/memory/v2";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import { mapLinkSchemas } from "@commonfabric/memory/v2/schema-table-links";
@@ -8256,13 +8255,38 @@ const toRejectedError = (
   ) {
     const retryAfterSeq = (error as { retryAfterSeq?: unknown })?.retryAfterSeq;
     const readyToRetry = (error as { readyToRetry?: unknown })?.readyToRetry;
-    // Structured wire errors preserve scope alongside identity. In-process
-    // engine errors expose the same fields directly; older peers name only
-    // the entity in the diagnostic and retain default-scope recovery.
-    const details = (error as { conflict?: V2Error["conflict"] })?.conflict;
-    const staleReadOf = details?.of ?? (error as { of?: unknown })?.of ??
-      message.match(/stale confirmed read: (\S+) at seq/)?.[1];
-    const scope = details?.scope ?? (error as { scope?: unknown })?.scope;
+    // Scoped descriptors cross current protocol boundaries structurally.
+    // Message-only errors retain default-scope recovery for every named read.
+    const toConflicts = (details: unknown): IConflictError["conflict"][] => {
+      const { of, scope } = (details ?? {}) as {
+        of?: unknown;
+        scope?: unknown;
+      };
+      return typeof of === "string"
+        ? [{
+          space,
+          the: DOCUMENT_MIME,
+          of: of as Entity,
+          ...(isCellScope(scope) ? { scope } : {}),
+        }]
+        : [];
+    };
+    const structuredConflicts = (error as { conflicts?: unknown })?.conflicts;
+    let conflicts = Array.isArray(structuredConflicts)
+      ? structuredConflicts.flatMap(toConflicts)
+      : [];
+    if (conflicts.length === 0) {
+      conflicts = toConflicts((error as { conflict?: unknown })?.conflict);
+    }
+    if (conflicts.length === 0) {
+      conflicts = toConflicts(error);
+    }
+    if (conflicts.length === 0) {
+      conflicts = Array.from(
+        message.matchAll(/stale confirmed read: (\S+) at seq/g),
+        (match) => toConflicts({ of: match[1] })[0],
+      );
+    }
     const firstOperation = commit.operations?.[0];
     const firstOperationId = firstOperation && "id" in firstOperation
       ? firstOperation.id
@@ -8271,17 +8295,14 @@ const toRejectedError = (
       name: "ConflictError",
       message,
       transaction: commit,
-      // Conflict descriptor: for stale-read conflicts `of` is authoritative
-      // (the memory engine names the conflicted entity structurally), so a
-      // retrier can pull exactly that doc before re-running. `the` remains a
-      // placeholder.
-      conflict: {
+      // The singular descriptor remains the first conflict for consumers of
+      // the legacy interface. `the` remains a placeholder.
+      conflict: conflicts[0] ?? {
         space,
         the: DOCUMENT_MIME,
-        of: ((typeof staleReadOf === "string" ? staleReadOf : undefined) ??
-          firstOperationId ?? "of:unknown") as Entity,
-        ...(isCellScope(scope) ? { scope } : {}),
+        of: (firstOperationId ?? "of:unknown") as Entity,
       },
+      ...(conflicts.length > 0 ? { conflicts } : {}),
     };
     // retryAfterSeq is carried for diagnostics; retry gating is by caughtUpLocalSeq
     // (readyToRetry), and downstream only uses retryAfterSeq's presence to mark

--- a/packages/runner/test/compile-cache-writeback-conflict.test.ts
+++ b/packages/runner/test/compile-cache-writeback-conflict.test.ts
@@ -132,8 +132,7 @@ describe("write-back pre-sync materializes edge element docs (CT-1848)", () => {
     // `imports[i]` into) are client-known BEFORE the re-write. A schema-less
     // pre-sync normalizes to the rejecting selector and delivers only the root
     // doc; in the browser the re-write then touches the element docs blind and
-    // the engine reveals the conflicts one per attempt (the CT-1824 loop,
-    // converged only by the retry budget). NOTE: the blind-conflict itself does
+    // needs a rejected commit plus conflict repair. NOTE: the blind-conflict does
     // not reproduce in-process (this fixture's flows warm the element docs some
     // other way — same limitation as the healing test above); the conflict-free
     // attempt-1 property is verified live on the browser rig. What IS pinned
@@ -304,32 +303,24 @@ describe("editWithRetry conflict catch-up", () => {
   });
 });
 
-describe("editWithRetry sequential conflict discovery", () => {
-  // The browser cold-boot shape of CT-1824 (live-traced on the rig): the
-  // write-back's derived docs are discovered ONE per attempt — the engine
-  // rejects on the first stale read, the retry pulls exactly that doc, and
-  // only then does the next attempt's diff reach the following one.
-  // editWithRetry must (a) pull the doc each conflict names so each round
-  // makes progress, and (b) survive a pull or catch-up failure without giving
-  // up the round (the retry's commit is the definitive outcome). Convergence
-  // takes one round per pre-existing derived doc, which is why
-  // `#writeBackCompileCache` passes a budget sized to its write set instead of
-  // DEFAULT_MAX_RETRIES.
-
-  it("pulls each named doc and converges one doc per round", async () => {
+describe("editWithRetry conflict repair", () => {
+  it("pulls every named document before one retry", async () => {
     const server = newSharedServer();
     const sm = EmulatedStorageManager.connectTo(server, { as: signer });
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: sm,
     });
-    const CONFLICTS = 8;
+    const conflicts = Array.from({ length: 8 }, (_, index) => ({
+      space,
+      the: "application/json",
+      of: `of:doc-${index + 1}`,
+    }));
     const pulls: string[] = [];
     const provider = sm.open(space);
     // deno-lint-ignore no-explicit-any
     (provider as any).sync = (uri: string) => {
       pulls.push(uri);
-      // Round 3's pull fails; the round must still proceed to its retry.
       if (uri === "of:doc-3") {
         return Promise.reject(new Error("pull failed"));
       }
@@ -341,26 +332,14 @@ describe("editWithRetry sequential conflict discovery", () => {
       abort: () => {},
       commit: () => {
         commits++;
-        if (commits <= CONFLICTS) {
-          const k = commits;
+        if (commits === 1) {
           return Promise.resolve({
             error: {
               name: "ConflictError",
-              message:
-                `stale confirmed read: of:doc-${k} at seq 0 conflicted with seq ${
-                  10 + k
-                }`,
-              // Round 5's catch-up gate rejects (session churn); the retry
-              // must run anyway.
-              readyToRetry: () =>
-                k === 5
-                  ? Promise.reject(new Error("session replaced"))
-                  : Promise.resolve(),
-              conflict: {
-                space,
-                the: "application/json",
-                of: `of:doc-${k}`,
-              },
+              message: "stale confirmed reads",
+              readyToRetry: () => Promise.reject(new Error("session replaced")),
+              conflict: conflicts[0],
+              conflicts: [...conflicts, conflicts[0]],
             },
           });
         }
@@ -372,13 +351,11 @@ describe("editWithRetry sequential conflict discovery", () => {
     // deno-lint-ignore no-explicit-any
     (runtime as any).prepareTxForCommit = () => {};
     try {
-      const result = await runtime.editWithRetry(() => {}, 64);
+      const result = await runtime.editWithRetry(() => {});
       expect(result.error).toBeUndefined();
-      // One commit per conflict round plus the converging attempt.
-      expect(commits).toBe(CONFLICTS + 1);
-      // Every round pulled exactly the doc its conflict named, in order.
+      expect(commits).toBe(2);
       expect(pulls).toEqual(
-        Array.from({ length: CONFLICTS }, (_, i) => `of:doc-${i + 1}`),
+        conflicts.map(({ of }) => of),
       );
     } finally {
       await runtime.dispose();
@@ -387,7 +364,7 @@ describe("editWithRetry sequential conflict discovery", () => {
     }
   });
 
-  it("exhausts the default budget when discovery outlasts it", async () => {
+  it("pulls a singular conflict from an older rejection", async () => {
     const server = newSharedServer();
     const sm = EmulatedStorageManager.connectTo(server, { as: signer });
     const runtime = new Runtime({
@@ -395,27 +372,34 @@ describe("editWithRetry sequential conflict discovery", () => {
       storageManager: sm,
     });
     const provider = sm.open(space);
+    const pulls: string[] = [];
     // deno-lint-ignore no-explicit-any
-    (provider as any).sync = () => Promise.resolve({ ok: {} });
+    (provider as any).sync = (uri: string) => {
+      pulls.push(uri);
+      return Promise.resolve({ ok: {} });
+    };
     let commits = 0;
     const fakeTx = () => ({
       tx: {},
       abort: () => {},
       commit: () => {
         commits++;
-        return Promise.resolve({
-          error: {
-            name: "ConflictError",
-            message: `stale confirmed read: of:doc-${commits} at seq 0 ` +
-              `conflicted with seq ${10 + commits}`,
-            readyToRetry: () => Promise.resolve(),
-            conflict: {
-              space,
-              the: "application/json",
-              of: `of:doc-${commits}`,
-            },
-          },
-        });
+        return Promise.resolve(
+          commits === 1
+            ? {
+              error: {
+                name: "ConflictError",
+                message: "stale confirmed read",
+                readyToRetry: () => Promise.resolve(),
+                conflict: {
+                  space,
+                  the: "application/json",
+                  of: "of:legacy-doc",
+                },
+              },
+            }
+            : {},
+        );
       },
     });
     // deno-lint-ignore no-explicit-any
@@ -423,13 +407,10 @@ describe("editWithRetry sequential conflict discovery", () => {
     // deno-lint-ignore no-explicit-any
     (runtime as any).prepareTxForCommit = () => {};
     try {
-      // With the general default (5 retries = 6 attempts), a write set with
-      // more never-read derived docs than that cannot converge — the CT-1824
-      // cold-boot loop. This is the behavior `#writeBackCompileCache`'s larger
-      // budget exists to clear.
       const result = await runtime.editWithRetry(() => {});
-      expect(result.error).toBeDefined();
-      expect(commits).toBe(6);
+      expect(result.error).toBeUndefined();
+      expect(commits).toBe(2);
+      expect(pulls).toEqual(["of:legacy-doc"]);
     } finally {
       await runtime.dispose();
       await sm.close();

--- a/packages/runner/test/edit-with-retry-conflict-aggregation.test.ts
+++ b/packages/runner/test/edit-with-retry-conflict-aggregation.test.ts
@@ -1,0 +1,121 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+
+import { Runtime } from "../src/runtime.ts";
+import { toMemorySpaceAddress } from "../src/link-types.ts";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
+
+const signer = await Identity.fromPassphrase(
+  "editWithRetry conflict aggregation test",
+);
+const space = signer.did();
+
+const valueSchema = {
+  type: "object",
+  properties: { value: { type: "number" } },
+} as const;
+
+describe("editWithRetry conflict aggregation", () => {
+  it("repairs unseen space and user instances sharing an ID after one rejected commit", async () => {
+    const server = newSharedServer();
+    const writerStorage = EmulatedStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const writer = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: writerStorage,
+    });
+    let readerStorage: EmulatedStorageManager | undefined;
+    let reader: Runtime | undefined;
+    try {
+      const seed = writer.edit();
+      const staleA = writer.getCell(
+        space,
+        "aggregated-stale",
+        valueSchema,
+        seed,
+      );
+      const staleB = writer.getCell(
+        space,
+        "aggregated-stale",
+        valueSchema,
+        seed,
+        "user",
+      );
+      const anchor = writer.getCell(space, "unrelated-anchor", undefined, seed);
+      anchor.set("watched");
+      staleA.set({ value: 41 });
+      staleB.set({ value: 42 });
+      const scopes = ["space", "user"] as const;
+      const staleConflicts = scopes.map((scope) => ({
+        of: staleA.getAsNormalizedFullLink().id,
+        scope,
+      }));
+      expect((await seed.commit()).error).toBeUndefined();
+      await writerStorage.synced();
+
+      readerStorage = EmulatedStorageManager.connectTo(server, { as: signer });
+      reader = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: readerStorage,
+      });
+      // Keep a watched view for the ordered catch-up without covering either
+      // conflicting instance.
+      await readerStorage.open(space).sync(
+        anchor.getAsNormalizedFullLink().id,
+        { path: [], schema: false },
+      );
+      const rejections: unknown[] = [];
+      const awaitReadiness = reader.awaitCommitRetryReadiness.bind(reader);
+      reader.awaitCommitRetryReadiness = (error, teardownSignal) => {
+        const conflicts = (error as {
+          conflicts?: Array<{ of?: unknown; scope?: unknown }>;
+        }).conflicts ?? [];
+        rejections.push(
+          conflicts.map(({ of, scope }) => ({ of, scope })),
+        );
+        return awaitReadiness(error, teardownSignal);
+      };
+
+      let runs = 0;
+      let observed: unknown[] = [];
+      const result = await reader.editWithRetry((tx) => {
+        runs++;
+        observed = scopes.map((scope) => {
+          const address = toMemorySpaceAddress(
+            reader!.getCell(
+              space,
+              "aggregated-stale",
+              valueSchema,
+              tx,
+              scope,
+            ).getAsNormalizedFullLink(),
+          );
+          // Record a validation read without an independent load. Writing
+          // the same address leaves its absent basis for the server to judge.
+          const read = tx.read(address, { trackReadWithoutLoad: true });
+          expect(read.error).toBeUndefined();
+          tx.write(address, { value: runs });
+          return readerStorage!.open(space).replica.getDocument(
+            address.id,
+            scope,
+          )?.value;
+        });
+      }, 1);
+
+      expect(result.error).toBeUndefined();
+      expect(runs).toBe(2);
+      expect(observed).toEqual([{ value: 41 }, { value: 42 }]);
+      expect(rejections).toEqual([staleConflicts]);
+    } finally {
+      await reader?.dispose();
+      await writer.dispose();
+      await readerStorage?.close();
+      await writerStorage.close();
+      await server.close();
+    }
+  });
+});

--- a/packages/runner/test/runtime-conflict-readiness.test.ts
+++ b/packages/runner/test/runtime-conflict-readiness.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { stub } from "@std/testing/mock";
+import { Identity } from "@commonfabric/identity";
+
+import { Runtime } from "../src/runtime.ts";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+
+const signer = await Identity.fromPassphrase("conflict readiness fallback");
+const space = signer.did();
+
+describe("runtime-conflict-readiness", () => {
+  let storage: EmulatedStorageManager;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storage = EmulatedStorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storage.close();
+  });
+
+  it("pulls the scoped singular descriptor when every array entry is unusable", async () => {
+    using sync = stub(
+      storage.open(space),
+      "sync",
+      () => Promise.resolve({ ok: {} }),
+    );
+    await runtime.awaitCommitRetryReadiness({
+      conflicts: [
+        { of: "of:missing-space" },
+        { space },
+        { space, of: "of:unknown" },
+      ],
+      conflict: { space, of: "of:fallback", scope: "user" },
+    });
+    expect(sync.calls.map(({ args }) => args)).toEqual([
+      ["of:fallback", { path: [], schema: false }, "user"],
+    ]);
+  });
+
+  it("uses valid array entries without pulling the singular fallback", async () => {
+    using sync = stub(
+      storage.open(space),
+      "sync",
+      () => Promise.resolve({ ok: {} }),
+    );
+    await runtime.awaitCommitRetryReadiness({
+      conflicts: [
+        null,
+        undefined,
+        { space, of: "of:invalid-scope", scope: "invalid" },
+        { space, of: "of:shared", scope: "space" },
+        { space, of: "of:shared" },
+        { space, of: "of:shared", scope: "session" },
+      ],
+      conflict: { space, of: "of:fallback", scope: "user" },
+    });
+    expect(sync.calls.map(({ args }) => args)).toEqual([
+      ["of:shared", { path: [], schema: false }, "space"],
+      ["of:shared", { path: [], schema: false }, "session"],
+    ]);
+  });
+
+  it("resolves without a pull when neither conflict representation is usable", async () => {
+    using sync = stub(
+      storage.open(space),
+      "sync",
+      () => Promise.resolve({ ok: {} }),
+    );
+    await runtime.awaitCommitRetryReadiness({
+      conflicts: [{ of: "of:missing-space" }],
+      conflict: { space, of: "of:unknown" },
+    });
+    await runtime.awaitCommitRetryReadiness(undefined);
+    expect(sync.calls).toHaveLength(0);
+  });
+
+  it("continues other recovery pulls when one throws synchronously", async () => {
+    using sync = stub(storage.open(space), "sync", (of) => {
+      if (of === "of:failed") throw new Error("provider unavailable");
+      return Promise.resolve({ ok: {} });
+    });
+    await runtime.awaitCommitRetryReadiness({
+      conflicts: [
+        { space, of: "of:failed", scope: "user" },
+        { space, of: "of:other", scope: "session" },
+      ],
+    });
+    expect(sync.calls.map(({ args }) => args[0])).toEqual([
+      "of:failed",
+      "of:other",
+    ]);
+  });
+});

--- a/packages/runner/test/scoped-conflict-retry.test.ts
+++ b/packages/runner/test/scoped-conflict-retry.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Conflict recovery loads the scoped output that failed validation even when
+ * the space instance's current link does not reach that output.
+ */
+
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { Identity } from "@commonfabric/identity";
+
+import { Runtime } from "../src/runtime.ts";
+import { createSigilLinkFromParsedLink } from "../src/link-utils.ts";
+import { toMemorySpaceAddress } from "../src/link-types.ts";
+import { ignoreReadForScheduling } from "../src/storage/reactivity-log.ts";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { newSharedServer } from "./memory-v2-test-utils.ts";
+
+describe("scoped-conflict-retry", () => {
+  it("restores an unwatched user output after one conflict and a scoped recovery pull", async () => {
+    const signer = await Identity.fromPassphrase("scoped conflict retry");
+    const space = signer.did();
+    const server = newSharedServer();
+    const writerStorage = EmulatedStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const readerStorage = EmulatedStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const writer = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: writerStorage,
+    });
+    const reader = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: readerStorage,
+    });
+    try {
+      const seed = writer.edit();
+      const previous = writer.getCell<string>(
+        space,
+        "output",
+        undefined,
+        seed,
+        "user",
+      );
+      previous.set("previous user value");
+      const alternate = writer.getCell<string>(
+        space,
+        "alternate",
+        undefined,
+        seed,
+      );
+      alternate.set("alternate value");
+      writer.getCell(space, "output", undefined, seed).set(alternate);
+      expect((await seed.commit()).error).toBeUndefined();
+      await writerStorage.synced();
+
+      const output = reader.getCell(space, "output");
+      await readerStorage.open(space).sync(
+        output.getAsNormalizedFullLink().id,
+        {
+          path: [],
+          schema: false,
+        },
+      );
+      const attempt = () => {
+        const tx = reader.edit();
+        const scoped = reader.getCell<string>(
+          space,
+          "output",
+          undefined,
+          tx,
+          "user",
+        );
+        const scopedAddress = toMemorySpaceAddress(
+          scoped.getAsNormalizedFullLink(),
+        );
+        // Keep the output's validation dependency without starting a load
+        // that could repair it independently of the retry helper.
+        tx.read(scopedAddress, {
+          meta: ignoreReadForScheduling,
+          trackReadWithoutLoad: true,
+        });
+        tx.write(scopedAddress, "updated user value");
+        tx.write(
+          toMemorySpaceAddress(output.getAsNormalizedFullLink()),
+          createSigilLinkFromParsedLink(scoped.getAsNormalizedFullLink()),
+        );
+        return tx.commit();
+      };
+      const rejected = await attempt();
+      expect(rejected.error?.name).toBe("ConflictError");
+      if (rejected.error?.name !== "ConflictError") {
+        throw new Error("Expected the unseen user output to conflict");
+      }
+      expect(rejected.error.conflict.of).toBe(
+        output.getAsNormalizedFullLink().id,
+      );
+      expect(rejected.error.conflict.scope).toBe("user");
+      expect(
+        readerStorage.open(space).replica.getDocument(
+          output.getAsNormalizedFullLink().id,
+          "user",
+        ),
+      )
+        .toBeUndefined();
+      await reader.awaitCommitRetryReadiness(rejected.error);
+      expect(
+        readerStorage.open(space).replica.getDocument(
+          output.getAsNormalizedFullLink().id,
+          "user",
+        ),
+      )
+        .toEqual({ value: "previous user value" });
+      const retried = await attempt();
+      expect(retried.error).toBeUndefined();
+      await readerStorage.synced();
+      expect(
+        reader.getCell<string>(space, "output", undefined, undefined, "user")
+          .get(),
+      )
+        .toBe("updated user value");
+      expect(output.get()).toBe("updated user value");
+    } finally {
+      await reader.dispose();
+      await writer.dispose();
+      await readerStorage.close();
+      await writerStorage.close();
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
A blind write can conflict on several documents whose current values are outside the replica's watched view. Reporting only the first stale read requires another rejection to discover the next one, and pulling a user- or session-scoped conflict as a space document leaves that instance stale.

Collect each stale branch, document ID, and scope once and return a `conflicts` array of `{ of, scope, seq, conflictSeq }` descriptors, plus `branch` for non-default branches, including for a single conflict. Preserve these descriptors through client decoding and runner normalization. The runner emits default-branch reads; direct memory clients use branch-aware queries for other branches. The runtime retry helper pulls its named instances concurrently, deduplicating by space, document ID, and scope. The runner retains the first descriptor as `conflict`, and older message-only errors retain default-scope recovery. If no array entry supplies a usable address, recovery falls back to the singular descriptor while preserving its scope.

The diagnostic previews up to three distinct entity IDs and reports an omitted count. Each ID uses its first diagnostic clause, while the structured array retains every stale instance. Nested maps keep branch, scope, and ID separate, including when the strings contain delimiter characters. After the first stale read of an instance, the engine skips further conflict queries for it; the first read supplies its diagnostic sequences. Every read still validates its branch and resolves its scope before deduplication. Validation errors such as an unknown branch take precedence over stale reads; regression tests cover both read orders for unknown branches and unresolvable user/session scopes. Query-count assertions cover repeated reads, same-ID conflicts on different branches, delimiter-containing addresses, and path-dependent patch conflicts, and a fresh read cannot suppress a later stale read. The engine constructor accepts only an array of conflict descriptors, and the compile-cache retry budget is documented as conservative headroom.

Cherry-picks the conflict aggregation change from #7068 (`ef1380fa0bbf090e68d4e30cbfa8d8c0a447941a`), adapted to preserve scope throughout recovery.

Regression coverage verifies that space and user instances sharing one ID are repaired after one rejection and commit successfully on the next attempt. This test fails when recovery deduplicates by ID alone. Wire tests cover conflicting space, user, and session instances alongside a fresh read of the same ID in another scope. The existing unwatched user-output regression and legacy singular-error recovery remain covered. Additional tests cover unusable arrays, mixed valid and invalid entries, and synchronous pull failures. Focused V8 coverage exercises all 40 executable lines of conflict selection and pull handling.

Validation:

- Memory package: type checking and 614 tests passed (566 steps)
- Runner package: 1,407 tests passed (8,629 steps); focused recovery regressions repeated after the branch and key follow-ups
- Repository `deno fmt --check` and `deno lint`
- `deno task check-docs`: all 596 checked code blocks passed
